### PR TITLE
Add accurate GR timestep calculation option

### DIFF
--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -95,6 +95,7 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   // (3) read time-evolution option [already error checked in driver constructor]
   // Then initialize memory and algorithms for reconstruction and Riemann solvers
   std::string evolution_t = pin->GetString("time","evolution");
+  gr_dt = pin->GetOrAddBoolean("time","gr_dt",false);
 
   // allocate memory for conserved and primitive variables
   // With AMR, maximum size of Views are limited by total device memory through an input

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -98,6 +98,7 @@ class Hydro {
   DvceArray5D<Real> u1;       // conserved variables at intermediate step
   DvceFaceFld5D<Real> uflx;   // fluxes of conserved quantities on cell faces
   Real dtnew;
+  bool gr_dt = false;         // flag for accurate GR timestep calculation
 
   // following used for FOFC
   DvceArray4D<bool> fofc;  // flag for each cell to indicate if FOFC is needed

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -125,6 +125,7 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   // (3) read time-evolution option [already error checked in driver constructor]
   // Then initialize memory and algorithms for reconstruction and Riemann solvers
   std::string evolution_t = pin->GetString("time","evolution");
+  gr_dt = pin->GetOrAddBoolean("time","gr_dt",false);
 
   // allocate memory for conserved and primitive variables
   // With AMR, maximum size of Views are limited by total device memory through an input

--- a/src/mhd/mhd.hpp
+++ b/src/mhd/mhd.hpp
@@ -133,6 +133,7 @@ class MHD {
   DvceArray4D<Real> e1x2, e3x2;
   DvceArray4D<Real> e2x3, e1x3;
   Real dtnew;
+  bool gr_dt = false;         // flag for accurate GR timestep calculation
 
   // following used for time derivatives in computation of jcon
   bool wbcc_saved = false;

--- a/src/mhd/mhd_newdt.cpp
+++ b/src/mhd/mhd_newdt.cpp
@@ -19,6 +19,8 @@
 #include "mhd.hpp"
 #include "diffusion/conduction.hpp"
 #include "srcterms/srcterms.hpp"
+#include "coordinates/cell_locations.hpp"
+#include "coordinates/cartesian_ks.hpp"
 
 namespace mhd {
 
@@ -26,8 +28,8 @@ namespace mhd {
 // \!fn void MHD::NewTimeStep()
 // \brief calculate the minimum timestep within a MeshBlockPack for MHD problems
 
-TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
-  if (stage != (pdriver->nexp_stages)) {
+TaskStatus MHD::NewTimeStep(Driver *pdrive, int stage) {
+  if (stage != (pdrive->nexp_stages)) {
     return TaskStatus::complete; // only execute last stage
   }
 
@@ -47,11 +49,14 @@ TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
   auto &is_special_relativistic_ = pmy_pack->pcoord->is_special_relativistic;
   auto &is_general_relativistic_ = pmy_pack->pcoord->is_general_relativistic;
   auto &is_dynamical_relativistic_ = pmy_pack->pcoord->is_dynamical_relativistic;
+  auto &gr_dt_ = gr_dt;
+  auto &flat = pmy_pack->pcoord->coord_data.is_minkowski;
+  auto &spin = pmy_pack->pcoord->coord_data.bh_spin;
   const int nmkji = (pmy_pack->nmb_thispack)*nx3*nx2*nx1;
   const int nkji = nx3*nx2*nx1;
   const int nji  = nx2*nx1;
 
-  if (pdriver->time_evolution == TimeEvolution::kinematic) {
+  if (pdrive->time_evolution == TimeEvolution::kinematic) {
     // find smallest (dx/v) in each direction for advection problems
     Kokkos::parallel_reduce("MHDNudt1",Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
     KOKKOS_LAMBDA(const int &idx, Real &min_dt1, Real &min_dt2, Real &min_dt3) {
@@ -82,11 +87,108 @@ TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
       j += js;
       Real max_dv1 = 0.0, max_dv2 = 0.0, max_dv3 = 0.0;
 
-      // timestep in GR MHD
-      if (is_general_relativistic_ || is_dynamical_relativistic_) {
+      if (is_dynamical_relativistic_) {
         max_dv1 = 1.0;
         max_dv2 = 1.0;
         max_dv3 = 1.0;
+      // timestep in GR MHD
+      } else if (is_general_relativistic_) {
+        if (!gr_dt_) {
+          max_dv1 = 1.0;
+          max_dv2 = 1.0;
+          max_dv3 = 1.0;
+        } else {
+          // Use the GR fast magnetosonic speed to compute the time step
+          // References to left primitives
+          Real &wd = w0_(m,IDN,k,j,i);
+          Real &ux = w0_(m,IVX,k,j,i);
+          Real &uy = w0_(m,IVY,k,j,i);
+          Real &uz = w0_(m,IVZ,k,j,i);
+          Real &bcc1 = bcc0_(m,IBX,k,j,i);
+          Real &bcc2 = bcc0_(m,IBY,k,j,i);
+          Real &bcc3 = bcc0_(m,IBZ,k,j,i);
+
+          // FIXME MG: Ideal fluid for now
+          Real p = eos.IdealGasPressure(w0_(m,IEN,k,j,i));
+
+          // Extract components of metric
+          Real &x1min = mbsize.d_view(m).x1min;
+          Real &x1max = mbsize.d_view(m).x1max;
+          Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
+          Real &x2min = mbsize.d_view(m).x2min;
+          Real &x2max = mbsize.d_view(m).x2max;
+          Real x2v = CellCenterX(j-js, nx2, x2min, x2max);
+          Real &x3min = mbsize.d_view(m).x3min;
+          Real &x3max = mbsize.d_view(m).x3max;
+          Real x3v = CellCenterX(k-ks, nx3, x3min, x3max);
+          Real glower[4][4], gupper[4][4];
+          ComputeMetricAndInverse(x1v, x2v, x3v, flat, spin, glower, gupper);
+
+          // Calculate 4-velocity (contravariant compt)
+          Real q = glower[IVX][IVX] * SQR(ux) + glower[IVY][IVY] * SQR(uy) +
+                  glower[IVZ][IVZ] * SQR(uz) + 2.0*glower[IVX][IVY] * ux * uy +
+              2.0*glower[IVX][IVZ] * ux * uz + 2.0*glower[IVY][IVZ] * uy * uz;
+
+          Real alpha = std::sqrt(-1.0/gupper[0][0]);
+          Real gamma = sqrt(1.0 + q);
+          Real uu[4];
+          uu[0] = gamma / alpha;
+          uu[IVX] = ux - alpha * gamma * gupper[0][IVX];
+          uu[IVY] = uy - alpha * gamma * gupper[0][IVY];
+          uu[IVZ] = uz - alpha * gamma * gupper[0][IVZ];
+
+          // lower vector indices (covariant compt)
+          Real ul[4];
+          ul[0]   = glower[0][0]  *uu[0]   + glower[0][IVX]*uu[IVX] +
+                    glower[0][IVY]*uu[IVY] + glower[0][IVZ]*uu[IVZ];
+
+          ul[IVX] = glower[IVX][0]  *uu[0]   + glower[IVX][IVX]*uu[IVX] +
+                    glower[IVX][IVY]*uu[IVY] + glower[IVX][IVZ]*uu[IVZ];
+
+          ul[IVY] = glower[IVY][0]  *uu[0]   + glower[IVY][IVX]*uu[IVX] +
+                    glower[IVY][IVY]*uu[IVY] + glower[IVY][IVZ]*uu[IVZ];
+
+          ul[IVZ] = glower[IVZ][0]  *uu[0]   + glower[IVZ][IVX]*uu[IVX] +
+                    glower[IVZ][IVY]*uu[IVY] + glower[IVZ][IVZ]*uu[IVZ];
+
+
+          // Calculate 4-magnetic field in right state
+          Real bu[4];
+          bu[0]   = ul[IVX]*bcc1 + ul[IVY]*bcc2 + ul[IVZ]*bcc3;
+          bu[IVX] = (bcc1 + bu[0] * uu[IVX]) / uu[0];
+          bu[IVY] = (bcc2 + bu[0] * uu[IVY]) / uu[0];
+          bu[IVZ] = (bcc3 + bu[0] * uu[IVZ]) / uu[0];
+
+          // lower vector indices (covariant compt)
+          Real bl[4];
+          bl[0]   = glower[0][0]  *bu[0]   + glower[0][IVX]*bu[IVX] +
+                    glower[0][IVY]*bu[IVY] + glower[0][IVZ]*bu[IVZ];
+
+          bl[IVX] = glower[IVX][0]  *bu[0]   + glower[IVX][IVX]*bu[IVX] +
+                    glower[IVX][IVY]*bu[IVY] + glower[IVX][IVZ]*bu[IVZ];
+
+          bl[IVY] = glower[IVY][0]  *bu[0]   + glower[IVY][IVX]*bu[IVX] +
+                    glower[IVY][IVY]*bu[IVY] + glower[IVY][IVZ]*bu[IVZ];
+
+          bl[IVZ] = glower[IVZ][0]  *bu[0]   + glower[IVZ][IVX]*bu[IVX] +
+                    glower[IVZ][IVY]*bu[IVY] + glower[IVZ][IVZ]*bu[IVZ];
+
+          Real b_sq = bl[0]*bu[0] + bl[IVX]*bu[IVX] + bl[IVY]*bu[IVY] +bl[IVZ]*bu[IVZ];
+
+          // Calculate wavespeeds
+          Real lm, lp;
+          eos.IdealGRMHDFastSpeeds(wd, p, uu[0], uu[IVX], b_sq, gupper[0][0],
+                                  gupper[0][IVX], gupper[IVX][IVX], lp, lm);
+          max_dv1 = fmax(fabs(lm), lp);
+
+          eos.IdealGRMHDFastSpeeds(wd, p, uu[0], uu[IVY], b_sq, gupper[0][0],
+                                  gupper[0][IVY], gupper[IVY][IVY], lp, lm);
+          max_dv2 = fmax(fabs(lm), lp);
+
+          eos.IdealGRMHDFastSpeeds(wd, p, uu[0], uu[IVZ], b_sq, gupper[0][0],
+                                  gupper[0][IVZ], gupper[IVZ][IVZ], lp, lm);
+          max_dv3 = fmax(fabs(lm), lp);
+        }
       // timestep in SR MHD
       } else if (is_special_relativistic_) {
         Real &wd = w0_(m,IDN,k,j,i);
@@ -146,7 +248,6 @@ TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
         }
         max_dv3 = fabs(w0_(m,IVZ,k,j,i)) + cf;
       }
-
       min_dt1 = fmin((mbsize.d_view(m).dx1/max_dv1), min_dt1);
       min_dt2 = fmin((mbsize.d_view(m).dx2/max_dv2), min_dt2);
       min_dt3 = fmin((mbsize.d_view(m).dx3/max_dv3), min_dt3);


### PR DESCRIPTION
- Add 'gr_dt' boolean flag to hydro and MHD classes
- Read 'gr_dt' parameter from input file (defaults to false)
- Implement full GR wavespeed calculations when gr_dt=true
- Use conservative approximation (max speed = 1.0) when false
- Add necessary headers for metric computation