### PR TITLE
Fix CUDA compiler warnings observed on ALCF Polaris; bump Kokkos to 4.6.01

### DIFF
--- a/src/athena_tensor.hpp
+++ b/src/athena_tensor.hpp
@@ -437,6 +437,7 @@ class AthenaPointTensor<T, sym, ndim, 3> {
         return data_[c + ndim*(a*(2*ndim - a + 1)/2 + b - a)];
       }
     }
+    return data_[c + ndim*(b + ndim*a)]; // Default to NONE case
   }
   KOKKOS_INLINE_FUNCTION
   Real & operator()(int const a, int const b, int const c) {
@@ -456,6 +457,7 @@ class AthenaPointTensor<T, sym, ndim, 3> {
         return data_[c + ndim*(a*(2*ndim - a + 1)/2 + b - a)];
       }
     }
+    return data_[c + ndim*(b + ndim*a)]; // Default to NONE case
   }
   KOKKOS_INLINE_FUNCTION
   void ZeroClear() {

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -236,7 +236,7 @@ particles::ParticlesBoundaryValues::ParticlesBoundaryValues(
     pmy_part(pp) {
 #if MPI_PARALLEL_ENABLED
   // Guess that no more than 10% of particles will be communicated to set size of buffer
-  int npart = pmy_part->nprtcl_thispack;
+  //int npart = pmy_part->nprtcl_thispack;
 
   //resize vectors over number of ranks
   nsends_eachrank.resize(global_variable::nranks);

--- a/src/bvals/bvals_part.cpp
+++ b/src/bvals/bvals_part.cpp
@@ -349,8 +349,9 @@ TaskStatus ParticlesBoundaryValues::PackAndSendPrtcls() {
     auto &pi = pmy_part->prtcl_idata;
     auto &rsendbuf = prtcl_rsendbuf;
     auto &isendbuf = prtcl_isendbuf;
+    auto sendlist_view = sendlist.d_view;
     par_for("ppack",DevExeSpace(),0,(nprtcl_send-1), KOKKOS_LAMBDA(const int n) {
-      int p = sendlist.d_view(n).prtcl_indx;
+      int p = sendlist_view(n).prtcl_indx;
       for (int i=0; i<nidata; ++i) {
         isendbuf(nidata*n + i) = pi(i,p);
       }
@@ -468,10 +469,11 @@ TaskStatus ParticlesBoundaryValues::RecvAndUnpackPrtcls() {
     auto &irecvbuf = prtcl_irecvbuf;
     int &npart = pmy_part->nprtcl_thispack;
     int nprtcl_send_ = nprtcl_send;
+    auto sendlist_view = sendlist.d_view;
     par_for("punpack",DevExeSpace(),0,(nprtcl_recv-1), KOKKOS_LAMBDA(const int n) {
       int p;
       if (n < nprtcl_send_) {
-        p = sendlist.d_view(n).prtcl_indx; // place particles in holes created by sends
+        p = sendlist_view(n).prtcl_indx; // place particles in holes created by sends
       } else {
         p = npart + (n - nprtcl_send_);     // place particle at end of arrays
       }

--- a/src/bvals/bvals_part.cpp
+++ b/src/bvals/bvals_part.cpp
@@ -467,12 +467,13 @@ TaskStatus ParticlesBoundaryValues::RecvAndUnpackPrtcls() {
     auto &rrecvbuf = prtcl_rrecvbuf;
     auto &irecvbuf = prtcl_irecvbuf;
     int &npart = pmy_part->nprtcl_thispack;
+    int nprtcl_send_ = nprtcl_send;
     par_for("punpack",DevExeSpace(),0,(nprtcl_recv-1), KOKKOS_LAMBDA(const int n) {
       int p;
-      if (n < nprtcl_send) {
+      if (n < nprtcl_send_) {
         p = sendlist.d_view(n).prtcl_indx; // place particles in holes created by sends
       } else {
-        p = npart + (n - nprtcl_send);     // place particle at end of arrays
+        p = npart + (n - nprtcl_send_);     // place particle at end of arrays
       }
       for (int i=0; i<nidata; ++i) {
         pi(i,p) = irecvbuf(nidata*n + i);

--- a/src/coordinates/adm.cpp
+++ b/src/coordinates/adm.cpp
@@ -67,7 +67,7 @@ void ADM::SetADMVariablesToKerrSchild(MeshBlockPack *pmbp) {
   auto &indcs = pmbp->pmesh->mb_indcs;
   int &ng = indcs.ng;
   int is = indcs.is, js = indcs.js, ks = indcs.ks;
-  int ie = indcs.ie, je = indcs.je, ke = indcs.ke;
+  //int ie = indcs.ie, je = indcs.je, ke = indcs.ke;
   int nmb = pmbp->nmb_thispack;
   int n1 = indcs.nx1 + 2*ng;
   int n2 = (indcs.nx2 > 1) ? (indcs.nx2 + 2*ng) : 1;

--- a/src/eos/primitive_solver_hyd.hpp
+++ b/src/eos/primitive_solver_hyd.hpp
@@ -159,7 +159,7 @@ class PrimitiveSolverHydro {
 
     // Check for NaNs
     /*if (CheckForConservedNaNs(cons_pt)) {
-      printf("Location: PrimToConsPt\n");
+      Kokkos::printf("Location: PrimToConsPt\n");
       DumpPrimitiveVars(prim_pt);
     }*/
 
@@ -475,7 +475,7 @@ class PrimitiveSolverHydro {
                             (j < js) || (j > je) ||
                             (k < ks) || (k > ke);
 
-            printf("Density was nontrivially adjusted on MeshBlock %d!\n"
+            Kokkos::printf("Density was nontrivially adjusted on MeshBlock %d!\n"
                    "  Grid index: (i=%d, j=%d, k=%d)\n"
                    "  Physical position: (%g, %g, %g)\n"
                    "  D (old): %.17g\n"

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -297,7 +297,7 @@ void CoarsenedBinaryOutput::LoadOutputData(Mesh *pm) {
 
 void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   // check if slicing
-  bool bin_slice = (out_params.slice1 || out_params.slice2 || out_params.slice3);
+  //bool bin_slice = (out_params.slice1 || out_params.slice2 || out_params.slice3);
 
   // create filename: "cbin_"+"file_id"+"_"+"coarsening_factor"+"/file_basename"
   // + "." + "file_id" + "." + XXXXX + ".cbin"

--- a/src/outputs/track_prtcl.cpp
+++ b/src/outputs/track_prtcl.cpp
@@ -50,8 +50,9 @@ void TrackedParticleOutput::LoadOutputData(Mesh *pm) {
   auto &pi = pm->pmb_pack->ppart->prtcl_idata;
   int counter=0;
   int *pcounter = &counter;
+  const int ntrack_ = ntrack;
   par_for("part_update",DevExeSpace(),0,(npart-1), KOKKOS_LAMBDA(const int p) {
-    if (pi(PTAG,p) < ntrack) {
+    if (pi(PTAG,p) < ntrack_) {
       int index = Kokkos::atomic_fetch_add(pcounter,1);
       tracked_prtcl.d_view(index).tag = pi(PTAG,p);
       tracked_prtcl.d_view(index).x   = pr(IPX,p);

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -298,7 +298,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   }
 
   // read CC data into host array
-  int mygids = pm->gids_eachrank[global_variable::my_rank];
+  //int mygids = pm->gids_eachrank[global_variable::my_rank];
   IOWrapperSizeT offset_myrank = headeroffset;
   if (!single_file_per_rank) {
     offset_myrank += data_size_ * pm->gids_eachrank[global_variable::my_rank];

--- a/src/pgen/tests/shock_tube.cpp
+++ b/src/pgen/tests/shock_tube.cpp
@@ -322,7 +322,7 @@ void SetADMVariablesToSchwarzschild(MeshBlockPack *pmbp) {
   int ivy = IVX + ((ivx - IVX) + 1)%3;
   int ivz = IVX + ((ivx - IVX) + 2)%3;
   int is = indcs.is, js = indcs.js, ks = indcs.ks;
-  int ie = indcs.ie, je = indcs.je, ke = indcs.ke;
+  //int ie = indcs.ie, je = indcs.je, ke = indcs.ke;
   int nmb1 = pmbp->nmb_thispack - 1;
   int ng = indcs.ng;
   int n1 = indcs.nx1 + 2*ng;

--- a/src/utils/spherical_harm.hpp
+++ b/src/utils/spherical_harm.hpp
@@ -35,8 +35,8 @@ void SWSphericalHarm(Real * ylmR, Real * ylmI, int l, int m, int s,
                      Real theta, Real phi) {
   Real wignerd = 0;
   int k1,k2,k;
-  k1 = std::max(0, m-s);
-  k2 = std::min(l+m,l-s);
+  k1 = Kokkos::max(0, m-s);
+  k2 = Kokkos::min(l+m,l-s);
 
   for (k = k1; k<=k2; ++k) {
     wignerd += pow((-1),k)*pow(cos(theta/2.0),2*l+m-s-2*k)*pow(sin(theta/2.0),2*k+s-m)

--- a/src/z4c/z4c_tasks.cpp
+++ b/src/z4c/z4c_tasks.cpp
@@ -30,7 +30,7 @@ namespace z4c {
 //! \fn  void Z4c::QueueZ4cTasks
 //! \brief queue Z4c tasks into NumericalRelativity
 void Z4c::QueueZ4cTasks() {
-  printf("AssembleZ4cTasks\n");
+  Kokkos::printf("AssembleZ4cTasks\n");
   using namespace mhd;     // NOLINT(build/namespaces)
   using namespace numrel;  // NOLINT(build/namespaces)
   NumericalRelativity *pnr = pmy_pack->pnr;


### PR DESCRIPTION
I believe these were all introduced to `main` within the last year--- it used to compile without warnings (default pgen option) on the machine. #613 added some warnings with the lack of `constexpr` fallthrough on the `enum`. Otherwise mostly standard "unused variable" and implicit capture of `this` in device lambdas. 

Still lots of CUDA and SYCL backend warnings and errors with some Z4c things and various problem generators that I didn't bother to fix (and some already addressed in other brances). E.g. `Kokkos::printf` should replace `printf` in https://github.com/IAS-Astrophysics/athenak/blob/cc65bf80d8d52f2034b6b194ab959a6ef4a732b5/src/pgen/sgrid_bns.cpp#L772-L783

Kokkos 4.6.01 removes a lot of deprecation warnings on ALCF Aurora and has been shown to be stable with Z4c tests. 