### PR TITLE
Updates to Lorene BNS pgen

### DIFF
--- a/src/eos/primitive-solver/piecewise_polytrope.hpp
+++ b/src/eos/primitive-solver/piecewise_polytrope.hpp
@@ -32,7 +32,7 @@ namespace Primitive {
 #define MAX_PIECES 7
 
 class PiecewisePolytrope : public EOSPolicyInterface {
- private:
+ protected:
   /// Number of polytropes in the EOS
   int n_pieces;
 

--- a/src/pgen/lorene_bns.cpp
+++ b/src/pgen/lorene_bns.cpp
@@ -204,8 +204,6 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
           Real egas = bns->nbar[idx]*(1.0 + bns->ener_spec[idx] / ener_unit)/rho_unit;
           Real& rho = host_w0(m, IDN, k, j, i);
           rho = eos.template GetRhoFromE<tov::LocationTag::Host>(egas);
-          host_w0(m, IPR, k, j, i) = eos.template
-                                     GetPFromRho<tov::LocationTag::Host>(rho);
           Real vu[3] = {bns->u_euler_x[idx] / vel_unit,
                         bns->u_euler_y[idx] / vel_unit,
                         bns->u_euler_z[idx] / vel_unit};
@@ -218,6 +216,9 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
             vu[1] = 0.0;
             vu[2] = 0.0;
           }
+
+          host_w0(m, IPR, k, j, i) = eos.template
+                                     GetPFromRho<tov::LocationTag::Host>(rho);
 
           // If the electron fraction is available, find it in the 1D EOS.
           if constexpr (use_ye) {

--- a/src/pgen/lorene_bns.cpp
+++ b/src/pgen/lorene_bns.cpp
@@ -43,6 +43,12 @@
 void BNSHistory(HistoryData *pdata, Mesh *pm);
 void LoreneBNSRefinementCondition(MeshBlockPack *pmbp);
 
+// Prototypes for magnetic vector potential
+KOKKOS_INLINE_FUNCTION
+static Real A1(Real x, Real y, Real z, Real I_0, Real r_0);
+KOKKOS_INLINE_FUNCTION
+static Real A2(Real x, Real y, Real z, Real I_0, Real r_0);
+
 template<class TOVEOS>
 void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
   MeshBlockPack *pmbp = pmy_mesh_->pmb_pack;
@@ -75,6 +81,9 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
 
   std::string fname = pin->GetString("problem", "initial_data_file");
   Real rho_cut = pin->GetOrAddReal("problem", "rho_cut", 1e-5);
+  Real b_max = pin->GetOrAddReal("problem", "b_max", 1e12) / 8.3519664583273e+19;
+  Real r_0 = pin->GetOrAddReal("problem", "r_0_current", 5.0);
+  Real I_0 = 4*r_0*b_max/(23.0*M_PI);
 
   int ncells1 = indcs.nx1 + 2*(indcs.ng);
   int ncells2 = indcs.nx2 + 2*(indcs.ng);
@@ -256,6 +265,11 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
     std::cout << "Host mirrors filled." << std::endl;
   }
 
+  Real sep = bns->dist/coord_unit;
+  if (global_variable::my_rank == 0) {
+    std::cout << "sep = " << sep << std::endl;
+  }
+
   // Cleanup
   delete bns;
 
@@ -274,22 +288,144 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
     std::cout << "Data copied." << std::endl;
   }
 
-  // TODO(JMF): Add magnetic fields
+  // compute vector potential over all faces
+  DvceArray4D<Real> a1, a2, a3;
+  Kokkos::realloc(a1, nmb,ncells3,ncells2,ncells1);
+  Kokkos::realloc(a2, nmb,ncells3,ncells2,ncells1);
+  Kokkos::realloc(a3, nmb,ncells3,ncells2,ncells1);
+
+  auto &nghbr = pmbp->pmb->nghbr;
+  auto &mblev = pmbp->pmb->mb_lev;
+
+  par_for("pgen_vector_potential", DevExeSpace(), 0,nmb-1,ks,ke+1,js,je+1,is,ie+1,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real &x1min = size.d_view(m).x1min;
+    Real &x1max = size.d_view(m).x1max;
+    int nx1 = indcs.nx1;
+    Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
+    Real x1f   = LeftEdgeX(i  -is, nx1, x1min, x1max);
+
+    Real &x2min = size.d_view(m).x2min;
+    Real &x2max = size.d_view(m).x2max;
+    int nx2 = indcs.nx2;
+    Real x2v = CellCenterX(j-js, nx2, x2min, x2max);
+    Real x2f   = LeftEdgeX(j  -js, nx2, x2min, x2max);
+
+    Real &x3min = size.d_view(m).x3min;
+    Real &x3max = size.d_view(m).x3max;
+    int nx3 = indcs.nx3;
+    Real x3v = CellCenterX(k-ks, nx3, x3min, x3max);
+    Real x3f   = LeftEdgeX(k  -ks, nx3, x3min, x3max);
+
+    Real dx1 = size.d_view(m).dx1;
+    Real dx2 = size.d_view(m).dx2;
+    Real dx3 = size.d_view(m).dx3;
+
+    a1(m,k,j,i) = A1(x1v - 0.5*sep, x2f, x3f, I_0, r_0) +
+                  A1(x1v + 0.5*sep, x2f, x3f, I_0, r_0);
+    a2(m,k,j,i) = A2(x1f - 0.5*sep, x2v, x3f, I_0, r_0) +
+                  A2(x1f + 0.5*sep, x2v, x3f, I_0, r_0);
+    a3(m,k,j,i) = 0.0;
+
+    // When neighboring MeshBock is at finer level, compute vector potential as sum of
+    // values at fine grid resolution.  This guarantees flux on shared fine/coarse
+    // faces is identical.
+
+    // Correct A1 at x2-faces, x3-faces, and x2x3-edges
+    if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,28).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,29).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,30).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,31).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,40).lev > mblev.d_view(m) && j==js && k==ks) ||
+        (nghbr.d_view(m,41).lev > mblev.d_view(m) && j==js && k==ks) ||
+        (nghbr.d_view(m,42).lev > mblev.d_view(m) && j==je+1 && k==ks) ||
+        (nghbr.d_view(m,43).lev > mblev.d_view(m) && j==je+1 && k==ks) ||
+        (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
+        (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
+        (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
+        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+      Real xl = x1v + 0.25*dx1;
+      Real xr = x1v - 0.25*dx1;
+      a1(m,k,j,i) = 0.5*((A1(xl-0.5*sep, x2f, x3f, I_0, r_0) +
+                         A1(xl+0.5*sep, x2f, x3f, I_0, r_0)) +
+                         (A1(xr-0.5*sep, x2f, x3f, I_0, r_0) +
+                         A1(xr+0.5*sep, x2f, x3f, I_0, r_0)));
+    }
+
+    // Correct A2 at x1-faces, x3-faces, and x1x3-edges
+    if ((nghbr.d_view(m,0 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,1 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,2 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,3 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,4 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,28).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,29).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,30).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,31).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,32).lev > mblev.d_view(m) && i==is && k==ks) ||
+        (nghbr.d_view(m,33).lev > mblev.d_view(m) && i==is && k==ks) ||
+        (nghbr.d_view(m,34).lev > mblev.d_view(m) && i==ie+1 && k==ks) ||
+        (nghbr.d_view(m,35).lev > mblev.d_view(m) && i==ie+1 && k==ks) ||
+        (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
+        (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
+        (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
+        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+      Real xl = x2v + 0.25*dx2;
+      Real xr = x2v - 0.25*dx2;
+      a2(m,k,j,i) = 0.5*((A2(x1f-0.5*sep, xl, x3f, I_0, r_0) +
+                         A2(x1f+0.5*sep, xl, x3f, I_0, r_0)) +
+                         (A2(x1f-0.5*sep, xr, x3f, I_0, r_0) +
+                         A2(x1f+0.5*sep, xr, x3f, I_0, r_0)));
+    }
+  });
+
   auto &b0 = pmbp->pmhd->b0;
   par_for("pgen_Bfc", DevExeSpace(), 0, nmb-1,ks,ke,js,je,is,ie,
   KOKKOS_LAMBDA(int m, int k, int j, int i) {
-    b0.x1f(m, k, j, i) = 0.0;
-    b0.x2f(m, k, j, i) = 0.0;
-    b0.x3f(m, k, j, i) = 0.0;
+    // Compute face-centered fields from curl(A).
+    Real dx1 = size.d_view(m).dx1;
+    Real dx2 = size.d_view(m).dx2;
+    Real dx3 = size.d_view(m).dx3;
 
+    b0.x1f(m, k, j, i) = ((a3(m,k,j+1,i) - a3(m,k,j,i))/dx2 -
+                          (a2(m,k+1,j,i) - a2(m,k,j,i))/dx3);
+    b0.x2f(m, k, j, i) = ((a1(m,k+1,j,i) - a1(m,k,j,i))/dx3 -
+                          (a3(m,k,j,i+1) - a3(m,k,j,i))/dx1);
+    b0.x3f(m, k, j, i) = ((a2(m,k,j,i+1) - a2(m,k,j,i))/dx1 -
+                          (a1(m,k,j+1,i) - a1(m,k,j,i))/dx2);
+
+
+    // Include extra face-component at edge of block in each direction
     if (i == ie) {
-      b0.x1f(m, k, j, i+1) = 0.0;
+      b0.x1f(m, k, j, i+1) = ((a3(m,k,j+1,i+1) - a3(m,k,j,i+1))/dx2 -
+                              (a2(m,k+1,j,i+1) - a2(m,k,j,i+1))/dx3);
     }
     if (j == je) {
-      b0.x2f(m, k, j+1, i) = 0.0;
+      b0.x2f(m, k, j+1, i) = ((a1(m,k+1,j+1,i) - a1(m,k,j+1,i))/dx3 -
+                              (a3(m,k,j+1,i+1) - a3(m,k,j+1,i))/dx1);
     }
     if (k == ke) {
-      b0.x3f(m, k+1, j, i) = 0.0;
+      b0.x3f(m, k+1, j ,i) = ((a2(m,k+1,j,i+1) - a2(m,k+1,j,i))/dx1 -
+                              (a1(m,k+1,j+1,i) - a1(m,k+1,j,i))/dx2);
     }
   });
 
@@ -422,4 +558,20 @@ void BNSHistory(HistoryData *pdata, Mesh *pm) {
 
 void LoreneBNSRefinementCondition(MeshBlockPack *pmbp) {
   pmbp->pz4c->pamr->Refine(pmbp);
+}
+
+KOKKOS_INLINE_FUNCTION
+static Real A1(Real x, Real y, Real z, Real I_0, Real r_0) {
+  Real w2 = SQR(x) + SQR(y);
+  Real r2 = w2 + SQR(z);
+  return -y * M_PI * SQR(r_0)*I_0 / pow(SQR(r_0) + r2, 1.5) *
+         (1.0 + 15.0/8.0*SQR(r_0)*(SQR(r_0)+w2)/SQR(SQR(r_0)+r2));
+}
+
+KOKKOS_INLINE_FUNCTION
+static Real A2(Real x, Real y, Real z, Real I_0, Real r_0) {
+  Real w2 = SQR(x) + SQR(y);
+  Real r2 = w2 + SQR(z);
+  return x * M_PI * SQR(r_0)*I_0 / pow(SQR(r_0) + r2, 1.5) *
+         (1.0 + 15.0/8.0*SQR(r_0)*(SQR(r_0)+w2)/SQR(SQR(r_0)+r2));
 }

--- a/src/utils/tov/tov_piecewise_poly.hpp
+++ b/src/utils/tov/tov_piecewise_poly.hpp
@@ -31,6 +31,47 @@ class PiecewisePolytropeEOS: public Primitive::PiecewisePolytrope {
 
   template<LocationTag loc>
   KOKKOS_INLINE_FUNCTION
+  Real GetRhoFromE(Real e) const {
+    // Unfortunately, e(rho) cannot be inverted simply. Therefore, we use a Newton-Raphson
+    // solver to get this instead.
+    Real lb = 0.0;
+    Real ub = e;
+    auto f = [&](Real rho) -> Real {
+      Real nb = rho/mb;
+      int p = FindPiece(nb);
+      return GetColdEnergy(nb, p) - e;
+    };
+    auto df = [&](Real rho) -> Real {
+      Real nb = rho/mb;
+      int p = FindPiece(nb);
+      return 1.0 + eps_pieces[p] +
+             gamma_pieces[p]*GetColdPressure(nb, p)/(rho*gamma_pieces[p] - 1.0);
+    };
+    Real flb = f(lb);
+    Real fub = f(ub);
+    Real x = (fub*lb - flb*ub)/(fub - flb);
+    Real fx = f(x);
+    const Real tol = 1e-15;
+    while (Kokkos::fabs(fx) > e*tol) {
+      Real xnew = x - fx/df(x);
+      // If the guess is no good, throw it away and use bisection instead.
+      if (xnew > ub || xnew < lb) {
+        xnew = 0.5*(ub + lb);
+      }
+      fx = f(xnew);
+      if (fx > 0) {
+        ub = xnew;
+      } else {
+        lb = xnew;
+      }
+      x = xnew;
+    }
+
+    return x;
+  }
+
+  template<LocationTag loc>
+  KOKKOS_INLINE_FUNCTION
   Real GetRhoFromP(Real P) const {
     Real rhob = GetDensityFromColdPressure(P);
     return rhob;

--- a/src/utils/tov/tov_polytrope.hpp
+++ b/src/utils/tov/tov_polytrope.hpp
@@ -33,6 +33,45 @@ class PolytropeEOS {
 
   template<LocationTag loc>
   KOKKOS_INLINE_FUNCTION
+  Real GetRhoFromE(Real e) const {
+    // Note that e = rho + kappa/(gamma - 1)*rho^gamma, which doesn't usually have an
+    // algebraic solution. Consequently, we choose to solve this with a Newton-Raphson
+    // solve instead.
+    // To ensure the solution converges, we bracket the solution from above and below by
+    // recognizing that rho <= e, rho > 0
+    Real lb = 0.0;
+    Real ub = e;
+    auto f = [&](Real rho) -> Real {
+      return rho + kappa*Kokkos::pow(rho, gamma)/(gamma - 1.0) - e;
+    };
+    auto df = [&](Real rho) -> Real {
+      return 1.0 + kappa*gamma*Kokkos::pow(rho, gamma - 1.0)/(gamma - 1.0);
+    };
+    Real flb = f(lb);
+    Real fub = f(ub);
+    Real x = (fub*lb - flb*ub)/(fub - flb);
+    Real fx = f(x);
+    const Real tol = 1e-15;
+    while (Kokkos::fabs(fx) > e*tol) {
+      Real xnew = x - fx/df(x);
+      // If the guess is no good, throw it away and use bisection instead.
+      if (xnew > ub || xnew < lb) {
+        xnew = 0.5*(ub + lb);
+      }
+      fx = f(xnew);
+      if (fx > 0) {
+        ub = xnew;
+      } else {
+        lb = xnew;
+      }
+      x = xnew;
+    }
+
+    return x;
+  }
+
+  template<LocationTag loc>
+  KOKKOS_INLINE_FUNCTION
   Real GetRhoFromP(Real P) const {
     return Kokkos::pow(P/kappa, 1.0/gamma);
   }


### PR DESCRIPTION
This pull request includes the following updates to `lorene_bns`:
1. The pgen has been refactored to use the `TOVEOS` utilities for 1D EOSs in a manner similar to `dyngr_tov`. This makes the BNS reader agnostic of the EOS; previously tabulated EOSs were treated slightly differently.
2. Because the baryon mass in Lorene is usually slightly different than the one use in AthenaK, BNS data typically had small errors (~1%) in the density and pressure, especially for realistic equations of state. This update now reads in the total energy density, $e = \rho(1 + \epsilon)$, as the fundamental thermodynamic variable, and self-consistently calculates the density and pressure from it using the supplied 1D EOS. Notably, this has effectively eliminated temperature errors in the initial data for piecewise-polytropic data.
3. The extended dipole magnetic fields used in the BNS zoom-in branch have been ported.

Currently there are no additional diagnostics added to the history output, though depending on what people think is useful it may be good to add something (e.g., the maximum magnetic field strength) before merging this in.