### PR TITLE
Fix duplicated cells in the spherical output

### DIFF
--- a/src/utils/spherical_surface.cpp
+++ b/src/utils/spherical_surface.cpp
@@ -126,9 +126,9 @@ void SphericalSurface::SetInterpolationIndices() {
 
       // save MeshBlock and zone indicies for nearest position to spherical
       // patch center if this angle position resides in this MeshBlock
-      if ((rcoord.h_view(n, 0) >= x1min && rcoord.h_view(n, 0) <= x1max) &&
-          (rcoord.h_view(n, 1) >= x2min && rcoord.h_view(n, 1) <= x2max) &&
-          (rcoord.h_view(n, 2) >= x3min && rcoord.h_view(n, 2) <= x3max)) {
+      if ((rcoord.h_view(n, 0) >= x1min && rcoord.h_view(n, 0) < x1max) &&
+          (rcoord.h_view(n, 1) >= x2min && rcoord.h_view(n, 1) < x2max) &&
+          (rcoord.h_view(n, 2) >= x3min && rcoord.h_view(n, 2) < x3max)) {
         iindcs.h_view(n, 0) = m;
         iindcs.h_view(n, 1) = static_cast<int>(
             std::floor((rcoord.h_view(n, 0) - (x1min + dx1 / 2.0)) / dx1));


### PR DESCRIPTION
Cells at $\phi = 0$ and $\theta=0$ are duplicated (become multiple values) since they fall on the lower or upper bounds of multiple mesh blocks. By changing `<=` to `<`in the upper bounds, every mesh block is exclusive to the cells it claims.