### PR TITLE
Added the ability to output just the hydro or mhd variables (without scalars...

### DIFF
--- a/src/outputs/basetype_output.cpp
+++ b/src/outputs/basetype_output.cpp
@@ -76,52 +76,62 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // hydro (lab-frame) density
   if (out_params.variable.compare("hydro_u_d") == 0 ||
+      out_params.variable.compare("hydro_u_h") == 0 ||
       out_params.variable.compare("hydro_u") == 0) {
     outvars.emplace_back("dens",0,&(pm->pmb_pack->phydro->u0));
   }
 
   // hydro (rest-frame) density
   if (out_params.variable.compare("hydro_w_d") == 0 ||
+      out_params.variable.compare("hydro_w_h") == 0 ||
       out_params.variable.compare("hydro_w") == 0) {
     outvars.emplace_back("dens",0,&(pm->pmb_pack->phydro->w0));
   }
 
   // hydro components of momentum
   if (out_params.variable.compare("hydro_u_m1") == 0 ||
+      out_params.variable.compare("hydro_u_h") == 0 ||
       out_params.variable.compare("hydro_u") == 0) {
     outvars.emplace_back("mom1",1,&(pm->pmb_pack->phydro->u0));
   }
   if (out_params.variable.compare("hydro_u_m2") == 0 ||
+      out_params.variable.compare("hydro_u_h") == 0 ||
       out_params.variable.compare("hydro_u") == 0) {
     outvars.emplace_back("mom2",2,&(pm->pmb_pack->phydro->u0));
   }
   if (out_params.variable.compare("hydro_u_m3") == 0 ||
+      out_params.variable.compare("hydro_u_h") == 0 ||
       out_params.variable.compare("hydro_u") == 0) {
     outvars.emplace_back("mom3",3,&(pm->pmb_pack->phydro->u0));
   }
 
   // hydro components of velocity
   if (out_params.variable.compare("hydro_w_vx") == 0 ||
+      out_params.variable.compare("hydro_w_h") == 0 ||
       out_params.variable.compare("hydro_w") == 0) {
     outvars.emplace_back("velx",1,&(pm->pmb_pack->phydro->w0));
   }
   if (out_params.variable.compare("hydro_w_vy") == 0 ||
+      out_params.variable.compare("hydro_w_h") == 0 ||
       out_params.variable.compare("hydro_w") == 0) {
     outvars.emplace_back("vely",2,&(pm->pmb_pack->phydro->w0));
   }
   if (out_params.variable.compare("hydro_w_vz") == 0 ||
+      out_params.variable.compare("hydro_w_h") == 0 ||
       out_params.variable.compare("hydro_w") == 0) {
     outvars.emplace_back("velz",3,&(pm->pmb_pack->phydro->w0));
   }
 
   // hydro total energy
   if (out_params.variable.compare("hydro_u_e") == 0 ||
+      out_params.variable.compare("hydro_u_h") == 0 ||
       out_params.variable.compare("hydro_u") == 0) {
     outvars.emplace_back("ener",4,&(pm->pmb_pack->phydro->u0));
   }
 
   // hydro internal energy or temperature
   if (out_params.variable.compare("hydro_w_e") == 0 ||
+      out_params.variable.compare("hydro_w_h") == 0 ||
       out_params.variable.compare("hydro_w") == 0) {
     outvars.emplace_back("eint",4,&(pm->pmb_pack->phydro->w0));
   }
@@ -158,6 +168,7 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // mhd (lab-frame) density
   if (out_params.variable.compare("mhd_u_d") == 0 ||
+      out_params.variable.compare("mhd_u_m") == 0 ||
       out_params.variable.compare("mhd_u") == 0 ||
       out_params.variable.compare("mhd_u_bcc") == 0) {
     outvars.emplace_back("dens",0,&(pm->pmb_pack->pmhd->u0));
@@ -165,6 +176,7 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // mhd (rest-frame) density
   if (out_params.variable.compare("mhd_w_d") == 0 ||
+      out_params.variable.compare("mhd_w_m") == 0 ||
       out_params.variable.compare("mhd_w") == 0 ||
       out_params.variable.compare("mhd_w_bcc") == 0) {
     outvars.emplace_back("dens",0,&(pm->pmb_pack->pmhd->w0));
@@ -172,16 +184,19 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // mhd components of momentum
   if (out_params.variable.compare("mhd_u_m1") == 0 ||
+      out_params.variable.compare("mhd_u_m") == 0 ||
       out_params.variable.compare("mhd_u") == 0 ||
       out_params.variable.compare("mhd_u_bcc") == 0) {
     outvars.emplace_back("mom1",1,&(pm->pmb_pack->pmhd->u0));
   }
   if (out_params.variable.compare("mhd_u_m2") == 0 ||
+      out_params.variable.compare("mhd_u_m") == 0 ||
       out_params.variable.compare("mhd_u") == 0 ||
       out_params.variable.compare("mhd_u_bcc") == 0) {
     outvars.emplace_back("mom2",2,&(pm->pmb_pack->pmhd->u0));
   }
   if (out_params.variable.compare("mhd_u_m3") == 0 ||
+      out_params.variable.compare("mhd_u_m") == 0 ||
       out_params.variable.compare("mhd_u") == 0 ||
       out_params.variable.compare("mhd_u_bcc") == 0) {
     outvars.emplace_back("mom3",3,&(pm->pmb_pack->pmhd->u0));
@@ -189,16 +204,19 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // mhd components of velocity
   if (out_params.variable.compare("mhd_w_vx") == 0 ||
+      out_params.variable.compare("mhd_w_m") == 0 ||
       out_params.variable.compare("mhd_w") == 0 ||
       out_params.variable.compare("mhd_w_bcc") == 0) {
     outvars.emplace_back("velx",1,&(pm->pmb_pack->pmhd->w0));
   }
   if (out_params.variable.compare("mhd_w_vy") == 0 ||
+      out_params.variable.compare("mhd_w_m") == 0 ||
       out_params.variable.compare("mhd_w") == 0 ||
       out_params.variable.compare("mhd_w_bcc") == 0) {
     outvars.emplace_back("vely",2,&(pm->pmb_pack->pmhd->w0));
   }
   if (out_params.variable.compare("mhd_w_vz") == 0 ||
+      out_params.variable.compare("mhd_w_m") == 0 ||
       out_params.variable.compare("mhd_w") == 0 ||
       out_params.variable.compare("mhd_w_bcc") == 0) {
     outvars.emplace_back("velz",3,&(pm->pmb_pack->pmhd->w0));
@@ -206,6 +224,7 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // mhd total energy
   if (out_params.variable.compare("mhd_u_e") == 0 ||
+      out_params.variable.compare("mhd_u_m") == 0 ||
       out_params.variable.compare("mhd_u") == 0 ||
       out_params.variable.compare("mhd_u_bcc") == 0) {
     outvars.emplace_back("ener",4,&(pm->pmb_pack->pmhd->u0));
@@ -213,6 +232,7 @@ BaseTypeOutput::BaseTypeOutput(OutputParameters opar, Mesh *pm) :
 
   // mhd internal energy or temperature
   if (out_params.variable.compare("mhd_w_e") == 0 ||
+      out_params.variable.compare("mhd_w_m") == 0 ||
       out_params.variable.compare("mhd_w") == 0 ||
       out_params.variable.compare("mhd_w_bcc") == 0) {
     outvars.emplace_back("eint",4,&(pm->pmb_pack->pmhd->w0));

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -14,12 +14,9 @@
 #include "athena.hpp"
 #include "io_wrapper.hpp"
 
-#define NHISTORY_VARIABLES 12
-#if NHISTORY_VARIABLES > NREDUCTION_VARIABLES
-    #error NHISTORY > NREDUCTION in outputs.hpp
-#endif
+#define NHISTORY_VARIABLES 100
 
-#define NOUTPUT_CHOICES 42
+#define NOUTPUT_CHOICES 46
 // choices for output variables used in <ouput> blocks in input file
 // TO ADD MORE CHOICES:
 //   - add more strings to array below, change NOUTPUT_CHOICES above appropriately
@@ -29,10 +26,10 @@
 static const char *var_choice[NOUTPUT_CHOICES] = {
   "hydro_u_d", "hydro_u_m1", "hydro_u_m2", "hydro_u_m3", "hydro_u_e", "hydro_u",
   "hydro_w_d", "hydro_w_vx", "hydro_w_vy", "hydro_w_vz", "hydro_w_e", "hydro_w",
-  "hydro_u_s", "hydro_w_s",  "hydro_wz",   "hydro_w2",
+  "hydro_u_h", "hydro_w_h",  "hydro_u_s",  "hydro_w_s",  "hydro_wz",  "hydro_w2",
   "mhd_u_d",   "mhd_u_m1",   "mhd_u_m2",   "mhd_u_m3",   "mhd_u_e",   "mhd_u",
   "mhd_w_d",   "mhd_w_vx",   "mhd_w_vy",   "mhd_w_vz",   "mhd_w_e",   "mhd_w",
-  "mhd_u_s",   "mhd_w_s",    "mhd_wz",     "mhd_w2",
+  "mhd_u_m",   "mhd_w_m",    "mhd_u_s",    "mhd_w_s",    "mhd_wz",    "mhd_w2",
   "mhd_bcc1",  "mhd_bcc2",   "mhd_bcc3",   "mhd_bcc",    "mhd_u_bcc", "mhd_w_bcc",
   "mhd_jz",    "mhd_j2",     "mhd_divb",
   "turb_force"};


### PR DESCRIPTION
In GitLab by @mhguo on Sep 15, 2022, 17:18

Added the ability to output just the hydro or mhd variables (without scalars and other variables) in one file

1. hydro conserved variables are named as `hydro_u_h`
2. hydro primitive variables are named as `hydro_w_h`
3. mhd conserved variables are named as `mhd_u_m`
4. mhd primitive variables are named as `mhd_w_m`