### PR TITLE
Make restart file compatible with previous version

### DIFF
--- a/src/dyn_grmhd/dyn_grmhd.cpp
+++ b/src/dyn_grmhd/dyn_grmhd.cpp
@@ -474,7 +474,7 @@ void DynGRMHDPS<EOSPolicy, ErrorPolicy>::AddCoordTermsEOS(const DvceArray5D<Real
                     &g3u[S11], &g3u[S12], &g3u[S13], &g3u[S22], &g3u[S23], &g3u[S33]);
 
     // Calculate the metric derivatives
-    Real idx[] = {size.d_view(m).idx1, size.d_view(m).idx2, size.d_view(m).idx3};
+    Real idx[] = {1./size.d_view(m).dx1, 1./size.d_view(m).dx2, 1./size.d_view(m).dx3};
     Real dalpha_d[3] = {0.};
     for (int a = 0; a < ndim; a++) {
       dalpha_d[a] = Dx<NGHOST>(a, idx, adm.alpha, m, k, j, i);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -26,7 +26,6 @@ struct RegionSize {
   Real x1min, x2min, x3min;
   Real x1max, x2max, x3max;
   Real dx1, dx2, dx3;       // (uniform) grid spacing
-  Real idx1, idx2, idx3;
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -116,9 +116,6 @@ MeshBlock::MeshBlock(MeshBlockPack* ppack, int igids, int nmb) :
                             static_cast<Real>(pm->mb_indcs.nx2);
     mb_size.h_view(m).dx3 = (mb_size.h_view(m).x3max - mb_size.h_view(m).x3min)/
                             static_cast<Real>(pm->mb_indcs.nx3);
-    mb_size.h_view(m).idx1 = 1./mb_size.h_view(m).dx1;
-    mb_size.h_view(m).idx2 = 1./mb_size.h_view(m).dx2;
-    mb_size.h_view(m).idx3 = 1./mb_size.h_view(m).dx3;
   }
 
   // For each DualArray: mark host views as modified, and then sync to device array


### PR DESCRIPTION
The `RegionSize` struct has been changed since the merge of the DynGRMHD module. This leads to a change in the structure of the restart file so the the code cannot read the previous restart file correctly. This PR rollbacks the `RegionSize` struct so that the restart file is compatible with previous versions. In addition, the new variables `ixd1, idx2, idx3` in `RegionSize` are used only once in the code so it seems not necessary. I'm also open to keeping these variables if they are necessary.