### PR TITLE
hotfixing z4c amr and remove most warnings at compile time

### DIFF
--- a/src/bvals/prolongation.cpp
+++ b/src/bvals/prolongation.cpp
@@ -32,7 +32,6 @@ void MeshBoundaryValuesCC::FillCoarseInBndryCC(DvceArray5D<Real> &a,
   // create local references for variables in kernel
   int nmb = pmy_pack->nmb_thispack;
   int nnghbr = pmy_pack->pmb->nnghbr;
-  MeshBlockPack* pmbp = pmy_pack->pmesh->pmb_pack;
   //bool not_z4c = (pmbp->pz4c == nullptr)? true : false;
 
   int nvar = a.extent_int(1);  // TODO(@user): 2nd index from L of in array must be NVAR
@@ -139,7 +138,6 @@ void MeshBoundaryValuesCC::ProlongateCC(DvceArray5D<Real> &a, DvceArray5D<Real> 
   int nnghbr = pmy_pack->pmb->nnghbr;
 
   // ptr to z4c, which requires different prolongation/restriction scheme
-  MeshBlockPack* pmbp = pmy_pack->pmesh->pmb_pack;
   //bool not_z4c = (pmbp->pz4c == nullptr)? true : false;
 
   int nvar = a.extent_int(1);  // TODO(@user): 2nd index from L of in array must be NVAR

--- a/src/coordinates/excision.cpp
+++ b/src/coordinates/excision.cpp
@@ -170,13 +170,11 @@ void Coordinates::UpdateExcisionMasks() {
   if (coord_data.excision_scheme == ExcisionScheme::lapse) {
     // capture variables for kernel
     auto &indcs = pmy_pack->pmesh->mb_indcs;
-    int is = indcs.is; int js = indcs.js; int ks = indcs.ks;
     int &ng = indcs.ng;
     int n1 = indcs.nx1 + 2*ng;
     int n2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*ng) : 1;
     int n3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*ng) : 1;
     int nmb1 = pmy_pack->nmb_thispack - 1;
-    auto &size = pmy_pack->pmb->mb_size;
     auto &adm = pmy_pack->padm->adm;
     auto &floor = excision_floor;
     auto &flux = excision_flux;

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -276,7 +276,6 @@ void Driver::Initialize(Mesh *pmesh, ParameterInput *pin, Outputs *pout, bool re
   mhd::MHD *pmhd = pmesh->pmb_pack->pmhd;
   radiation::Radiation *prad = pmesh->pmb_pack->prad;
   z4c::Z4c *pz4c = pmesh->pmb_pack->pz4c;
-  dyngr::DynGRMHD *pdyngr = pmesh->pmb_pack->pdyngr;
   if (time_evolution != TimeEvolution::tstatic) {
     if (phydro != nullptr) {
       (void) pmesh->pmb_pack->phydro->NewTimeStep(this, nexp_stages);

--- a/src/dyn_grmhd/dyn_grmhd.cpp
+++ b/src/dyn_grmhd/dyn_grmhd.cpp
@@ -364,7 +364,6 @@ TaskStatus DynGRMHD::SetTmunu(Driver *pdrive, int stage) {
   int &js = indcs.js; int &je = indcs.je;
   int &ks = indcs.ks; int &ke = indcs.ke;
 
-  int ncells1 = indcs.nx1+indcs.ng; // Align scratch buffers with variables
   int nmb = pmy_pack->nmb_thispack;
 
   auto &adm = pmy_pack->padm->adm;

--- a/src/dyn_grmhd/dyn_grmhd_fofc.cpp
+++ b/src/dyn_grmhd/dyn_grmhd_fofc.cpp
@@ -36,9 +36,9 @@ namespace dyngr {
 template<class EOSPolicy, class ErrorPolicy> template <DynGRMHD_RSolver rsolver_method_>
 void DynGRMHDPS<EOSPolicy, ErrorPolicy>::FOFC(Driver *pdriver, int stage) {
   auto &indcs = pmy_pack->pmesh->mb_indcs;
-  int is = indcs.is, ie = indcs.ie, nx1 = indcs.nx1;
-  int js = indcs.js, je = indcs.je, nx2 = indcs.nx2;
-  int ks = indcs.ks, ke = indcs.ke, nx3 = indcs.nx3;
+  int is = indcs.is, ie = indcs.ie;
+  int js = indcs.js, je = indcs.je;
+  int ks = indcs.ks, ke = indcs.ke;
 
   bool &multi_d = pmy_pack->pmesh->multi_d;
   bool &three_d = pmy_pack->pmesh->three_d;
@@ -150,7 +150,6 @@ void DynGRMHDPS<EOSPolicy, ErrorPolicy>::FOFC(Driver *pdriver, int stage) {
                            pmy_pack->pmhd->w0, il, iu, jl, ju, kl, ku, true);
   }
 
-  auto &coord = pmy_pack->pcoord->coord_data;
   auto &use_fofc_ = pmy_pack->pmhd->use_fofc;
   auto fofc_ = pmy_pack->pmhd->fofc;
   auto &eos_ = eos;

--- a/src/dyn_grmhd/rsolvers/hlle_dyn_grmhd.hpp
+++ b/src/dyn_grmhd/rsolvers/hlle_dyn_grmhd.hpp
@@ -33,7 +33,6 @@ void SingleStateHLLE_DYNGR(const PrimitiveSolverHydro<EOSPolicy, ErrorPolicy>& e
   constexpr int ibz = ((ivx - IVX) + 2)%3;
 
   constexpr int diag[3] = {S11, S22, S33};
-  constexpr int idx = diag[ivx - IVX];
   constexpr int offdiag[3] = {S23, S13, S12};
   constexpr int offidx = offdiag[ivx - IVX];
   constexpr int idxy = diag[(ivx - IVX + 1) % 3];
@@ -138,7 +137,6 @@ void HLLE_DYNGR(TeamMember_t const &member,
     constexpr int ibz = ((ivx - IVX) + 2)%3;
 
     constexpr int diag[3] = {S11, S22, S33};
-    constexpr int idx = diag[ivx - IVX];
     constexpr int offdiag[3] = {S23, S13, S12};
     constexpr int offidx = offdiag[ivx - IVX];
     constexpr int idxy = diag[(ivx - IVX + 1) % 3];

--- a/src/dyn_grmhd/rsolvers/llf_dyn_grmhd.hpp
+++ b/src/dyn_grmhd/rsolvers/llf_dyn_grmhd.hpp
@@ -32,12 +32,10 @@ void SingleStateLLF_DYNGR(const PrimitiveSolverHydro<EOSPolicy, ErrorPolicy>& eo
     const int nmhd, const int nscal,
     Real g3d[NSPMETRIC], Real beta_u[3], Real alpha,
     Real flux[NCONS], Real bflux[NMAG]) {
-  constexpr int ibx = ivx - IVX;
   constexpr int iby = ((ivx - IVX) + 1)%3;
   constexpr int ibz = ((ivx - IVX) + 2)%3;
 
   constexpr int diag[3] = {S11, S22, S33};
-  constexpr int idx = diag[ivx - IVX];
   constexpr int offdiag[3] = {S23, S13, S12};
   constexpr int offidx = offdiag[ivx - IVX];
   constexpr int idxy = diag[(ivx - IVX + 1) % 3];
@@ -115,7 +113,6 @@ void LLF_DYNGR(TeamMember_t const &member,
     constexpr int ibz = ((ivx - IVX) + 2)%3;
 
     constexpr int diag[3] = {S11, S22, S33};
-    constexpr int idx = diag[ivx - IVX];
     constexpr int offdiag[3] = {S23, S13, S12};
     constexpr int offidx = offdiag[ivx - IVX];
     constexpr int idxy = diag[(ivx - IVX + 1) % 3];

--- a/src/eos/primitive_solver_hyd.hpp
+++ b/src/eos/primitive_solver_hyd.hpp
@@ -273,7 +273,6 @@ class PrimitiveSolverHydro {
                   DvceArray5D<Real> &bcc0, DvceArray5D<Real> &prim,
                   const int il, const int iu, const int jl, const int ju,
                   const int kl, const int ku, bool floors_only=false) {
-
     int &nhyd = pmy_pack->pmhd->nmhd;
     int &nscal = pmy_pack->pmhd->nscalars;
     int &nmb = pmy_pack->nmb_thispack;

--- a/src/eos/primitive_solver_hyd.hpp
+++ b/src/eos/primitive_solver_hyd.hpp
@@ -181,7 +181,6 @@ class PrimitiveSolverHydro {
                   DvceArray5D<Real> &cons,
                   const int il, const int iu, const int jl, const int ju,
                   const int kl, const int ku) {
-    auto &indcs = pmy_pack->pmesh->mb_indcs;
     //int &is = indcs.is, &js = indcs.js, &ks = indcs.ks;
     //auto &size = pmy_pack->pmb->mb_size;
     //auto &flat = pmy_pack->pcoord->coord_data.is_minkowski;
@@ -274,10 +273,6 @@ class PrimitiveSolverHydro {
                   DvceArray5D<Real> &bcc0, DvceArray5D<Real> &prim,
                   const int il, const int iu, const int jl, const int ju,
                   const int kl, const int ku, bool floors_only=false) {
-    auto &indcs = pmy_pack->pmesh->mb_indcs;
-    int &is = indcs.is, &js = indcs.js, &ks = indcs.ks;
-    int &ie = indcs.ie, &je = indcs.ie, &ke = indcs.ke;
-    auto &size = pmy_pack->pmb->mb_size;
 
     int &nhyd = pmy_pack->pmhd->nmhd;
     int &nscal = pmy_pack->pmhd->nscalars;

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -1030,7 +1030,6 @@ void MeshRefinement::RefineCC(DualArray1D<int> &n2o, DvceArray5D<Real> &a,
                               DvceArray5D<Real> &ca, bool is_z4c) {
   int nvar = a.extent_int(1);  // TODO(@user): 2nd index from L of in array must be NVAR
   auto &new_nmb = new_nmb_eachrank[global_variable::my_rank];
-  MeshBlockPack* pmbp = pmy_mesh->pmb_pack;
   auto &indcs = pmy_mesh->mb_indcs;
   auto &cis = indcs.cis, &cie = indcs.cie;
   auto &cjs = indcs.cjs, &cje = indcs.cje;
@@ -1182,7 +1181,6 @@ void MeshRefinement::RestrictCC(DvceArray5D<Real> &u, DvceArray5D<Real> &cu,
   int nmb  = u.extent_int(0);  // TODO(@user): 1st index from L of in array must be NMB
   int nvar = u.extent_int(1);  // TODO(@user): 2nd index from L of in array must be NVAR
 
-  MeshBlockPack* pmbp = pmy_mesh->pmb_pack;
   auto &indcs = pmy_mesh->mb_indcs;
   auto &cis = indcs.cis, &cie = indcs.cie;
   auto &cjs = indcs.cjs, &cje = indcs.cje;

--- a/src/mesh/meshblock_pack.cpp
+++ b/src/mesh/meshblock_pack.cpp
@@ -192,7 +192,7 @@ void MeshBlockPack::AddPhysics(ParameterInput *pin) {
   if (pin->DoesBlockExist("z4c")) {
     pz4c = new z4c::Z4c(this, pin);
     padm = new adm::ADM(this, pin);
-    ptmunu = new Tmunu(this, pin);
+    ptmunu = nullptr;
     // init puncture tracker
     int npunct = pin->GetOrAddInteger("z4c", "npunct", 0);
     if (npunct > 0) {
@@ -223,6 +223,7 @@ void MeshBlockPack::AddPhysics(ParameterInput *pin) {
   if ((pin->DoesBlockExist("z4c") || pin->DoesBlockExist("adm")) &&
       (pin->DoesBlockExist("mhd")) ) {
     pdyngr = dyngr::BuildDynGRMHD(this, pin);
+    ptmunu = new Tmunu(this, pin);
   }
 
   if (pz4c != nullptr || padm != nullptr) {

--- a/src/outputs/basetype_output.cpp
+++ b/src/outputs/basetype_output.cpp
@@ -162,7 +162,6 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
 
   // Now load STL vector of output variables
   outvars.clear();
-  int ndvars=0;
 
   // make a vector of out_params.variables
   std::vector<std::string> variables;

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -288,7 +288,6 @@ void CoarsenedBinaryOutput::LoadOutputData(Mesh *pm) {
 
 void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   // check if slicing
-  bool bin_slice = (out_params.slice1 || out_params.slice2 || out_params.slice3);
 
   // create filename: "cbin_"+"file_id"+"_"+"coarsening_factor"+"/file_basename"
   // + "." + "file_id" + "." + XXXXX + ".cbin"

--- a/src/outputs/io_wrapper.cpp
+++ b/src/outputs/io_wrapper.cpp
@@ -301,7 +301,7 @@ std::size_t IOWrapper::Write_any_type(const void *buf, IOWrapperSizeT cnt,
   return nwrite;
 #else
   // set appropriate datasize
-  std:size_t datasize;
+  std::size_t datasize;
   if (datatype.compare("byte") == 0) {
     datasize = sizeof(char);
   } else if (datatype.compare("int") == 0) {
@@ -364,7 +364,7 @@ std::size_t IOWrapper::Write_any_type_at(const void *buf, IOWrapperSizeT cnt,
   return nwrite;
 #else
   // set appropriate datasize
-  std:size_t datasize;
+  std::size_t datasize;
   if (datatype.compare("byte") == 0) {
     datasize = sizeof(char);
   } else if (datatype.compare("int") == 0) {
@@ -428,7 +428,7 @@ std::size_t IOWrapper::Write_any_type_at_all(const void *buf, IOWrapperSizeT cnt
   return nwrite;
 #else
   // set appropriate datasize
-  std:size_t datasize;
+  std::size_t datasize;
   if (datatype.compare("byte") == 0) {
     datasize = sizeof(char);
   } else if (datatype.compare("int") == 0) {

--- a/src/outputs/track_prtcl.cpp
+++ b/src/outputs/track_prtcl.cpp
@@ -43,7 +43,6 @@ TrackedParticleOutput::TrackedParticleOutput(ParameterInput *pin, Mesh *pm,
 // Copies data for tracked particles on this rank to host outpart array
 
 void TrackedParticleOutput::LoadOutputData(Mesh *pm) {
-  particles::Particles *pp = pm->pmb_pack->ppart;
 
   // Load data for tracked particles on this rank into new device array
   DualArray1D<TrackedParticleData> tracked_prtcl("d_trked",ntrack_thisrank);
@@ -136,7 +135,6 @@ void TrackedParticleOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     npout_min = std::min(npout_min, npout_eachrank[n]);
   }
 
-  std::size_t datasize = sizeof(float);
   // Write tracked particle data collectively over minimum shared number of prtcls
   for (int p=0; p<npout_min; ++p) {
     // offset computed assuming tags run 0...(ntrack-1) sequentially

--- a/src/outputs/track_prtcl.cpp
+++ b/src/outputs/track_prtcl.cpp
@@ -43,7 +43,6 @@ TrackedParticleOutput::TrackedParticleOutput(ParameterInput *pin, Mesh *pm,
 // Copies data for tracked particles on this rank to host outpart array
 
 void TrackedParticleOutput::LoadOutputData(Mesh *pm) {
-
   // Load data for tracked particles on this rank into new device array
   DualArray1D<TrackedParticleData> tracked_prtcl("d_trked",ntrack_thisrank);
   int npart = pm->nprtcl_thisrank;

--- a/src/pgen/tests/collapse.cpp
+++ b/src/pgen/tests/collapse.cpp
@@ -158,5 +158,4 @@ void ProblemGenerator::SphericalCollapse(ParameterInput *pin, const bool restart
 }
 
 void AnalyticCollapse(MeshBlockPack* pmbp) {
-  Real time = pmbp->pmesh->time;
 }

--- a/src/z4c/tmunu.cpp
+++ b/src/z4c/tmunu.cpp
@@ -22,7 +22,7 @@ char const * const Tmunu::Tmunu_names[Tmunu::N_Tmunu] = {
 Tmunu::Tmunu(MeshBlockPack *ppack, ParameterInput *pin):
   pmy_pack(ppack),
   u_tmunu("u_tmunu",1,1,1,1,1) {
-  int nmb = ppack->nmb_thispack;
+  int nmb = std::max((ppack->nmb_thispack), (ppack->pmesh->nmb_maxperrank));
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int ncells1 = indcs.nx1 + 2*(indcs.ng);
   int ncells2 = (indcs.nx2 > 1) ? (indcs.nx2 + 2*(indcs.ng)) : 1;

--- a/src/z4c/tmunu.cpp
+++ b/src/z4c/tmunu.cpp
@@ -5,6 +5,7 @@
 //========================================================================================
 //! \file tmunu.hpp
 //! \brief implementation of Tmunu class
+#include <algorithm>
 
 #include "athena.hpp"
 #include "athena_tensor.hpp"

--- a/src/z4c/z4c.cpp
+++ b/src/z4c/z4c.cpp
@@ -201,7 +201,6 @@ void Z4c::AlgConstr(MeshBlockPack *pmbp) {
   int nmb = pmbp->nmb_thispack;
 
   auto &z4c = pmbp->pz4c->z4c;
-  auto &opt = pmbp->pz4c->opt;
   par_for("Alg constr loop",DevExeSpace(),
   0,nmb-1,ksg,keg,jsg,jeg,isg,ieg,
   KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {

--- a/src/z4c/z4c.hpp
+++ b/src/z4c/z4c.hpp
@@ -223,7 +223,6 @@ class Z4c {
   int nrad; // number of radii to perform wave extraction
 
   // functions
-  void AssembleZ4cTasks(std::map<std::string, std::shared_ptr<TaskList>> tl);
   void QueueZ4cTasks();
   TaskStatus InitRecv(Driver *d, int stage);
   TaskStatus ClearRecv(Driver *d, int stage);

--- a/src/z4c/z4c_Sbc.cpp
+++ b/src/z4c/z4c_Sbc.cpp
@@ -126,15 +126,11 @@ static void Z4cSommerfeld(const Z4c::Z4c_vars& z4c, const Z4c::Z4c_vars& rhs,
 //! \brief placeholder for the Sommerfield Boundary conditions for z4c
 TaskStatus Z4c::Z4cBoundaryRHS(Driver *pdriver, int stage) {
   auto &pm = pmy_pack->pmesh;
-  int &ng = pmy_pack->pmesh->mb_indcs.ng;
   auto &mb_bcs = pmy_pack->pmb->mb_bcs;
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   auto &size = pmy_pack->pmb->mb_size;
 
   int nmb = pmy_pack->nmb_thispack;
-  int n1 = indcs.nx1 + 2*ng;
-  int n2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*ng) : 1;
-  int n3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*ng) : 1;
   int is = indcs.is;
   int ie = indcs.ie;
   int js = indcs.js;

--- a/src/z4c/z4c_adm.cpp
+++ b/src/z4c/z4c_adm.cpp
@@ -257,11 +257,9 @@ void Z4c::ADMConstraints(MeshBlockPack *pmbp) {
   int &ks = indcs.ks; int &ke = indcs.ke;
   //For GLOOPS
 
-  int ncells1 = indcs.nx1 + 2*(indcs.ng);
   int nmb = pmbp->nmb_thispack;
 
   auto &z4c = pmbp->pz4c->z4c;
-  auto &opt = pmbp->pz4c->opt;
   auto &adm = pmbp->padm->adm;
   auto &tmunu = pmbp->ptmunu->tmunu;
   auto &u_con = pmbp->pz4c->u_con;

--- a/src/z4c/z4c_adm.cpp
+++ b/src/z4c/z4c_adm.cpp
@@ -261,11 +261,12 @@ void Z4c::ADMConstraints(MeshBlockPack *pmbp) {
 
   auto &z4c = pmbp->pz4c->z4c;
   auto &adm = pmbp->padm->adm;
-  auto &tmunu = pmbp->ptmunu->tmunu;
   auto &u_con = pmbp->pz4c->u_con;
 
   // vacuum or with matter?
-  bool is_vacuum = (pmbp->ptmunu == nullptr) ? true : false;
+  bool is_vacuum = (pmy_pack->ptmunu == nullptr) ? true : false;
+  Tmunu::Tmunu_vars tmunu;
+  if (!is_vacuum) tmunu = pmy_pack->ptmunu->tmunu;
 
   Kokkos::deep_copy(u_con, 0.);
   auto &con = pmbp->pz4c->con;

--- a/src/z4c/z4c_calcrhs.cpp
+++ b/src/z4c/z4c_calcrhs.cpp
@@ -379,7 +379,6 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
         S += oopsi4 * g_uu(a,b) * tmunu.S_dd(m,a,b,k,j,i);
       }
     }
-    
 
     // -----------------------------------------------------------------------------------
     // 2nd covariant derivative of the lapse

--- a/src/z4c/z4c_calcrhs.cpp
+++ b/src/z4c/z4c_calcrhs.cpp
@@ -35,11 +35,12 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
   int nmb = pmy_pack->nmb_thispack;
 
   auto &z4c = pmy_pack->pz4c->z4c;
-  auto &tmunu = pmy_pack->ptmunu->tmunu;
   auto &rhs = pmy_pack->pz4c->rhs;
   auto &opt = pmy_pack->pz4c->opt;
 
   bool is_vacuum = (pmy_pack->ptmunu == nullptr) ? true : false;
+  Tmunu::Tmunu_vars tmunu;
+  if (!is_vacuum) tmunu = pmy_pack->ptmunu->tmunu;
 
   // ===================================================================================
   // Main RHS calculation

--- a/src/z4c/z4c_calcrhs.cpp
+++ b/src/z4c/z4c_calcrhs.cpp
@@ -39,6 +39,8 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
   auto &rhs = pmy_pack->pz4c->rhs;
   auto &opt = pmy_pack->pz4c->opt;
 
+  bool is_vacuum = (pmy_pack->ptmunu == nullptr) ? true : false;
+
   // ===================================================================================
   // Main RHS calculation
   //
@@ -370,10 +372,13 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
     //    S(1) += oopsi4(1) * g_uu(a,b,i) * mat.S_dd(m,a,b,k,j,i);
     //  }
     //}
-    for (int a = 0; a < 3; ++a)
-    for (int b = 0; b < 3; ++b) {
-      S += oopsi4 * g_uu(a,b) * tmunu.S_dd(m,a,b,k,j,i);
+    if(is_vacuum) {
+      for (int a = 0; a < 3; ++a)
+      for (int b = 0; b < 3; ++b) {
+        S += oopsi4 * g_uu(a,b) * tmunu.S_dd(m,a,b,k,j,i);
+      }
     }
+    
 
     // -----------------------------------------------------------------------------------
     // 2nd covariant derivative of the lapse
@@ -494,13 +499,17 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
       LKhat + opt.damp_kappa1*(1 - opt.damp_kappa2)
       * z4c.alpha(m,k,j,i) * z4c.vTheta(m,k,j,i);
     // Matter term
-    rhs.vKhat(m,k,j,i) += 4.*M_PI * z4c.alpha(m,k,j,i) * (S + tmunu.E(m,k,j,i));
+    if(is_vacuum) {
+      rhs.vKhat(m,k,j,i) += 4.*M_PI * z4c.alpha(m,k,j,i) * (S + tmunu.E(m,k,j,i));
+    }
     rhs.chi(m,k,j,i) = Lchi - (1./6.) * opt.chi_psi_power *
       chi_guarded * z4c.alpha(m,k,j,i) * K;
     rhs.vTheta(m,k,j,i) = LTheta + z4c.alpha(m,k,j,i) * (
         0.5*Ht - (2. + opt.damp_kappa2) * opt.damp_kappa1 * z4c.vTheta(m,k,j,i));
     // Matter term
-    rhs.vTheta(m,k,j,i) -= 8.*M_PI * z4c.alpha(m,k,j,i) * tmunu.E(m,k,j,i);
+    if(is_vacuum) {
+      rhs.vTheta(m,k,j,i) -= 8.*M_PI * z4c.alpha(m,k,j,i) * tmunu.E(m,k,j,i);
+    }
     // If BSSN is enabled, theta is disabled.
     rhs.vTheta(m,k,j,i) *= opt.use_z4c;
     // Gamma's
@@ -511,8 +520,10 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
       for(int b = 0; b < 3; ++b) {
         rhs.vGam_u(m,a,k,j,i) -= 2. * A_uu(a,b) * dalpha_d(b);
         // Matter term
-        rhs.vGam_u(m,a,k,j,i) -= 16.*M_PI * z4c.alpha(m,k,j,i)
+        if(is_vacuum) {
+          rhs.vGam_u(m,a,k,j,i) -= 16.*M_PI * z4c.alpha(m,k,j,i)
                               * g_uu(a,b) * tmunu.S_d(m,b,k,j,i);
+        }
       }
     }
 
@@ -529,8 +540,10 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
                              - 2.*AA_dd(a,b));
       rhs.vA_dd(m,a,b,k,j,i) += LA_dd(a,b);
       // Matter term
-      rhs.vA_dd(m,a,b,k,j,i) -= 8.*M_PI * z4c.alpha(m,k,j,i) *
-        (oopsi4*tmunu.S_dd(m,a,b,k,j,i) - (1./3.)*S*z4c.g_dd(m,a,b,k,j,i));
+      if(is_vacuum) {
+        rhs.vA_dd(m,a,b,k,j,i) -= 8.*M_PI * z4c.alpha(m,k,j,i) *
+                (oopsi4*tmunu.S_dd(m,a,b,k,j,i) - (1./3.)*S*z4c.g_dd(m,a,b,k,j,i));
+      }
     }
     // lapse function
     Real const f = opt.lapse_oplog * opt.lapse_harmonicf

--- a/src/z4c/z4c_calcrhs.cpp
+++ b/src/z4c/z4c_calcrhs.cpp
@@ -372,7 +372,7 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
     //    S(1) += oopsi4(1) * g_uu(a,b,i) * mat.S_dd(m,a,b,k,j,i);
     //  }
     //}
-    if(is_vacuum) {
+    if(!is_vacuum) {
       for (int a = 0; a < 3; ++a)
       for (int b = 0; b < 3; ++b) {
         S += oopsi4 * g_uu(a,b) * tmunu.S_dd(m,a,b,k,j,i);
@@ -499,7 +499,7 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
       LKhat + opt.damp_kappa1*(1 - opt.damp_kappa2)
       * z4c.alpha(m,k,j,i) * z4c.vTheta(m,k,j,i);
     // Matter term
-    if(is_vacuum) {
+    if(!is_vacuum) {
       rhs.vKhat(m,k,j,i) += 4.*M_PI * z4c.alpha(m,k,j,i) * (S + tmunu.E(m,k,j,i));
     }
     rhs.chi(m,k,j,i) = Lchi - (1./6.) * opt.chi_psi_power *
@@ -507,7 +507,7 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
     rhs.vTheta(m,k,j,i) = LTheta + z4c.alpha(m,k,j,i) * (
         0.5*Ht - (2. + opt.damp_kappa2) * opt.damp_kappa1 * z4c.vTheta(m,k,j,i));
     // Matter term
-    if(is_vacuum) {
+    if(!is_vacuum) {
       rhs.vTheta(m,k,j,i) -= 8.*M_PI * z4c.alpha(m,k,j,i) * tmunu.E(m,k,j,i);
     }
     // If BSSN is enabled, theta is disabled.
@@ -520,7 +520,7 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
       for(int b = 0; b < 3; ++b) {
         rhs.vGam_u(m,a,k,j,i) -= 2. * A_uu(a,b) * dalpha_d(b);
         // Matter term
-        if(is_vacuum) {
+        if(!is_vacuum) {
           rhs.vGam_u(m,a,k,j,i) -= 16.*M_PI * z4c.alpha(m,k,j,i)
                               * g_uu(a,b) * tmunu.S_d(m,b,k,j,i);
         }
@@ -540,7 +540,7 @@ TaskStatus Z4c::CalcRHS(Driver *pdriver, int stage) {
                              - 2.*AA_dd(a,b));
       rhs.vA_dd(m,a,b,k,j,i) += LA_dd(a,b);
       // Matter term
-      if(is_vacuum) {
+      if(!is_vacuum) {
         rhs.vA_dd(m,a,b,k,j,i) -= 8.*M_PI * z4c.alpha(m,k,j,i) *
                 (oopsi4*tmunu.S_dd(m,a,b,k,j,i) - (1./3.)*S*z4c.g_dd(m,a,b,k,j,i));
       }

--- a/src/z4c/z4c_calculate_weyl_scalars.cpp
+++ b/src/z4c/z4c_calculate_weyl_scalars.cpp
@@ -37,7 +37,6 @@ void Z4c::Z4cWeyl(MeshBlockPack *pmbp) {
   int &ks = indcs.ks; int &ke = indcs.ke;
   int nmb = pmbp->nmb_thispack;
 
-  auto &z4c = pmbp->pz4c->z4c;
   auto &adm = pmbp->padm->adm;
   auto &weyl = pmbp->pz4c->weyl;
   auto &u_weyl = pmbp->pz4c->u_weyl;

--- a/src/z4c/z4c_gauge.cpp
+++ b/src/z4c/z4c_gauge.cpp
@@ -34,7 +34,6 @@ void Z4c::GaugePreCollapsedLapse(MeshBlockPack *pmbp, ParameterInput *pin) {
   int isg = is-indcs.ng; int ieg = ie+indcs.ng;
   int jsg = js-indcs.ng; int jeg = je+indcs.ng;
   int ksg = ks-indcs.ng; int keg = ke+indcs.ng;
-  int ncells1 = indcs.nx1 + 2*(indcs.ng);
   int nmb = pmbp->nmb_thispack;
   auto &z4c = pmbp->pz4c->z4c;
   auto &adm = pmbp->padm->adm;

--- a/src/z4c/z4c_wave_extr.cpp
+++ b/src/z4c/z4c_wave_extr.cpp
@@ -77,7 +77,7 @@ void Z4c::WaveExtr(MeshBlockPack *pmbp) {
 
   // maximum l; TODO(@hzhu): read in from input file
   int lmax = 8;
-  bool bitant = false;
+  // bool bitant = false;
 
   Real ylmR,ylmI;
   for (int g=0; g<nradii; ++g) {


### PR DESCRIPTION
Z4c with AMR is broken in current master due to incorrect size of the T_\mu\nu array when AMR is invoked. This merge request fixes this. Also removes most of the warnings during compile. 