### PR TITLE
fix vtk format bug with POINT_DATA header

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -645,6 +645,7 @@ void Mesh::AddCoordinatesAndPhysics(ParameterInput *pinput) {
   // Determine total number of particles across all ranks
   particles::Particles *ppart = pmb_pack->ppart;
   if (ppart != nullptr) {
+    nprtcl_thisrank = 0;
     for (int n=0; n<nmb_packs_thisrank; ++n) {
       nprtcl_thisrank += pmb_pack->ppart->nprtcl_thispack;
     }

--- a/src/outputs/vtk_prtcl.cpp
+++ b/src/outputs/vtk_prtcl.cpp
@@ -182,19 +182,29 @@ void ParticleVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   }
 
   // Write Part 6: scalar particle data
+  bool have_written_pointdata_header = false;
+
   // Write gid of points
   for (int n=0; n<(pm->pmb_pack->ppart->nidata); ++n) {
     std::stringstream msg;
-    if (n == static_cast<int>(PGID)) {
-      msg << std::endl << std::endl << "POINT_DATA " << npout_total << std::endl
-          << "SCALARS gid float" << std::endl << "LOOKUP_TABLE default" << std::endl;
-    } else if (n == static_cast<int>(PTAG)) {
-      msg << std::endl << std::endl << "POINT_DATA " << npout_total << std::endl
-          << "SCALARS ptag float" << std::endl << "LOOKUP_TABLE default" << std::endl;
+
+    if (!have_written_pointdata_header) {
+      have_written_pointdata_header = true;
+      msg << std::endl << std::endl << "POINT_DATA " << npout_total << std::endl;
     }
+
+    if (n == static_cast<int>(PGID)) {
+      msg << std::endl << "SCALARS gid float" << std::endl
+          << "LOOKUP_TABLE default" << std::endl;
+    } else if (n == static_cast<int>(PTAG)) {
+      msg << std::endl << "SCALARS ptag float" << std::endl
+          << "LOOKUP_TABLE default" << std::endl;
+    }
+
     if (global_variable::my_rank == 0) {
       partfile.Write_any_type_at(msg.str().c_str(),msg.str().size(),header_offset,"byte");
     }
+
     header_offset += msg.str().size();
 
     // Loop over particles, load gid into data[]


### PR DESCRIPTION
Simple fix to bug in particle vtk output format. The POINT_DATA header should only be written once and SCALARS should be used to specify different point datasets.