### PR TITLE
Add zero-net-flux initialization to forced MHD turbulence

### DIFF
--- a/src/pgen/turb.cpp
+++ b/src/pgen/turb.cpp
@@ -5,6 +5,7 @@
 //========================================================================================
 //! \file turb.cpp
 //  \brief Problem generator for turbulence
+#include <cmath>
 #include <iostream> // cout
 
 #include "athena.hpp"
@@ -82,9 +83,20 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
   if (pmbp->pmhd != nullptr) {
     Real d_i = pin->GetOrAddReal("problem","d_i",1.0);
     Real d_n = pin->GetOrAddReal("problem","d_n",1.0);
+    int ifield = pin->GetOrAddInteger("problem","ifield",2);
+    if (ifield != 1 && ifield != 2) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+                << "Invalid <problem>/ifield = " << ifield
+                << ", allowed values are 1 (zero-net-flux Bz) or 2 (uniform Bz)."
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
     Real B0 = cs*std::sqrt(2.0*d_i/beta);
+    Real x1size = pmy_mesh_->mesh_size.x1max - pmy_mesh_->mesh_size.x1min;
+    Real kx = 2.0*(M_PI/x1size);
     auto &u0 = pmbp->pmhd->u0;
     auto &b0 = pmbp->pmhd->b0;
+    auto &size = pmbp->pmb->mb_size;
     EOS_Data &eos = pmbp->pmhd->peos->eos_data;
     Real gm1 = eos.gamma - 1.0;
     Real p0 = 1.0/eos.gamma;
@@ -97,16 +109,32 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
       u0(m,IM2,k,j,i) = 0.0;
       u0(m,IM3,k,j,i) = 0.0;
 
-      // initialize B
-      b0.x1f(m,k,j,i) = 0.0;
-      b0.x2f(m,k,j,i) = 0.0;
-      b0.x3f(m,k,j,i) = B0;
-      if (i==ie) {b0.x1f(m,k,j,i+1) = 0.0;}
-      if (j==je) {b0.x2f(m,k,j+1,i) = 0.0;}
-      if (k==ke) {b0.x3f(m,k+1,j,i) = B0;}
+      Real &x1min = size.d_view(m).x1min;
+      Real &x1max = size.d_view(m).x1max;
+      int nx1 = indcs.nx1;
+      Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
+
+      if (ifield == 1) {
+        // zero-net-flux Bz
+        b0.x1f(m,k,j,i) = 0.0;
+        b0.x2f(m,k,j,i) = 0.0;
+        b0.x3f(m,k,j,i) = B0*std::sin(kx*x1v);
+        if (i==ie) {b0.x1f(m,k,j,i+1) = 0.0;}
+        if (j==je) {b0.x2f(m,k,j+1,i) = 0.0;}
+        if (k==ke) {b0.x3f(m,k+1,j,i) = B0*std::sin(kx*x1v);}
+      } else if (ifield == 2) {
+        // constant Bz
+        b0.x1f(m,k,j,i) = 0.0;
+        b0.x2f(m,k,j,i) = 0.0;
+        b0.x3f(m,k,j,i) = B0;
+        if (i==ie) {b0.x1f(m,k,j,i+1) = 0.0;}
+        if (j==je) {b0.x2f(m,k,j+1,i) = 0.0;}
+        if (k==ke) {b0.x3f(m,k+1,j,i) = B0;}
+      }
 
       if (eos.is_ideal) {
-        u0(m,IEN,k,j,i) = p0/gm1 + 0.5*B0*B0 + // fix contribution from dB
+        Real bz_cc = 0.5*(b0.x3f(m,k,j,i) + b0.x3f(m,k+1,j,i));
+        u0(m,IEN,k,j,i) = p0/gm1 + 0.5*bz_cc*bz_cc +
            0.5*(SQR(u0(m,IM1,k,j,i)) + SQR(u0(m,IM2,k,j,i)) +
            SQR(u0(m,IM3,k,j,i)))/u0(m,IDN,k,j,i);
       }

--- a/src/pgen/turb.cpp
+++ b/src/pgen/turb.cpp
@@ -150,11 +150,22 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
   if (pmbp->pionn != nullptr) {
     Real d_i = pin->GetOrAddReal("problem","d_i",1.0);
     Real d_n = pin->GetOrAddReal("problem","d_n",1.0);
+    int ifield = pin->GetOrAddInteger("problem","ifield",2);
+    if (ifield != 1 && ifield != 2) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+                << "Invalid <problem>/ifield = " << ifield
+                << ", allowed values are 1 (zero-net-flux Bz) or 2 (uniform Bz)."
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
     Real B0 = cs*std::sqrt(2.0*(d_i+d_n)/beta);
+    Real x1size = pmy_mesh_->mesh_size.x1max - pmy_mesh_->mesh_size.x1min;
+    Real kx = 2.0*(M_PI/x1size);
 
     // MHD
     auto &u0 = pmbp->pmhd->u0;
     auto &b0 = pmbp->pmhd->b0;
+    auto &size = pmbp->pmb->mb_size;
     EOS_Data &eos = pmbp->pmhd->peos->eos_data;
     Real gm1 = eos.gamma - 1.0;
     Real p0 = d_i/eos.gamma; // TODO(@user): multiply by ionized density
@@ -167,16 +178,32 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
       u0(m,IM2,k,j,i) = 0.0;
       u0(m,IM3,k,j,i) = 0.0;
 
-      // initialize B
-      b0.x1f(m,k,j,i) = 0.0;
-      b0.x2f(m,k,j,i) = 0.0;
-      b0.x3f(m,k,j,i) = B0;
-      if (i==ie) {b0.x1f(m,k,j,i+1) = 0.0;}
-      if (j==je) {b0.x2f(m,k,j+1,i) = 0.0;}
-      if (k==ke) {b0.x3f(m,k+1,j,i) = B0;}
+      Real &x1min = size.d_view(m).x1min;
+      Real &x1max = size.d_view(m).x1max;
+      int nx1 = indcs.nx1;
+      Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
+
+      if (ifield == 1) {
+        // zero-net-flux Bz
+        b0.x1f(m,k,j,i) = 0.0;
+        b0.x2f(m,k,j,i) = 0.0;
+        b0.x3f(m,k,j,i) = B0*std::sin(kx*x1v);
+        if (i==ie) {b0.x1f(m,k,j,i+1) = 0.0;}
+        if (j==je) {b0.x2f(m,k,j+1,i) = 0.0;}
+        if (k==ke) {b0.x3f(m,k+1,j,i) = B0*std::sin(kx*x1v);}
+      } else if (ifield == 2) {
+        // constant Bz
+        b0.x1f(m,k,j,i) = 0.0;
+        b0.x2f(m,k,j,i) = 0.0;
+        b0.x3f(m,k,j,i) = B0;
+        if (i==ie) {b0.x1f(m,k,j,i+1) = 0.0;}
+        if (j==je) {b0.x2f(m,k,j+1,i) = 0.0;}
+        if (k==ke) {b0.x3f(m,k+1,j,i) = B0;}
+      }
 
       if (eos.is_ideal) {
-        u0(m,IEN,k,j,i) = p0/gm1 + 0.5*B0*B0 + // fix contribution from dB
+        Real bz_cc = 0.5*(b0.x3f(m,k,j,i) + b0.x3f(m,k+1,j,i));
+        u0(m,IEN,k,j,i) = p0/gm1 + 0.5*bz_cc*bz_cc +
            0.5*(SQR(u0(m,IM1,k,j,i)) + SQR(u0(m,IM2,k,j,i)) +
            SQR(u0(m,IM3,k,j,i)))/u0(m,IDN,k,j,i);
       }

--- a/src/pgen/turb.cpp
+++ b/src/pgen/turb.cpp
@@ -85,7 +85,8 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     Real d_n = pin->GetOrAddReal("problem","d_n",1.0);
     int ifield = pin->GetOrAddInteger("problem","ifield",2);
     if (ifield != 1 && ifield != 2) {
-      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+      std::cout << "### FATAL ERROR in " << __FILE__
+                << " at line " << __LINE__ << std::endl
                 << "Invalid <problem>/ifield = " << ifield
                 << ", allowed values are 1 (zero-net-flux Bz) or 2 (uniform Bz)."
                 << std::endl;
@@ -152,7 +153,8 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     Real d_n = pin->GetOrAddReal("problem","d_n",1.0);
     int ifield = pin->GetOrAddInteger("problem","ifield",2);
     if (ifield != 1 && ifield != 2) {
-      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+      std::cout << "### FATAL ERROR in " << __FILE__
+                << " at line " << __LINE__ << std::endl
                 << "Invalid <problem>/ifield = " << ifield
                 << ", allowed values are 1 (zero-net-flux Bz) or 2 (uniform Bz)."
                 << std::endl;

--- a/src/pgen/turb.cpp
+++ b/src/pgen/turb.cpp
@@ -98,13 +98,18 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     auto &b0 = pmbp->pmhd->b0;
     auto &size = pmbp->pmb->mb_size;
     EOS_Data &eos = pmbp->pmhd->peos->eos_data;
-    Real gm1 = eos.gamma - 1.0;
-    Real p0 = 1.0/eos.gamma;
+    Real gm1 = 0.0;
+    Real p0 = 0.0;
+    if (eos.is_ideal) {
+      gm1 = eos.gamma - 1.0;
+      p0 = d_i*SQR(cs)/eos.gamma;
+      B0 = std::sqrt(2.0*p0/beta);
+    }
 
     // Set initial conditions
     par_for("pgen_turb", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
     KOKKOS_LAMBDA(int m, int k, int j, int i) {
-      u0(m,IDN,k,j,i) = 1.0;
+      u0(m,IDN,k,j,i) = d_i;
       u0(m,IM1,k,j,i) = 0.0;
       u0(m,IM2,k,j,i) = 0.0;
       u0(m,IM3,k,j,i) = 0.0;


### PR DESCRIPTION
## New Feature

Add a new initial magnetic field configuration option to `turb.cpp`:

```ini
<problem>
d_i    = 1.0       # ion density, corresponding to fluid density in MHD
ifield = 1         # 1 for zero-net-flux Bz, 2 for constant Bz
beta   = 1         # initial plasma beta
```
where (following the implementation in `mri3d.cpp`)
- `ifield = 1`: `Bz = B0 * sin(2*pi/Lx * x)`
- `ifield = 2`: `Bz = B0`
- The default is `ifield = 2`, so existing input files without `ifield` remain unchanged.

This feature is implemented for both the MHD and ion-neutral variables, and the initial energy density `u0(m,IEN,k,j,i)` is updated accordingly.

## Small Bug Fix

Fix an inconsistency where the initial density was hard-coded to `1.0` while `B0` already depended on the input `d_i`:

```cpp
u0(m,IDN,k,j,i) = d_i
```

Additionally, for ideal (adiabatic) EOS, `p0` and `B0` are initialized self-consistently as:

```cpp
if (eos.is_ideal) {
  gm1 = eos.gamma - 1.0;
  p0 = d_i*SQR(cs)/eos.gamma;
  B0 = std::sqrt(2.0*p0/beta);
}
```

This assumes `cs` is the adiabatic sound speed, i.e., $\rho_0 c_{\mathrm s}^2 = \gamma p_0$.