### PR TITLE
Minor updates to PS false position root solver

### DIFF
--- a/src/eos/primitive-solver/numtools_root.hpp
+++ b/src/eos/primitive-solver/numtools_root.hpp
@@ -29,7 +29,7 @@ class Root {
   // Find the root of a generic functor taking at least one argument. The first
   // argument is assumed to be the quantity of interest. All other arguments are
   // assumed to be constant parameters for the function. The root-finding method
-  // is the Illinois variant of false position.
+  // is the Anderson-Bjorck variant of false position.
   //
   // \param[in]  f  The functor to find a root for. Its root function must take at
   //                least one argument.
@@ -52,10 +52,10 @@ class Root {
     Real xold;
     x = lb;
     // If one of the bounds is already within tolerance of the root, we have the root.
-    if (fabs(flb) <= tol) {
+    if (fabs(flb)/lb <= tol) {
       x = lb;
       return true;
-    } else if (fabs(fub) <= tol) {
+    } else if (fabs(fub)/ub <= tol) {
       x = ub;
       return true;
     }
@@ -81,14 +81,18 @@ class Root {
         flb = ftest;
         lb = x;
         if (side == 1) {
-          fub /= 2.0;
+          Real m = 1. - ftest/flb;
+          fub = (m > 0) ? fub*m : 0.5*fub;
+          //fub /= 2.0;
         }
         side = 1;
       } else {
         fub = ftest;
         ub = x;
         if (side == -1) {
-          flb /= 2.0;
+          Real m = 1. - ftest/fub;
+          flb = (m > 0) ? flb*m : 0.5*flb;
+          //flb /= 2.0;
         }
         side = -1;
       }


### PR DESCRIPTION
This implements two minor updates to the root solver used by `PrimitiveSolver`:
1. This adds a small bug fix when the bounds are close to the root but not actually accurate enough in order to prevent early termination. The fix works well for `PrimitiveSolver` because of the form of the root function, but any other code that uses or plans to use `FalsePosition` should check that this still works. If it seems to cause problems, the simplest solution would be to remove the early termination check altogether (unless `f(lb)` or `f(ub)` are *exactly* zero).
2. The current version of `FalsePosition` is based on the Illinois method, which has a simple fix to whittle the bounds down more evenly to reduce problems with slow convergence. This pull request switches to the [Anderson-Björck method](https://en.wikipedia.org/wiki/Regula_falsi#Improvements_in_regula_falsi), which slightly tweaks the fix to offer improved convergence.

Concerning the switch to Anderson-Björck, tests with the standalone version of `PrimitiveSolver` suggest that the new version of the root solver converges faster with superior accuracy. The following tests are based on the setup in Siegel et al. (1712.07538) using an ideal gas and the LS220 equation of state and a tolerance of 5e-9:

Old solver, ideal gas:
![ideal_iter](https://github.com/user-attachments/assets/623f8270-b7d4-4585-a78d-88a55f9978dc) ![ideal_err](https://github.com/user-attachments/assets/86294271-892b-48c4-85e9-0bade0d6716c)
Avg. iterations: 3.8
Log avg. error: 5.0e-14

New solver, ideal gas:
![ideal_iter](https://github.com/user-attachments/assets/b8c1f2d8-5be1-46a7-a322-f4a339ce9542) ![ideal_err](https://github.com/user-attachments/assets/3d22598d-4698-4228-ac4d-b7a68f0e4dc9)
Avg. iterations: 3.4
Log avg. error: 2.4e-15

Old solver, LS220:
![ls220_iter](https://github.com/user-attachments/assets/4cbb541c-8e56-4ce1-a338-9b3078cdce4e) ![ls220_err](https://github.com/user-attachments/assets/0f34224d-52ff-47aa-b1be-f4ed4d4ea600)
Avg. iterations: 5.5
Log avg. error: 3.9e-13

New solver, LS220:
![ls220_iter](https://github.com/user-attachments/assets/12aea3f3-5fef-4a5a-bc3d-305a87ffcb96) ![ls220_err](https://github.com/user-attachments/assets/8358a4d9-9671-4c38-80d1-d24fda56e77a)
Avg. iterations: 4.5
Log avg. error: 6.3e-15

Increasing the solver tolerance to 1e-13 shows that the improved convergence properties remain at higher tolerances, and other tests suggest the code is much more accurate at high Lorentz factors as well (with an ideal gas now being accurate up to Lorentz factors of 1000, and LS220 accurate beyond 300).

For full BNS problems, the effect on an ideal gas is more or less negligible, but I see a 5-10% performance boost in small-scale tests with a realistic tabulated EOS. For pure GRMHD tests, I expect the performance boost to be more significant.