### PR TITLE
Replaced printf with Kokkos::printf.

### DIFF
--- a/src/eos/primitive-solver/piecewise_polytrope.hpp
+++ b/src/eos/primitive-solver/piecewise_polytrope.hpp
@@ -17,6 +17,7 @@
 
 #include <math.h>
 #include <float.h>
+#include <cstdio>
 
 #include <stdexcept>
 #include <limits>

--- a/src/eos/primitive-solver/piecewise_polytrope.hpp
+++ b/src/eos/primitive-solver/piecewise_polytrope.hpp
@@ -16,7 +16,6 @@
 //  \f$P_\textrm{therm} = nk_B T\f$
 
 #include <math.h>
-#include <stdio.h>
 #include <float.h>
 
 #include <stdexcept>
@@ -177,7 +176,7 @@ class PiecewisePolytrope : public EOSPolicyInterface {
                           Real P0, Real m, int n) {
     // Make sure that we actually *have* polytropes
     if (n <= 1) {
-      printf("PiecewisePolytrope: Invalid number of polytropes requested."); // NOLINT
+      Kokkos::printf("PiecewisePolytrope: Invalid number of polytropes requested.");
       return false;
     }
     // Before we even try to construct anything, we need to make sure that
@@ -186,14 +185,14 @@ class PiecewisePolytrope : public EOSPolicyInterface {
       if(densities[i] <= densities[i-1]) {
         // The densities must be ordered from smallest to largest and strictly
         // increasing.
-        printf("PiecewisePolytrope: Densities must be strictly increasing."); // NOLINT
+        Kokkos::printf("PiecewisePolytrope: Densities must be strictly increasing.");
         return false;
       }
     }
 
     // Make sure that we're not trying to allocate too many polytropes
     if (n > MAX_PIECES) {
-      printf("PiecewisePolytrope: number of pieces requested exceeds limit."); // NOLINT
+      Kokkos::printf("PiecewisePolytrope: number of pieces requested exceeds limit.");
       return false;
     }
 

--- a/src/eos/primitive_solver_hyd.hpp
+++ b/src/eos/primitive_solver_hyd.hpp
@@ -12,7 +12,6 @@
 // C headers
 #include <float.h>
 #include <math.h>
-#include <stdio.h>
 
 // C++ headers
 #include <string>
@@ -239,7 +238,7 @@ class PrimitiveSolverHydro {
 
       // Check for NaNs
       if (CheckForConservedNaNs(cons_pt)) {
-        printf("Error occurred in PrimToCons at (%d, %d, %d, %d)\n", m, k, j, i);
+        Kokkos::printf("Error occurred in PrimToCons at (%d, %d, %d, %d)\n", m, k, j, i);
         DumpPrimitiveVars(prim_pt);
       }
 
@@ -408,7 +407,7 @@ class PrimitiveSolverHydro {
         if (result.error != Primitive::Error::SUCCESS && (nerrs_ + sumerrs < errcap_)) {
           // TODO(JF): put in a proper error response here.
           sumerrs++;
-          printf("An error occurred during the primitive solve: %s\n"
+          Kokkos::printf("An error occurred during the primitive solve: %s\n"
                  "  Location: (%d, %d, %d, %d)\n"
                  "  Conserved vars: \n"
                  "    D   = %.17g\n"
@@ -441,7 +440,8 @@ class PrimitiveSolverHydro {
                  adm.vK_dd(m, 1, 1, k, j, i), adm.vK_dd(m, 1, 2, k, j, i),
                  adm.vK_dd(m, 2, 2, k, j, i));
           if (nerrs_ + sumerrs == errcap_) {
-            printf("%d C2P errors have been detected on rank %d. All future C2P errors\n"
+            Kokkos::printf("%d C2P errors have been detected on rank %d."
+                   "All future C2P errors\n"
                    "on this rank will be suppressed. Fix your code!\n",
                    nerrs_ + sumerrs,rank);
           }
@@ -581,23 +581,23 @@ class PrimitiveSolverHydro {
   static int CheckForConservedNaNs(const Real cons_pt[NCONS]) {
     int nans = 0;
     if (!isfinite(cons_pt[CDN])) {
-      printf("D is NaN!\n"); // NOLINT
+      Kokkos::printf("D is NaN!\n"); // NOLINT
       nans = 1;
     }
     if (!isfinite(cons_pt[CSX])) {
-      printf("Sx is NaN!\n"); // NOLINT
+      Kokkos::printf("Sx is NaN!\n"); // NOLINT
       nans = 1;
     }
     if (!isfinite(cons_pt[CSY])) {
-      printf("Sy is NaN!\n"); // NOLINT
+      Kokkos::printf("Sy is NaN!\n"); // NOLINT
       nans = 1;
     }
     if (!isfinite(cons_pt[CSZ])) {
-      printf("Sz is NaN!\n"); // NOLINT
+      Kokkos::printf("Sz is NaN!\n"); // NOLINT
       nans = 1;
     }
     if (!isfinite(cons_pt[CTA])) {
-      printf("Tau is NaN!\n"); // NOLINT
+      Kokkos::printf("Tau is NaN!\n"); // NOLINT
       nans = 1;
     }
 
@@ -606,7 +606,7 @@ class PrimitiveSolverHydro {
 
   KOKKOS_INLINE_FUNCTION
   static void DumpPrimitiveVars(const Real prim_pt[NPRIM]) {
-    printf("Primitive vars: \n" // NOLINT
+    Kokkos::printf("Primitive vars: \n" // NOLINT
            "  rho = %.17g\n"
            "  ux  = %.17g\n"
            "  uy  = %.17g\n"

--- a/src/outputs/io_wrapper.cpp
+++ b/src/outputs/io_wrapper.cpp
@@ -31,7 +31,7 @@ int IOWrapper::Open(const char* fname, FileMode rw) {
       char msg[MPI_MAX_ERROR_STRING];
       int resultlen;
       MPI_Error_string(errcode, msg, &resultlen);
-      printf("%.*s\n", resultlen, msg);
+      Kokkos::printf("%.*s\n", resultlen, msg);
       MPI_Abort(MPI_COMM_WORLD, 1);
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "Input file '" << fname << "' could not be opened"
@@ -57,7 +57,7 @@ int IOWrapper::Open(const char* fname, FileMode rw) {
       char msg[MPI_MAX_ERROR_STRING];
       int resultlen;
       MPI_Error_string(errcode, msg, &resultlen);
-      printf("%.*s\n", resultlen, msg);
+      Kokkos::printf("%.*s\n", resultlen, msg);
       MPI_Abort(MPI_COMM_WORLD, 1);
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "Input file '" << fname << "' could not be opened"
@@ -82,7 +82,7 @@ int IOWrapper::Open(const char* fname, FileMode rw) {
       char msg[MPI_MAX_ERROR_STRING];
       int resultlen;
       MPI_Error_string(errcode, msg, &resultlen);
-      printf("%.*s\n", resultlen, msg);
+      Kokkos::printf("%.*s\n", resultlen, msg);
       MPI_Abort(MPI_COMM_WORLD, 1);
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "Input file '" << fname << "' could not be appended"
@@ -117,7 +117,7 @@ std::size_t IOWrapper::Read_bytes(void *buf, IOWrapperSizeT size, IOWrapperSizeT
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nread;
@@ -143,7 +143,7 @@ std::size_t IOWrapper::Read_bytes_at(void *buf, IOWrapperSizeT size,
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nread;
@@ -170,7 +170,7 @@ std::size_t IOWrapper::Read_bytes_at_all(void *buf, IOWrapperSizeT size,
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nread;
@@ -195,7 +195,7 @@ std::size_t IOWrapper::Read_Reals(void *buf, IOWrapperSizeT cnt) {
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nread;
@@ -220,7 +220,7 @@ std::size_t IOWrapper::Read_Reals_at(void *buf, IOWrapperSizeT cnt,
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nread;
@@ -247,7 +247,7 @@ std::size_t IOWrapper::Read_Reals_at_all(void *buf, IOWrapperSizeT cnt,
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nread;
@@ -293,7 +293,7 @@ std::size_t IOWrapper::Write_any_type(const void *buf, IOWrapperSizeT cnt,
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nwrite;
@@ -356,7 +356,7 @@ std::size_t IOWrapper::Write_any_type_at(const void *buf, IOWrapperSizeT cnt,
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nwrite;
@@ -420,7 +420,7 @@ std::size_t IOWrapper::Write_any_type_at_all(const void *buf, IOWrapperSizeT cnt
     char msg[MPI_MAX_ERROR_STRING];
     int resultlen;
     MPI_Error_string(errcode, msg, &resultlen);
-    printf("%.*s\n", resultlen, msg);
+    Kokkos::printf("%.*s\n", resultlen, msg);
     return 0;
   }
   int nwrite;

--- a/src/pgen/dyngr_tov.cpp
+++ b/src/pgen/dyngr_tov.cpp
@@ -6,7 +6,6 @@
 //! \file dyngr_tov.cpp
 //  \brief Problem generator for TOV star. Only works when ADM is enabled.
 
-#include <stdio.h>
 #include <math.h>     // abs(), cos(), exp(), log(), NAN, pow(), sin(), sqrt()
 
 #include <algorithm>  // max(), max_element(), min(), min_element()
@@ -1009,7 +1008,7 @@ static void GetPrimitivesAtIsoPoint(const tov_pgen& tov, const TOVEOS& eos, Real
   const auto &alps = tov.alp.d_view;
   const auto &Ms = tov.M.d_view;
   if (idx >= tov.npoints || idx < 0) {
-    printf("There's a problem with the index!\n" // NOLINT
+    Kokkos::printf("There's a problem with the index!\n" // NOLINT
            " idx = %d\n"
            " r_iso = %g\n"
            " dr = %g\n",idx,r_iso,tov.dr);
@@ -1022,7 +1021,7 @@ static void GetPrimitivesAtIsoPoint(const tov_pgen& tov, const TOVEOS& eos, Real
   //rho = pow(p/tov.kappa, 1.0/tov.gamma);
   rho = eos.template GetRhoFromP<LocationTag::Device>(fmax(p, tov.pfloor));
   if (!isfinite(p)) {
-    printf("There's a problem with p!\n"); // NOLINT
+    Kokkos::printf("There's a problem with p!\n"); // NOLINT
     assert(false);
   }
 }

--- a/src/z4c/z4c_tasks.cpp
+++ b/src/z4c/z4c_tasks.cpp
@@ -28,7 +28,7 @@ namespace z4c {
 //! \fn  void Z4c::QueueZ4cTasks
 //! \brief queue Z4c tasks into NumericalRelativity
 void Z4c::QueueZ4cTasks() {
-  printf("AssembleZ4cTasks\n");
+  Kokkos::printf("AssembleZ4cTasks\n");
   using namespace mhd;     // NOLINT(build/namespaces)
   using namespace numrel;  // NOLINT(build/namespaces)
   NumericalRelativity *pnr = pmy_pack->pnr;


### PR DESCRIPTION
This pull request replaces `printf` with `Kokkos::printf` everywhere in the code to fix issue #582.