### PR TITLE
Improve `time` precision in output headers

### DIFF
--- a/src/outputs/binary.cpp
+++ b/src/outputs/binary.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <numeric>
 #include <sstream>
 #include <string>
@@ -84,9 +85,11 @@ void MeshBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   // 4. Header (input file information)
   {
     std::stringstream msg;
+    const int time_precision = std::numeric_limits<Real>::max_digits10 - 1;
     msg << "Athena binary output version=1.1" << std::endl
         // preheader size includes "size of preheader" line up to "number of variables"
         << "  size of preheader=5" << std::endl
+        << std::scientific << std::setprecision(time_precision)
         << "  time=" << pm->time << std::endl
         << "  cycle=" << pm->ncycle << std::endl
         << "  size of location=" << sizeof(Real) << std::endl

--- a/src/outputs/vtk_mesh.cpp
+++ b/src/outputs/vtk_mesh.cpp
@@ -54,6 +54,7 @@ MeshVTKOutput::MeshVTKOutput(ParameterInput *pin, Mesh *pm, OutputParameters op)
 
 void MeshVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   int big_end = IsBigEndian(); // =1 on big endian machine
+  const int time_precision = std::numeric_limits<Real>::max_digits10 - 1;
   // create filename: "vtk/file_basename"."file_id"."gid"."XXXXX".vtk
   // where XXXXX = 5-digit file_number, and gid only added if specified
   std::string fname;
@@ -92,6 +93,7 @@ void MeshVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   // Write parts 1-4: Create string with header text.
   std::stringstream msg;
   msg << "# vtk DataFile Version 2.0" << std::endl
+      << std::scientific << std::setprecision(time_precision)
       << "# Athena++ data at time= " << pm->time
       << "  level= 0"  // assuming uniform mesh
       << "  nranks= " << global_variable::nranks


### PR DESCRIPTION
Currently, header timestamps in `bin` and mesh `vtk` outputs are written via `std::stringstream` with default precision of around 6 significant digits. This can affect the accuracy of some post-processing algorithms of mine.

This PR defines timestamp precision as:

```cpp
const int time_precision = std::numeric_limits<Real>::max_digits10 - 1;
```

, following the Athena++ convention (see `dt_precision` in `mesh.cpp`). The header output is then updated to:

```cpp
<< std::scientific << std::setprecision(time_precision)
<< "  time=" << pm->time << std::endl
```

This change improves `time` precision in output headers.