### PR TITLE
fix bug in binary.cpp and coarsened_binary.cpp

### DIFF
--- a/src/outputs/binary.cpp
+++ b/src/outputs/binary.cpp
@@ -247,7 +247,8 @@ void MeshBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         std::size_t myoffset=header_offset+data_size*ns_mbs+data_size*m;
         // every rank has a MB to write, so write collectively
         if (m < noutmbs_min) {
-          if (binfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte") != data_size) {
+          if (binfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte")
+              != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "binary data not written correctly to binary file, "
                 << "binary file is broken." << std::endl;

--- a/src/outputs/binary.cpp
+++ b/src/outputs/binary.cpp
@@ -247,7 +247,7 @@ void MeshBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         std::size_t myoffset=header_offset+data_size*ns_mbs+data_size*m;
         // every rank has a MB to write, so write collectively
         if (m < noutmbs_min) {
-          if (binfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte") != 1) {
+          if (binfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte") != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "binary data not written correctly to binary file, "
                 << "binary file is broken." << std::endl;
@@ -255,7 +255,7 @@ void MeshBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
           }
         // some ranks are finished writing, so use non-collective write
         } else if (m < pm->nmb_thisrank) {
-          if (binfile.Write_any_type_at(pdata,(data_size),myoffset,"byte") != 1) {
+          if (binfile.Write_any_type_at(pdata,(data_size),myoffset,"byte") != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                  << std::endl << "binary data not written correctly to binary file, "
                  << "binary file is broken." << std::endl;

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -507,7 +507,7 @@ void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         std::size_t myoffset=header_offset+data_size*ns_mbs+data_size*m;
         // every rank has a MB to write, so write collectively
         if (m < noutmbs_min) {
-          if (cbinfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte") != 1) {
+          if (cbinfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte") != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "binary data not written correctly to binary file, "
                 << "binary file is broken." << std::endl;
@@ -515,7 +515,7 @@ void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
           }
         // some ranks are finished writing, so use non-collective write
         } else if (m < pm->nmb_thisrank) {
-          if (cbinfile.Write_any_type_at(pdata,(data_size),myoffset,"byte") != 1) {
+          if (cbinfile.Write_any_type_at(pdata,(data_size),myoffset,"byte") != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                  << std::endl << "binary data not written correctly to binary file, "
                  << "binary file is broken." << std::endl;

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -507,7 +507,8 @@ void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         std::size_t myoffset=header_offset+data_size*ns_mbs+data_size*m;
         // every rank has a MB to write, so write collectively
         if (m < noutmbs_min) {
-          if (cbinfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte") != data_size) {
+          if (cbinfile.Write_any_type_at_all(pdata,(data_size),myoffset,"byte")
+              != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl << "binary data not written correctly to binary file, "
                 << "binary file is broken." << std::endl;
@@ -515,7 +516,8 @@ void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
           }
         // some ranks are finished writing, so use non-collective write
         } else if (m < pm->nmb_thisrank) {
-          if (cbinfile.Write_any_type_at(pdata,(data_size),myoffset,"byte") != data_size) {
+          if (cbinfile.Write_any_type_at(pdata,(data_size),myoffset,"byte")
+              != data_size) {
             std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                  << std::endl << "binary data not written correctly to binary file, "
                  << "binary file is broken." << std::endl;


### PR DESCRIPTION
Correctly compare output of ```Write_any_type_at(...)``` and ```Write_any_type_at_all(...)``` to ```data_size``` rather than just ```1```. This fixes an output bug that occurred when attempting to write large binary files from a small number of (e.g.) GPUs, such as the H200s.