### PR TITLE
Change the AMR method: tracker in z4c_amr

### DIFF
--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -68,6 +68,8 @@ void Z4c_AMR::Refine(MeshBlockPack *pmy_pack) {
 }
 
 // refine region within a certain distance from each compact object
+// using exact minimum distance via AABB clamping, which correctly handles
+// all cases: tracker nearest to a face, edge, or corner of the block.
 void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
   Mesh *pmesh       = pmbp->pmesh;
   auto &refine_flag = pmesh->pmr->refine_flag;
@@ -91,18 +93,17 @@ void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
     Real &x3max = size.h_view(m).x3max;
 
     flag.clear();
-    for (auto & pt : pmbp->pz4c->ptracker) {
-      Real d2[8] = {
-        SQ(x1min - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1min - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1min - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-        SQ(x1min - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-      };
-      Real dmin2 = *std::min_element(&d2[0], &d2[8]);
+    for (auto &pt : pmbp->pz4c->ptracker) {
+      // clamp tracker position to box bounds: closest point on the box
+      Real cx = fmax(x1min, fmin(pt->GetPos(0), x1max));
+      Real cy = fmax(x2min, fmin(pt->GetPos(1), x2max));
+      Real cz = fmax(x3min, fmin(pt->GetPos(2), x3max));
+
+      Real dmin2 = SQ(pt->GetPos(0) - cx) \
+                   + SQ(pt->GetPos(1) - cy) \
+                   + SQ(pt->GetPos(2) - cz);
+
+      // safety net for radius = 0: dmin2 = 0 inside the block but 0 < SQ(0) is false
       bool iscontained =
         (pt->GetPos(0) >= x1min && pt->GetPos(0) <= x1max) &&
         (pt->GetPos(1) >= x2min && pt->GetPos(1) <= x2max) &&

--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -30,8 +30,6 @@ Z4c_AMR::Z4c_AMR(ParameterInput *pin) {
     method = Trivial;
   } else if (ref_method == "tracker") {
     method = Tracker;
-  } else if (ref_method == "tracker_clamp") {
-    method = TrackerClamp;
   } else if (ref_method == "chi") {
     method = Chi;
     chi_thresh = pin->GetOrAddReal("z4c_amr", "chi_min", 0.2);
@@ -61,75 +59,12 @@ Z4c_AMR::Z4c_AMR(ParameterInput *pin) {
 void Z4c_AMR::Refine(MeshBlockPack *pmy_pack) {
   if (method == Tracker) {
     RefineTracker(pmy_pack);
-  } else if (method == TrackerClamp) {
-    RefineTrackerClamp(pmy_pack);
   } else if (method == Chi) {
     RefineChiMin(pmy_pack);
   } else if (method == dChi) {
     RefineDchiMax(pmy_pack);
   }
   RefineRadii(pmy_pack);
-}
-
-// refine region within a certain distance from each compact object
-void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
-  Mesh *pmesh       = pmbp->pmesh;
-  auto &refine_flag = pmesh->pmr->refine_flag;
-  auto &size        = pmbp->pmb->mb_size;
-  int nmb           = pmbp->nmb_thispack;
-  int mbs           = pmesh->gids_eachrank[global_variable::my_rank];
-
-  std::vector<int> flag;
-  flag.reserve(pmbp->pz4c->ptracker.size());
-
-  for (int m = 0; m < nmb; ++m) {
-    // current refinement level
-    int level = pmesh->lloc_eachmb[m + mbs].level - pmesh->root_level;
-
-    // extract MeshBlock bounds
-    Real &x1min = size.h_view(m).x1min;
-    Real &x1max = size.h_view(m).x1max;
-    Real &x2min = size.h_view(m).x2min;
-    Real &x2max = size.h_view(m).x2max;
-    Real &x3min = size.h_view(m).x3min;
-    Real &x3max = size.h_view(m).x3max;
-
-    flag.clear();
-    for (auto & pt : pmbp->pz4c->ptracker) {
-      Real d2[8] = {
-        SQ(x1min - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1min - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
-        SQ(x1min - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-        SQ(x1min - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-        SQ(x1max - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
-      };
-      Real dmin2 = *std::min_element(&d2[0], &d2[8]);
-      bool iscontained =
-        (pt->GetPos(0) >= x1min && pt->GetPos(0) <= x1max) &&
-        (pt->GetPos(1) >= x2min && pt->GetPos(1) <= x2max) &&
-        (pt->GetPos(2) >= x3min && pt->GetPos(2) <= x3max);
-
-      if (dmin2 < SQ(pt->GetRadius()) || iscontained) {
-        if (pt->GetReflevel() < 0 || level < pt->GetReflevel()) {
-          flag.push_back(1);
-        } else if (level == pt->GetReflevel()) {
-          flag.push_back(0);
-        } else {
-          flag.push_back(-1);
-        }
-      } else {
-        flag.push_back(-1);
-      }
-    }
-    refine_flag.h_view(m + mbs) = *std::max_element(flag.begin(), flag.end());
-  }
-
-  // sync host and device
-  refine_flag.template modify<HostMemSpace>();
-  refine_flag.template sync<DevExeSpace>();
 }
 
 // refine based on min{chi}
@@ -278,7 +213,7 @@ void Z4c_AMR::RefineRadii(MeshBlockPack *pmbp) {
 // refine region within a certain distance from each compact object
 // using exact minimum distance via AABB clamping, which correctly handles
 // all cases: tracker nearest to a face, edge, or corner of the block.
-void Z4c_AMR::RefineTrackerClamp(MeshBlockPack *pmbp) {
+void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
   Mesh *pmesh       = pmbp->pmesh;
   auto &refine_flag = pmesh->pmr->refine_flag;
   auto &size        = pmbp->pmb->mb_size;

--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -30,6 +30,8 @@ Z4c_AMR::Z4c_AMR(ParameterInput *pin) {
     method = Trivial;
   } else if (ref_method == "tracker") {
     method = Tracker;
+  } else if (ref_method == "tracker_clamp") {
+    method = TrackerClamp;
   } else if (ref_method == "chi") {
     method = Chi;
     chi_thresh = pin->GetOrAddReal("z4c_amr", "chi_min", 0.2);
@@ -59,6 +61,8 @@ Z4c_AMR::Z4c_AMR(ParameterInput *pin) {
 void Z4c_AMR::Refine(MeshBlockPack *pmy_pack) {
   if (method == Tracker) {
     RefineTracker(pmy_pack);
+  } else if (method == TrackerClamp) {
+    RefineTrackerClamp(pmy_pack);
   } else if (method == Chi) {
     RefineChiMin(pmy_pack);
   } else if (method == dChi) {
@@ -264,6 +268,68 @@ void Z4c_AMR::RefineRadii(MeshBlockPack *pmbp) {
         }
       }
     }
+  }
+
+  // sync host and device
+  refine_flag.template modify<HostMemSpace>();
+  refine_flag.template sync<DevExeSpace>();
+}
+
+// refine region within a certain distance from each compact object
+// using exact minimum distance via AABB clamping, which correctly handles
+// all cases: tracker nearest to a face, edge, or corner of the block.
+void Z4c_AMR::RefineTrackerClamp(MeshBlockPack *pmbp) {
+  Mesh *pmesh       = pmbp->pmesh;
+  auto &refine_flag = pmesh->pmr->refine_flag;
+  auto &size        = pmbp->pmb->mb_size;
+  int nmb           = pmbp->nmb_thispack;
+  int mbs           = pmesh->gids_eachrank[global_variable::my_rank];
+
+  std::vector<int> flag;
+  flag.reserve(pmbp->pz4c->ptracker.size());
+
+  for (int m = 0; m < nmb; ++m) {
+    int level = pmesh->lloc_eachmb[m + mbs].level - pmesh->root_level;
+
+    Real &x1min = size.h_view(m).x1min;
+    Real &x1max = size.h_view(m).x1max;
+    Real &x2min = size.h_view(m).x2min;
+    Real &x2max = size.h_view(m).x2max;
+    Real &x3min = size.h_view(m).x3min;
+    Real &x3max = size.h_view(m).x3max;
+
+    flag.clear();
+    for (auto &pt : pmbp->pz4c->ptracker) {
+      Real px = pt->GetPos(0);
+      Real py = pt->GetPos(1);
+      Real pz = pt->GetPos(2);
+
+      // clamp tracker position to box bounds: closest point on the box
+      Real cx = fmax(x1min, fmin(px, x1max));
+      Real cy = fmax(x2min, fmin(py, x2max));
+      Real cz = fmax(x3min, fmin(pz, x3max));
+
+      Real dmin2 = SQ(px - cx) + SQ(py - cy) + SQ(pz - cz);
+
+      // safety net for radius = 0: dmin2 = 0 inside the block but 0 < SQ(0) is false
+      bool iscontained =
+        (px >= x1min && px <= x1max) &&
+        (py >= x2min && py <= x2max) &&
+        (pz >= x3min && pz <= x3max);
+
+      if (dmin2 < SQ(pt->GetRadius()) || iscontained) {
+        if (pt->GetReflevel() < 0 || level < pt->GetReflevel()) {
+          flag.push_back(1);
+        } else if (level == pt->GetReflevel()) {
+          flag.push_back(0);
+        } else {
+          flag.push_back(-1);
+        }
+      } else {
+        flag.push_back(-1);
+      }
+    }
+    refine_flag.h_view(m + mbs) = *std::max_element(flag.begin(), flag.end());
   }
 
   // sync host and device

--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -67,6 +67,68 @@ void Z4c_AMR::Refine(MeshBlockPack *pmy_pack) {
   RefineRadii(pmy_pack);
 }
 
+// refine region within a certain distance from each compact object
+// using exact minimum distance via AABB clamping, which correctly handles
+// all cases: tracker nearest to a face, edge, or corner of the block.
+void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
+  Mesh *pmesh       = pmbp->pmesh;
+  auto &refine_flag = pmesh->pmr->refine_flag;
+  auto &size        = pmbp->pmb->mb_size;
+  int nmb           = pmbp->nmb_thispack;
+  int mbs           = pmesh->gids_eachrank[global_variable::my_rank];
+
+  std::vector<int> flag;
+  flag.reserve(pmbp->pz4c->ptracker.size());
+
+  for (int m = 0; m < nmb; ++m) {
+    int level = pmesh->lloc_eachmb[m + mbs].level - pmesh->root_level;
+
+    Real &x1min = size.h_view(m).x1min;
+    Real &x1max = size.h_view(m).x1max;
+    Real &x2min = size.h_view(m).x2min;
+    Real &x2max = size.h_view(m).x2max;
+    Real &x3min = size.h_view(m).x3min;
+    Real &x3max = size.h_view(m).x3max;
+
+    flag.clear();
+    for (auto &pt : pmbp->pz4c->ptracker) {
+      Real px = pt->GetPos(0);
+      Real py = pt->GetPos(1);
+      Real pz = pt->GetPos(2);
+
+      // clamp tracker position to box bounds: closest point on the box
+      Real cx = fmax(x1min, fmin(px, x1max));
+      Real cy = fmax(x2min, fmin(py, x2max));
+      Real cz = fmax(x3min, fmin(pz, x3max));
+
+      Real dmin2 = SQ(px - cx) + SQ(py - cy) + SQ(pz - cz);
+
+      // safety net for radius = 0: dmin2 = 0 inside the block but 0 < SQ(0) is false
+      bool iscontained =
+        (px >= x1min && px <= x1max) &&
+        (py >= x2min && py <= x2max) &&
+        (pz >= x3min && pz <= x3max);
+
+      if (dmin2 < SQ(pt->GetRadius()) || iscontained) {
+        if (pt->GetReflevel() < 0 || level < pt->GetReflevel()) {
+          flag.push_back(1);
+        } else if (level == pt->GetReflevel()) {
+          flag.push_back(0);
+        } else {
+          flag.push_back(-1);
+        }
+      } else {
+        flag.push_back(-1);
+      }
+    }
+    refine_flag.h_view(m + mbs) = *std::max_element(flag.begin(), flag.end());
+  }
+
+  // sync host and device
+  refine_flag.template modify<HostMemSpace>();
+  refine_flag.template sync<DevExeSpace>();
+}
+
 // refine based on min{chi}
 void Z4c_AMR::RefineChiMin(MeshBlockPack *pmbp) {
   Mesh *pmesh       = pmbp->pmesh;
@@ -203,68 +265,6 @@ void Z4c_AMR::RefineRadii(MeshBlockPack *pmbp) {
         }
       }
     }
-  }
-
-  // sync host and device
-  refine_flag.template modify<HostMemSpace>();
-  refine_flag.template sync<DevExeSpace>();
-}
-
-// refine region within a certain distance from each compact object
-// using exact minimum distance via AABB clamping, which correctly handles
-// all cases: tracker nearest to a face, edge, or corner of the block.
-void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
-  Mesh *pmesh       = pmbp->pmesh;
-  auto &refine_flag = pmesh->pmr->refine_flag;
-  auto &size        = pmbp->pmb->mb_size;
-  int nmb           = pmbp->nmb_thispack;
-  int mbs           = pmesh->gids_eachrank[global_variable::my_rank];
-
-  std::vector<int> flag;
-  flag.reserve(pmbp->pz4c->ptracker.size());
-
-  for (int m = 0; m < nmb; ++m) {
-    int level = pmesh->lloc_eachmb[m + mbs].level - pmesh->root_level;
-
-    Real &x1min = size.h_view(m).x1min;
-    Real &x1max = size.h_view(m).x1max;
-    Real &x2min = size.h_view(m).x2min;
-    Real &x2max = size.h_view(m).x2max;
-    Real &x3min = size.h_view(m).x3min;
-    Real &x3max = size.h_view(m).x3max;
-
-    flag.clear();
-    for (auto &pt : pmbp->pz4c->ptracker) {
-      Real px = pt->GetPos(0);
-      Real py = pt->GetPos(1);
-      Real pz = pt->GetPos(2);
-
-      // clamp tracker position to box bounds: closest point on the box
-      Real cx = fmax(x1min, fmin(px, x1max));
-      Real cy = fmax(x2min, fmin(py, x2max));
-      Real cz = fmax(x3min, fmin(pz, x3max));
-
-      Real dmin2 = SQ(px - cx) + SQ(py - cy) + SQ(pz - cz);
-
-      // safety net for radius = 0: dmin2 = 0 inside the block but 0 < SQ(0) is false
-      bool iscontained =
-        (px >= x1min && px <= x1max) &&
-        (py >= x2min && py <= x2max) &&
-        (pz >= x3min && pz <= x3max);
-
-      if (dmin2 < SQ(pt->GetRadius()) || iscontained) {
-        if (pt->GetReflevel() < 0 || level < pt->GetReflevel()) {
-          flag.push_back(1);
-        } else if (level == pt->GetReflevel()) {
-          flag.push_back(0);
-        } else {
-          flag.push_back(-1);
-        }
-      } else {
-        flag.push_back(-1);
-      }
-    }
-    refine_flag.h_view(m + mbs) = *std::max_element(flag.begin(), flag.end());
   }
 
   // sync host and device

--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -68,8 +68,6 @@ void Z4c_AMR::Refine(MeshBlockPack *pmy_pack) {
 }
 
 // refine region within a certain distance from each compact object
-// using exact minimum distance via AABB clamping, which correctly handles
-// all cases: tracker nearest to a face, edge, or corner of the block.
 void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
   Mesh *pmesh       = pmbp->pmesh;
   auto &refine_flag = pmesh->pmr->refine_flag;
@@ -93,17 +91,18 @@ void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
     Real &x3max = size.h_view(m).x3max;
 
     flag.clear();
-    for (auto &pt : pmbp->pz4c->ptracker) {
-      // clamp tracker position to box bounds: closest point on the box
-      Real cx = fmax(x1min, fmin(pt->GetPos(0), x1max));
-      Real cy = fmax(x2min, fmin(pt->GetPos(1), x2max));
-      Real cz = fmax(x3min, fmin(pt->GetPos(2), x3max));
-
-      Real dmin2 = SQ(pt->GetPos(0) - cx) \
-                   + SQ(pt->GetPos(1) - cy) \
-                   + SQ(pt->GetPos(2) - cz);
-
-      // safety net for radius = 0: dmin2 = 0 inside the block but 0 < SQ(0) is false
+    for (auto & pt : pmbp->pz4c->ptracker) {
+      Real d2[8] = {
+        SQ(x1min - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
+        SQ(x1max - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
+        SQ(x1min - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
+        SQ(x1max - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3min - pt->GetPos(2)),
+        SQ(x1min - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
+        SQ(x1max - pt->GetPos(0)) + SQ(x2min - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
+        SQ(x1min - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
+        SQ(x1max - pt->GetPos(0)) + SQ(x2max - pt->GetPos(1)) + SQ(x3max - pt->GetPos(2)),
+      };
+      Real dmin2 = *std::min_element(&d2[0], &d2[8]);
       bool iscontained =
         (pt->GetPos(0) >= x1min && pt->GetPos(0) <= x1max) &&
         (pt->GetPos(1) >= x2min && pt->GetPos(1) <= x2max) &&

--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -81,8 +81,10 @@ void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
   flag.reserve(pmbp->pz4c->ptracker.size());
 
   for (int m = 0; m < nmb; ++m) {
+    // current refinement level
     int level = pmesh->lloc_eachmb[m + mbs].level - pmesh->root_level;
 
+    // extract MeshBlock bounds
     Real &x1min = size.h_view(m).x1min;
     Real &x1max = size.h_view(m).x1max;
     Real &x2min = size.h_view(m).x2min;
@@ -92,22 +94,20 @@ void Z4c_AMR::RefineTracker(MeshBlockPack *pmbp) {
 
     flag.clear();
     for (auto &pt : pmbp->pz4c->ptracker) {
-      Real px = pt->GetPos(0);
-      Real py = pt->GetPos(1);
-      Real pz = pt->GetPos(2);
-
       // clamp tracker position to box bounds: closest point on the box
-      Real cx = fmax(x1min, fmin(px, x1max));
-      Real cy = fmax(x2min, fmin(py, x2max));
-      Real cz = fmax(x3min, fmin(pz, x3max));
+      Real cx = fmax(x1min, fmin(pt->GetPos(0), x1max));
+      Real cy = fmax(x2min, fmin(pt->GetPos(1), x2max));
+      Real cz = fmax(x3min, fmin(pt->GetPos(2), x3max));
 
-      Real dmin2 = SQ(px - cx) + SQ(py - cy) + SQ(pz - cz);
+      Real dmin2 = SQ(pt->GetPos(0) - cx) \
+                   + SQ(pt->GetPos(1) - cy) \
+                   + SQ(pt->GetPos(2) - cz);
 
       // safety net for radius = 0: dmin2 = 0 inside the block but 0 < SQ(0) is false
       bool iscontained =
-        (px >= x1min && px <= x1max) &&
-        (py >= x2min && py <= x2max) &&
-        (pz >= x3min && pz <= x3max);
+        (pt->GetPos(0) >= x1min && pt->GetPos(0) <= x1max) &&
+        (pt->GetPos(1) >= x2min && pt->GetPos(1) <= x2max) &&
+        (pt->GetPos(2) >= x3min && pt->GetPos(2) <= x3max);
 
       if (dmin2 < SQ(pt->GetRadius()) || iscontained) {
         if (pt->GetReflevel() < 0 || level < pt->GetReflevel()) {

--- a/src/z4c/z4c_amr.hpp
+++ b/src/z4c/z4c_amr.hpp
@@ -28,7 +28,7 @@ class Z4c_AMR {
   ~Z4c_AMR() noexcept = default;
 
   void Refine(MeshBlockPack *pmbp);             // call the AMR method
-  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on the trackers
+  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on trackers
   void RefineChiMin(MeshBlockPack *pmbp);       // Refine based on min{chi}
   void RefineDchiMax(MeshBlockPack *pmbp);      // Refine based on max{dchi}
   void RefineRadii(MeshBlockPack *pmbp);        // Refine based on the radii

--- a/src/z4c/z4c_amr.hpp
+++ b/src/z4c/z4c_amr.hpp
@@ -21,14 +21,15 @@ class Z4c;
 //! \class Z4c_AMR
 //  \brief managing AMR for Z4c simulations
 class Z4c_AMR {
-  enum RefinementMethod { Trivial, Tracker, Chi, dChi };
+  enum RefinementMethod { Trivial, Tracker, TrackerClamp, Chi, dChi };
 
  public:
   explicit Z4c_AMR(ParameterInput *pin);
   ~Z4c_AMR() noexcept = default;
 
   void Refine(MeshBlockPack *pmbp);             // call the AMR method
-  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on the trackers
+  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on the trackers (corner distance)
+  void RefineTrackerClamp(MeshBlockPack *pmbp); // Refine based on the trackers (AABB clamp)
   void RefineChiMin(MeshBlockPack *pmbp);       // Refine based on min{chi}
   void RefineDchiMax(MeshBlockPack *pmbp);      // Refine based on max{dchi}
   void RefineRadii(MeshBlockPack *pmbp);        // Refine based on the radii

--- a/src/z4c/z4c_amr.hpp
+++ b/src/z4c/z4c_amr.hpp
@@ -21,15 +21,14 @@ class Z4c;
 //! \class Z4c_AMR
 //  \brief managing AMR for Z4c simulations
 class Z4c_AMR {
-  enum RefinementMethod { Trivial, Tracker, TrackerClamp, Chi, dChi };
+  enum RefinementMethod { Trivial, Tracker, Chi, dChi };
 
  public:
   explicit Z4c_AMR(ParameterInput *pin);
   ~Z4c_AMR() noexcept = default;
 
   void Refine(MeshBlockPack *pmbp);             // call the AMR method
-  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on the trackers (corner distance)
-  void RefineTrackerClamp(MeshBlockPack *pmbp); // Refine based on the trackers (AABB clamp)
+  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on trackers
   void RefineChiMin(MeshBlockPack *pmbp);       // Refine based on min{chi}
   void RefineDchiMax(MeshBlockPack *pmbp);      // Refine based on max{dchi}
   void RefineRadii(MeshBlockPack *pmbp);        // Refine based on the radii

--- a/src/z4c/z4c_amr.hpp
+++ b/src/z4c/z4c_amr.hpp
@@ -28,7 +28,7 @@ class Z4c_AMR {
   ~Z4c_AMR() noexcept = default;
 
   void Refine(MeshBlockPack *pmbp);             // call the AMR method
-  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on trackers
+  void RefineTracker(MeshBlockPack *pmbp);      // Refine based on the trackers
   void RefineChiMin(MeshBlockPack *pmbp);       // Refine based on min{chi}
   void RefineDchiMax(MeshBlockPack *pmbp);      // Refine based on max{dchi}
   void RefineRadii(MeshBlockPack *pmbp);        // Refine based on the radii


### PR DESCRIPTION
Change the method `tracker` in the z4c AMR criteria. Now it checks the minimum distances from the star centers to the mesh blocks, rather than only to the 8 corners.