### PR TITLE
Hotfix: PS root solver

### DIFF
--- a/src/eos/primitive-solver/numtools_root.hpp
+++ b/src/eos/primitive-solver/numtools_root.hpp
@@ -78,22 +78,22 @@ class Root {
       // the sides to force the new root to fall on the other side. This allows us to
       // whittle down both sides at once and get better average convergence.
       if (ftest*flb >= 0) {
-        flb = ftest;
-        lb = x;
         if (side == 1) {
           Real m = 1. - ftest/flb;
           fub = (m > 0) ? fub*m : 0.5*fub;
           //fub /= 2.0;
         }
+        flb = ftest;
+        lb = x;
         side = 1;
       } else {
-        fub = ftest;
-        ub = x;
         if (side == -1) {
           Real m = 1. - ftest/fub;
           flb = (m > 0) ? flb*m : 0.5*flb;
           //flb /= 2.0;
         }
+        fub = ftest;
+        ub = x;
         side = -1;
       }
     } while (count < iterations);


### PR DESCRIPTION
This pull request fixes a bug in the root solver for PrimitiveSolver. #644 included some small updates to the root solver in PrimitiveSolver to improve robustness and convergence. The robustness enhancements work, but I didn't port the changes from [the standalone repo](https://github.com/jfields7/primitive-solver/blob/da06f7d07e315bb4bc59127f3bea3cd688bf6066/include/numtools_root.hpp#L118-L125) correctly, so the convergence enhancements didn't actually ever get used in the AthenaK version of the code. I assume the speedups I reported were related to the robustness improvements (e.g., perhaps not needing to call FOFC as much).