### PR TITLE
Fix "_NV_ANON_NAMESPACE::shk_dir" error.

### DIFF
--- a/src/pgen/tests/shock_tube.cpp
+++ b/src/pgen/tests/shock_tube.cpp
@@ -122,7 +122,7 @@ void ProblemGenerator::ShockTube(ParameterInput *pin, const bool restart) {
 
     auto &w0 = pmbp->phydro->w0;
     auto &nscal = pmbp->phydro->nscalars;
-    auto &shk_dir_ = shk_dir;
+    auto shk_dir_ = shk_dir;
     par_for("pgen_shock1", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
     KOKKOS_LAMBDA(int m,int k, int j, int i) {
       Real x;
@@ -220,7 +220,7 @@ void ProblemGenerator::ShockTube(ParameterInput *pin, const bool restart) {
     auto &b0 = pmbp->pmhd->b0;
     auto &bcc0 = pmbp->pmhd->bcc0;
     auto &nscal = pmbp->pmhd->nscalars;
-    auto &shk_dir_ = shk_dir;
+    auto shk_dir_ = shk_dir;
     par_for("pgen_shock1", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
     KOKKOS_LAMBDA(int m,int k, int j, int i) {
       Real x,bxl,byl,bzl,bxr,byr,bzr;
@@ -328,7 +328,7 @@ void SetADMVariablesToSchwarzschild(MeshBlockPack *pmbp) {
   int n1 = indcs.nx1 + 2*ng;
   int n2 = (indcs.nx2 > 1) ? (indcs.nx2 + 2*ng) : 1;
   int n3 = (indcs.nx3 > 1) ? (indcs.nx3 + 2*ng) : 1;
-  auto& shk_dir_ = shk_dir;
+  auto shk_dir_ = shk_dir;
   par_for("pgen_adm_vars", DevExeSpace(), 0,nmb1,0,(n3-1),0,(n2-1),0,(n1-1),
   KOKKOS_LAMBDA(int m, int k, int j, int i) {
     Real &x1min = size.d_view(m).x1min;


### PR DESCRIPTION
This should fix the issue @HengruiZhu99 encountered while compiling on Della with the most recent changes. I encountered a similar issue on Vista. It appears to be due to a variable in the anonymous namespace not being captured properly by the GPU. Copying the offending variable rather than trying to use a reference appears to fix the issue. It isn't clear why it only appears with some versions of the Nvidia compiler.