### PR TITLE
chore: fix spelling typos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_executable(
 
         geodesic-grid/geodesic_grid.cpp
         geodesic-grid/spherical_grid.cpp
-	geodesic-grid/gauss_legendre.cpp
+        geodesic-grid/gauss_legendre.cpp
 
         hydro/hydro.cpp
         hydro/hydro_fluxes.cpp

--- a/src/athena.hpp
+++ b/src/athena.hpp
@@ -54,7 +54,7 @@ using Real = double;
 // data types only used in physics modules (defined here to avoid recursive dependencies)
 
 // constants that determine array index of Hydro/MHD variables
-// array indices for conserved: density, momemtum, total energy
+// array indices for conserved: density, momentum, total energy
 enum VariableIndex {IDN=0, IM1=1, IVX=1, IM2=2, IVY=2, IM3=3, IVZ=3, IEN=4,
                     ITM=4, IPR=4, IYF=5};
 // array indices for components of magnetic field

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -10,7 +10,7 @@
 //! types of Mesh variables. For Mesh variables, methods for cell-centered and
 //! face-centered fields are currently implemented, based on derived classes from the
 //! generic MeshBoundaryValue class.  A separate ParticlesBoundaryValues class is
-//! implemented for partciles.
+//! implemented for particles.
 
 // identifiers for all 6 faces of a MeshBlock
 enum BoundaryFace {undef=-1, inner_x1, outer_x1, inner_x2, outer_x2, inner_x3, outer_x3};

--- a/src/bvals/flux_correct_fc.cpp
+++ b/src/bvals/flux_correct_fc.cpp
@@ -452,7 +452,7 @@ void MeshBoundaryValuesFC::SumBoundaryFluxes(DvceEdgeFld4D<Real> &flx,
   auto &mblev = pmy_pack->pmb->mb_lev;
   auto &mbbcs = pmy_pack->pmb->mb_bcs;
 
-  // Sum recieve buffers into EMFs stored on MeshBlocks
+  // Sum receive buffers into EMFs stored on MeshBlocks
   // Outer loop over (# of MeshBlocks)*(3 field components)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (3*nmb), Kokkos::AUTO);
   Kokkos::parallel_for("RecvBuff", policy, KOKKOS_LAMBDA(TeamMember_t tmember) {

--- a/src/coordinates/cartesian_ks.hpp
+++ b/src/coordinates/cartesian_ks.hpp
@@ -100,7 +100,7 @@ void ComputeMetricAndInverse(Real x, Real y, Real z, bool minkowski, Real a,
 
 //----------------------------------------------------------------------------------------
 //! \fn void ComputeADMDecomposition
-//! \brief computes ADM quantitiese in Cartesian Kerr-Schild coordinates
+//! \brief computes ADM quantities in Cartesian Kerr-Schild coordinates
 
 // QUESTION: doesn't this assume bh_mass to be 1?
 KOKKOS_INLINE_FUNCTION
@@ -270,7 +270,7 @@ void ComputeADMDecomposition(Real x, Real y, Real z, bool minkowski, Real a,
 
 //----------------------------------------------------------------------------------------
 //! \fn void ComputeMetricDerivatives
-//! \brief computes derivates of metric in Cartesian Kerr-Schild coordinates, which are
+//! \brief computes derivatives of metric in Cartesian Kerr-Schild coordinates, which are
 //!  used to compute the coordinate source terms in the equations of motion.
 
 KOKKOS_INLINE_FUNCTION

--- a/src/coordinates/cell_locations.hpp
+++ b/src/coordinates/cell_locations.hpp
@@ -5,11 +5,11 @@
 // Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
-//! \file cell_locationss.hpp
+//! \file cell_locations.hpp
 //  \brief functions to compute locations on a uniform Cartesian grid
 // They provide functionality of the Coordinates class in the C++ version of the code.
 // Very similar to cc_pos.c function in C version of the code (Athena4.2)
-// Not incoporated in Coordinates class so that they can be used anywhere (for exmaple
+// Not incorporated in Coordinates class so that they can be used anywhere (for example
 // to compute locations of MeshBlocks in Mesh).
 
 #include "athena.hpp"

--- a/src/coordinates/coordinates.cpp
+++ b/src/coordinates/coordinates.cpp
@@ -162,7 +162,7 @@ void Coordinates::CoordSrcTerms(const DvceArray5D<Real> &prim, const EOS_Data &e
     tt[2][3] = wtot * u2 * u3 + ptot * gupper[2][3];
     tt[3][3] = wtot * u3 * u3 + ptot * gupper[3][3];
 
-    // compute derivates of metric.
+    // compute derivatives of metric.
     Real dg_dx1[4][4], dg_dx2[4][4], dg_dx3[4][4];
     ComputeMetricDerivatives(x1v, x2v, x3v, flat, spin, dg_dx1, dg_dx2, dg_dx3);
 
@@ -306,7 +306,7 @@ void Coordinates::CoordSrcTerms(const DvceArray5D<Real> &prim,
     tt[2][3] = wtot * u2 * u3 + ptot * gupper[2][3] - b2 * b3;
     tt[3][3] = wtot * u3 * u3 + ptot * gupper[3][3] - b3 * b3;
 
-    // compute derivates of metric.
+    // compute derivatives of metric.
     Real dg_dx1[4][4], dg_dx2[4][4], dg_dx3[4][4];
     ComputeMetricDerivatives(x1v, x2v, x3v, flat, spin, dg_dx1, dg_dx2, dg_dx3);
 

--- a/src/diffusion/conduction.hpp
+++ b/src/diffusion/conduction.hpp
@@ -28,7 +28,7 @@ class Conduction {
   Real kappa;         // thermal conductivity
   bool tdep_kappa;    // temperature-dependent conductivity
   Real kappa_ceiling; // ceiling of thermal conductivity
-  bool sat_hflux;     // saturtion of heat flux
+  bool sat_hflux;     // saturation of heat flux
 
   // function to add heat fluxes to Hydro and/or MHD fluxes
   void AddHeatFlux(const DvceArray5D<Real> &w, const EOS_Data &eos,

--- a/src/diffusion/viscosity.cpp
+++ b/src/diffusion/viscosity.cpp
@@ -22,7 +22,7 @@
 
 //----------------------------------------------------------------------------------------
 // ctor:
-// Note first argument passes string ("hydro" or "mhd") denoting in wihch class this
+// Note first argument passes string ("hydro" or "mhd") denoting in which class this
 // object is being constructed, and therefore which <block> in the input file from which
 // the parameters are read.
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -353,7 +353,7 @@ void Driver::Initialize(Mesh *pmesh, ParameterInput *pin, Outputs *pout, bool re
   if (pionn != nullptr) {
     if (nimp_stages == 0) {
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-          << std::endl << "IonNetral MHD can only be run with ImEx integrators."
+          << std::endl << "IonNeutral MHD can only be run with ImEx integrators."
           << std::endl;
       std::exit(EXIT_FAILURE);
     }

--- a/src/eos/primitive-solver/eos.hpp
+++ b/src/eos/primitive-solver/eos.hpp
@@ -486,7 +486,7 @@ class EOS : public EOSPolicy, public ErrorPolicy {
     T_atm = (floor >= min_T) ? floor : min_T;
   }
 
-  //! \fn void SetSpeciesAtmospher(Real atmo, int i)
+  //! \fn void SetSpeciesAtmosphere(Real atmo, int i)
   //  \brief Set the atmosphere abundance used by the EOS ErrorPolicy for species i.
   KOKKOS_INLINE_FUNCTION void SetSpeciesAtmosphere(Real atmo, int i) {
     assert((i < n_species) && "Not enough species");

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -34,7 +34,7 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
                 << "Table could not be read.\n";
       std::exit(EXIT_FAILURE);
     }
-    // Make sure table has correct dimentions
+    // Make sure table has correct dimensions
     assert(table.GetNDimensions()==3);
     // TODO(PH) check that required fields are present?
 
@@ -42,7 +42,7 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     auto& table_scalars = table.GetScalars();
     mb = table_scalars.at("mn");
 
-    // Get table dimesnions
+    // Get table dimensions
     auto& point_info = table.GetPointInfo();
     m_nn = point_info[0].second;
     m_ny = point_info[1].second;

--- a/src/eos/primitive-solver/eos_compose.hpp
+++ b/src/eos/primitive-solver/eos_compose.hpp
@@ -743,7 +743,7 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
   // Minimum enthalpy per baryon
   Real m_min_h;
 
-  // bool to protect against access of uninitialised table and prevent repeated reading
+  // bool to protect against access of uninitialized table and prevent repeated reading
   // of table
   bool m_initialized;
 

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -33,7 +33,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
       std::cout << "Table could not be read.\n" << std::flush;
       abort();
     }
-    // Make sure table has correct dimentions
+    // Make sure table has correct dimensions
     assert(table.GetNDimensions()==1);
     // TODO(PH) check that required fields are present?
 
@@ -41,7 +41,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     auto& table_scalars = table.GetScalars();
     mb = table_scalars.at("mn");
 
-    // Get table dimesnions
+    // Get table dimensions
     auto& point_info = table.GetPointInfo();
     m_nn = point_info[0].second;
 

--- a/src/eos/primitive-solver/eos_hybrid.hpp
+++ b/src/eos/primitive-solver/eos_hybrid.hpp
@@ -287,7 +287,7 @@ class EOSHybrid : public EOSPolicyInterface, public LogPolicy {
   // Minimum enthalpy per baryon
   Real m_min_h;
 
-  // bool to protect against access of uninitialised table and prevent repeated reading
+  // bool to protect against access of uninitialized table and prevent repeated reading
   // of table
   bool m_initialized;
 

--- a/src/geodesic-grid/gauss_legendre.cpp
+++ b/src/geodesic-grid/gauss_legendre.cpp
@@ -4,7 +4,7 @@
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
 //! \file gauss_legendre.cpp
-//  \brief Initializes a Gauss-Legendra grid to interpolate data onto
+//  \brief Initializes a Gauss-Legendre grid to interpolate data onto
 
 #include <cmath>
 #include <iostream>

--- a/src/hydro/hydro_tasks.cpp
+++ b/src/hydro/hydro_tasks.cpp
@@ -34,7 +34,7 @@ namespace hydro {
 //! Many of the functions in the task list are implemented in this file because they are
 //! simple, or they are wrappers that call one or more other functions.
 //!
-//! "before_stagen" tasks are those that must be cmpleted over all MeshBlocks BEFORE each
+//! "before_stagen" tasks are those that must be completed over all MeshBlocks BEFORE each
 //! stage can be run (such as posting MPI receives, setting BoundaryCommStatus flags, etc)
 //!
 //! "stagen" tasks are those performed DURING each stage
@@ -106,7 +106,7 @@ TaskStatus Hydro::InitRecv(Driver *pdrive, int stage) {
   }
   if (tstat != TaskStatus::complete) return tstat;
 
-  // with shearing box boundaries calculate x2-distance x1-boundarues have sheared and
+  // with shearing box boundaries calculate x2-distance x1-boundaries have sheared and
   // with MPI post receives for U.
   // only execute if (3D OR 2d_r_phi)
   if (psbox_u != nullptr) {
@@ -352,7 +352,7 @@ TaskStatus Hydro::RecvU_Shr(Driver *pdrive, int stage) {
 
 //----------------------------------------------------------------------------------------
 //! \fn TaskList Hydro::ApplyPhysicalBCs
-//! \brief Wrapper task list function to call funtions that set physical and user BCs,
+//! \brief Wrapper task list function to call functions that set physical and user BCs,
 
 TaskStatus Hydro::ApplyPhysicalBCs(Driver *pdrive, int stage) {
   // do not apply BCs if domain is strictly periodic

--- a/src/hydro/rsolvers/roe_hyd.hpp
+++ b/src/hydro/rsolvers/roe_hyd.hpp
@@ -211,7 +211,7 @@ namespace roe {
 //
 // OUTPUT:
 //   flx: final Roe flux
-//   ev: vector of eingenvalues
+//   ev: vector of eigenvalues
 //   llf_flag: flag set to 1 if d<0 in any intermediate state
 //
 //  The order of the components in the input vectors should be:

--- a/src/ion-neutral/ion-neutral_tasks.cpp
+++ b/src/ion-neutral/ion-neutral_tasks.cpp
@@ -130,7 +130,7 @@ TaskStatus IonNeutral::FirstTwoImpRK(Driver *pdrive, int stage) {
 //  \brief Implicit RK update of ion-neutral drag term. Used as part of ImEx RK integrator
 //  This function should be added AFTER the explicit updates in the task list, so that
 //  source terms are evaluated using partially updated values (including explicit terms
-//  such as flux divergence).  This means soure terms must only be evaluated using
+//  such as flux divergence).  This means source terms must only be evaluated using
 //  conserved variables (u0), as primitives (w0) are not updated until end of TaskList.
 //
 //  Note indices of source term array correspond to:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
   }
   if (mpiprv != MPI_THREAD_MULTIPLE) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
-              << "MPI_THREAD_MULTIPLE must be supported for hybrid parallelzation. "
+              << "MPI_THREAD_MULTIPLE must be supported for hybrid parallelization. "
               << MPI_THREAD_MULTIPLE << " : " << mpiprv
               << std::endl;
     MPI_Finalize();

--- a/src/mesh/build_tree.cpp
+++ b/src/mesh/build_tree.cpp
@@ -4,7 +4,7 @@
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
 //! \file build_tree.cpp
-//! \brief Functions to build MeshBlockTreee, both for new runs and restarts
+//! \brief Functions to build MeshBlock, both for new runs and restarts
 
 #include <iostream>
 #include <cinttypes>

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -68,7 +68,7 @@ class MeshRefinement {
   int *newtoold;          // mapping of new gid (index n) to old gid
   int *oldtonew;          // mapping of old gid (index n) to new gid
 
-  // arrays in Mesh class created for new MB hieararchy with AMR
+  // arrays in Mesh class created for new MB heirarchy with AMR
   // following 3x arrays allocated with length [new_nmb_total]
   float *new_cost_eachmb;            // cost of each MeshBlock
   int *new_rank_eachmb;              // rank of each MeshBlock

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -56,7 +56,7 @@ MeshBlock::MeshBlock(MeshBlockPack* ppack, int igids, int nmb) :
       mb_bcs.h_view(m,1) = BoundaryFlag::block;
     }
 
-    // calculate physical size and set BCs of each MeshBlock in x2, dependng on whether
+    // calculate physical size and set BCs of each MeshBlock in x2, depending on whether
     // there are none (1D), one, or more MeshBlocks in this direction
     if (!(pm->multi_d)) {
       mb_size.h_view(m).x2min = ms.x2min;
@@ -83,7 +83,7 @@ MeshBlock::MeshBlock(MeshBlockPack* ppack, int igids, int nmb) :
       }
     }
 
-    // calculate physical size and set BCs of each MeshBlock in x1, dependng on whether
+    // calculate physical size and set BCs of each MeshBlock in x1, depending on whether
     // there are none (1D/2D), one, or more MeshBlocks in this direction
     if (!(pm->three_d)) {
       mb_size.h_view(m).x3min = ms.x3min;

--- a/src/mesh/refinement_criteria.hpp
+++ b/src/mesh/refinement_criteria.hpp
@@ -8,7 +8,7 @@
 //! \file refinement_criteria.hpp
 //! \brief defines RefinementCriteria class containing data and functions controlling
 //! how mesh is refined/derefined with AMR
-//! This class implementes default refinement conditions:
+//! This class implements default refinement conditions:
 //!   (1) min/max of selected variable
 //!   (2) gradient of selected variable
 //!   (3) second derivative of selected variable

--- a/src/mhd/mhd_tasks.cpp
+++ b/src/mhd/mhd_tasks.cpp
@@ -137,7 +137,7 @@ TaskStatus MHD::InitRecv(Driver *pdrive, int stage) {
     }
   }
 
-  // with shearing box boundaries caluclate x2-distance x1-boundaries have sheared and
+  // with shearing box boundaries calculate x2-distance x1-boundaries have sheared and
   // with MPI post receives for U and B
   if (psbox_u != nullptr) {
     // only execute when (3D OR 2d_r_phi)
@@ -491,7 +491,7 @@ TaskStatus MHD::RecvB_Shr(Driver *pdrive, int stage) {
 
 //----------------------------------------------------------------------------------------
 //! \fn TaskStatus MHD::ApplyPhysicalBCs
-//! \brief Wrapper task list function to call funtions that set physical and user BCs
+//! \brief Wrapper task list function to call functions that set physical and user BCs
 
 TaskStatus MHD::ApplyPhysicalBCs(Driver *pdrive, int stage) {
   // do not apply BCs if domain is strictly periodic

--- a/src/mhd/rsolvers/hlld_mhd.hpp
+++ b/src/mhd/rsolvers/hlld_mhd.hpp
@@ -137,7 +137,7 @@ void HLLD(TeamMember_t const &member, const EOS_Data &eos,
       Real sdml_inv = 1.0/sdml;
       Real sdmr_inv = 1.0/sdmr;
 
-      MHDCons1D ulst,uldst,urdst,urst;   // intermadiate states for conserved variables
+      MHDCons1D ulst,uldst,urdst,urst;   // intermediate states for conserved variables
       // eqn (43) of Miyoshi & Kusano
       ulst.d = ul.d * sdl * sdml_inv;
       urst.d = ur.d * sdr * sdmr_inv;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -337,7 +337,7 @@ void ParameterInput::AddParameter(InputBlock *pb, std::string name, std::string 
     for (auto it = pb->line.begin(); it != pb->line.end(); ++it) {
       if (name.compare(it->param_name) == 0) {   // param name already exists
         it->param_value.assign(value);           // replace existing param value
-        it->param_comment.assign(comment);       // replace exisiting param comment
+        it->param_comment.assign(comment);       // replace existing param comment
         if (value.length() > pb->max_len_parvalue) pb->max_len_parvalue = value.length();
         return;
       }

--- a/src/particles/particles.cpp
+++ b/src/particles/particles.cpp
@@ -98,7 +98,7 @@ Particles::~Particles() {
 }
 
 //----------------------------------------------------------------------------------------
-// CreatePaticleTags()
+// CreateParticleTags()
 // Assigns tags to particles (unique integer).  Note that tracked particles are always
 // those with tag numbers less than ntrack.
 
@@ -131,7 +131,7 @@ void Particles::CreateParticleTags(ParameterInput *pin) {
   // tag algorithm not recognized, so quit with error
   } else {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
-              << "Particle tag assinment type = '" << assign << "' not recognized"
+              << "Particle tag assignment type = '" << assign << "' not recognized"
               << std::endl;
     std::exit(EXIT_FAILURE);
   }

--- a/src/particles/particles_tasks.cpp
+++ b/src/particles/particles_tasks.cpp
@@ -21,7 +21,7 @@
 
 namespace particles {
 //----------------------------------------------------------------------------------------
-//! \fn  void Particles::AssembleHydroTasks
+//! \fn  void Particles::AssembleTasks
 //! \brief Adds hydro tasks to appropriate task lists used by time integrators.
 //! Called by MeshBlockPack::AddPhysics() function directly after Hydro constructor.
 
@@ -53,7 +53,7 @@ TaskStatus Particles::NewGID(Driver *pdrive, int stage) {
 
 //----------------------------------------------------------------------------------------
 //! \fn TaskList Particles::SendCnt
-//! \brief Wrapper task list function to set share number of partciles communicated with
+//! \brief Wrapper task list function to set share number of particles communicated with
 //! MPI between all ranks
 
 TaskStatus Particles::SendCnt(Driver *pdrive, int stage) {

--- a/src/pgen/disk-magnetosphere.cpp
+++ b/src/pgen/disk-magnetosphere.cpp
@@ -239,7 +239,7 @@ void Mesh::InitUserMeshData(ParameterInput *pin) {
 //;  }
 
 
-  // Get parameters for gravitatonal potential of central point mass
+  // Get parameters for gravitational potential of central point mass
   if (std::strcmp(COORDINATE_SYSTEM, "cartesian") != 0
       && std::strcmp(COORDINATE_SYSTEM, "spherical_polar") != 0 ) {
     gm0 = pin->GetOrAddReal("problem","GM",0.0);
@@ -482,7 +482,7 @@ void MeshBlock::ProblemGenerator(ParameterInput *pin) {
 }
 
 // Set B field from is to ke
-// We normally need to adjut js and je limist when it is polar boundary,
+// We normally need to adjust js and je limit when it is polar boundary,
 // since the B field at the pole
 // is not set by the user. It also avoids deviding by zero.
 // When we set the boundary conditions (e.g. i),
@@ -1561,5 +1561,3 @@ void Cooling(MeshBlock *pmb, const Real time, const Real dt,const AthenaArray<Re
 //;    vpz(k) -= a * zp0(k);
 //;  }
 //;}
-
-

--- a/src/pgen/dyngr_tov.cpp
+++ b/src/pgen/dyngr_tov.cpp
@@ -618,7 +618,7 @@ void TOVHistory(HistoryData *pdata, Mesh *pm) {
   Real alpha_min = -rho_max;
   Kokkos::parallel_reduce("TOVHistSums",Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
   KOKKOS_LAMBDA(const int &idx, Real &mb_max, Real &mb_alp_min) {
-    // coompute n,k,j,i indices of thread
+    // compute n,k,j,i indices of thread
     int m = (idx)/nkji;
     int k = (idx - m*nkji)/nji;
     int j = (idx - m*nkji - k*nji)/nx1;

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -355,7 +355,7 @@ void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm) {
   Kokkos::parallel_reduce(
     "TOVHistSums", Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
     KOKKOS_LAMBDA(const int &idx, Real &mb_max, Real &mb_alp_min) {
-      // coompute n,k,j,i indices of thread
+      // compute n,k,j,i indices of thread
       int m = (idx) / nkji;
       int k = (idx - m * nkji) / nji;
       int j = (idx - m * nkji - k * nji) / nx1;

--- a/src/pgen/kh.cpp
+++ b/src/pgen/kh.cpp
@@ -8,7 +8,7 @@
 //  Sets up different initial conditions selected by flag "iprob"
 //    - iprob=1 : tanh profile with a single mode perturbation
 //    - iprob=2 : double tanh profile with a single mode perturbation
-//    - iprob=3 : sinusiodal velocity with random perturbations
+//    - iprob=3 : sinusoidal velocity with random perturbations
 //    - iprob=4 : Lecoanet test problem ICs
 
 #include <iostream>
@@ -109,7 +109,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     w0_(m,IEN,k,j,i) = 20.0/gm1;
     w0_(m,IVZ,k,j,i) = 0.0;
 
-    // Lorentz factor (needed to initializve 4-velocity in SR)
+    // Lorentz factor (needed to initialize 4-velocity in SR)
     Real u00 = 1.0;
 
     Real dens,pres,vx,vy,vz,scal;
@@ -148,7 +148,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
         scal = y0 + y1*tanh((x2v-0.5)/a_char);
       }
     } else if (iprob == 3) {
-      // sinusiodal velocity with random perts (geometry of turbulence test)
+      // sinusoidal velocity with random perts (geometry of turbulence test)
       rval = amp*2.0*(rand_gen.frand() - 0.5);
       dens = 1.0;
       pres = 1.0;

--- a/src/pgen/lorene_bns.cpp
+++ b/src/pgen/lorene_bns.cpp
@@ -532,7 +532,7 @@ void BNSHistory(HistoryData *pdata, Mesh *pm) {
   Real alpha_min = -rho_max;
   Kokkos::parallel_reduce("TOVHistSums",Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
   KOKKOS_LAMBDA(const int &idx, Real &mb_max, Real &mb_alp_min) {
-    // coompute n,k,j,i indices of thread
+    // compute n,k,j,i indices of thread
     int m = (idx)/nkji;
     int k = (idx - m*nkji)/nji;
     int j = (idx - m*nkji - k*nji)/nx1;

--- a/src/pgen/rad_diffusion.cpp
+++ b/src/pgen/rad_diffusion.cpp
@@ -101,7 +101,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     Real x3v = CellCenterX(k-ks, nx3, x3min, x3max);
 
     // energy density and flux
-    // NOTE(@pdmullen): there is some subtelty here. We need to find the energy density er
+    // NOTE(@pdmullen): there is some subtlety here. We need to find the energy density er
     // and flux fr in the comoving frame to pass to @c-white's Minerbo function...but the
     // comoving frame t' is a function of comoving position x' because we enforce that
     // the initial condition be defined at coordinate frame t=0.  We also offset t' by

--- a/src/pgen/rt.cpp
+++ b/src/pgen/rt.cpp
@@ -4,7 +4,7 @@
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
 //! \file rt.cpp
-//! \brief Problem generator for RT instabilty.
+//! \brief Problem generator for RT instability.
 //!
 //! Note the gravitational acceleration is hardwired to be 0.1. Density difference is
 //! hardwired to be 3.0 and is set by the input parameter `problem/drat`.

--- a/src/pgen/sgrid_bns.cpp
+++ b/src/pgen/sgrid_bns.cpp
@@ -432,7 +432,7 @@ void SGRIDHistory(HistoryData *pdata, Mesh *pm) {
   Kokkos::parallel_reduce(
       "BNSHistSums", Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
       KOKKOS_LAMBDA(const int &idx, Real &mb_max, Real &mb_alp_min) {
-        // coompute n,k,j,i indices of thread
+        // compute n,k,j,i indices of thread
         int m = (idx) / nkji;
         int k = (idx - m * nkji) / nji;
         int j = (idx - m * nkji - k * nji) / nx1;

--- a/src/pgen/tests/cshock.cpp
+++ b/src/pgen/tests/cshock.cpp
@@ -98,7 +98,7 @@ void ProblemGenerator::CShock(ParameterInput *pin, const bool restart) {
   // parse shock direction: {1,2,3} -> {x1,x2,x3}
   int shk_dir = pin->GetInteger("problem","shock_dir");
   if (shk_dir < 1 || shk_dir > 3) {
-    // Invaild input value for shk_dir
+    // Invalid input value for shk_dir
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
       << std::endl << "shock_dir=" <<shk_dir<< " must be either 1,2, or 3" << std::endl;
     exit(EXIT_FAILURE);

--- a/src/pgen/tests/mri3d.cpp
+++ b/src/pgen/tests/mri3d.cpp
@@ -88,7 +88,7 @@ void ProblemGenerator::MRI3d(ParameterInput *pin, const bool restart) {
   Real gm1 = eos.gamma - 1.0;
   if (eos.is_ideal && (is_strat)) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
-              << "Stratified shearing box only works with isothernal EOS" << std::endl;
+              << "Stratified shearing box only works with isothermal EOS" << std::endl;
     exit(EXIT_FAILURE);
   }
 

--- a/src/pgen/tests/shock_tube.cpp
+++ b/src/pgen/tests/shock_tube.cpp
@@ -42,7 +42,7 @@ void ProblemGenerator::ShockTube(ParameterInput *pin, const bool restart) {
   // parse shock direction: {1,2,3} -> {x1,x2,x3}
   shk_dir = pin->GetInteger("problem","shock_dir");
   if (shk_dir < 1 || shk_dir > 3) {
-    // Invaild input value for shk_dir
+    // Invalid input value for shk_dir
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
       << std::endl << "shock_dir=" <<shk_dir<< " must be either 1,2, or 3" << std::endl;
     exit(EXIT_FAILURE);

--- a/src/pgen/z4c_stability.cpp
+++ b/src/pgen/z4c_stability.cpp
@@ -81,7 +81,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     auto rand_gen = rand_pool64.get_state();
 
     // scratch array holding random numbers for 12 variables.
-    // only perturbaion in the z direction is added
+    // only perturbation in the z direction is added
     // in the x and y directions the values of perturbation
     // are always the same
     ScrArray1D<Real> rnum(member.team_scratch(scr_level), 12);

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -99,7 +99,7 @@ class Radiation {
   bool fixed_fluid;         // flag to enable/disable fluid integration
   bool affect_fluid;        // flag to enable/disable feedback of rad field on fluid
   Real arad;                // radiation constant
-  Real kappa_a;             // constant Rosseland mean absoprtion coefficient
+  Real kappa_a;             // constant Rosseland mean absorption coefficient
   Real kappa_s;             // constant scattering coefficient
   Real kappa_p;             // Planck - Rosseland mean coefficient
   bool power_opacity;       // flag to enable Kramer's law opacity for kappa_a

--- a/src/radiation/radiation_source.cpp
+++ b/src/radiation/radiation_source.cpp
@@ -270,7 +270,7 @@ TaskStatus Radiation::RadFluidCoupling(Driver *pdriver, int stage) {
         // handle excision
         // NOTE(@pdmullen): The below zeroes all intensities within rks <= r_excision and
         // zeroes intensities within angles where n_0 is about zero. When Compton is
-        // enabled, we delay the n_0_floor excision so that intensites updated via
+        // enabled, we delay the n_0_floor excision so that intensities updated via
         // absorption and scattering inform the Compton update
         if (excise) {
           bool apply_excision = (rad_mask_(m,k,j,i) ||

--- a/src/radiation/radiation_tasks.cpp
+++ b/src/radiation/radiation_tasks.cpp
@@ -273,7 +273,7 @@ TaskStatus Radiation::RecvI(Driver *pdrive, int stage) {
 
 //----------------------------------------------------------------------------------------
 //! \fn TaskStatus Radiation::ApplyPhysicalBCs
-//! \brief Wrapper task list function to call funtions that set physical and user BCs
+//! \brief Wrapper task list function to call functions that set physical and user BCs
 
 TaskStatus Radiation::ApplyPhysicalBCs(Driver *pdrive, int stage) {
   // do not apply BCs if domain is strictly periodic

--- a/src/radiation/radiation_update.cpp
+++ b/src/radiation/radiation_update.cpp
@@ -81,7 +81,7 @@ TaskStatus Radiation::RKUpdate(Driver *pdriver, int stage) {
     i0_(m,n,k,j,i) = n0*n_0*fmax((i0_(m,n,k,j,i)/(n0*n_0)), 0.0);
 
     // handle excision
-    // NOTE(@pdmullen): exicision criterion are not finalized.  The below zeroes all
+    // NOTE(@pdmullen): excision criterion are not finalized.  The below zeroes all
     // intensities within rks <= 1.0 and zeroes intensities within angles where n_0
     // is about zero.  This needs future attention.
     if (excise) {

--- a/src/reconstruct/ppm.hpp
+++ b/src/reconstruct/ppm.hpp
@@ -138,7 +138,7 @@ void PPMX(const Real &q_im2, const Real &q_im1, const Real &q_i, const Real &q_i
   Real qa = (qrv - q_i)*(q_i - qlv);
   Real qb = (q_im1 - q_i)*(q_i - q_ip1);
   if (qa <= 0.0 || qb <= 0.0) {
-    // approximate secnd derivates (PH 3.37)
+    // approximate second derivatives (PH 3.37)
     // KGF: add the off-center quantities first to preserve FP symmetry
     Real d2q  = 6.0*(qlv + qrv - 2.0*q_i);
     Real d2qc = (q_im1 + q_ip1) - 2.0*q_i;

--- a/src/shearing_box/shearing_box.hpp
+++ b/src/shearing_box/shearing_box.hpp
@@ -61,7 +61,7 @@ class ShearingBox {
   bool is_stratified;              // true for stratified shearing box
 
   // data buffers for shearing box BCs.  Only two x1-faces get sheared
-  // Use seperate variables for ix1/ox1 since number of MBs on each face can be different
+  // Use separate variables for ix1/ox1 since number of MBs on each face can be different
   ShearingBoxBoundaryBuffer sendbuf[2], recvbuf[2];
 
 #if MPI_PARALLEL_ENABLED

--- a/src/shearing_box/shearing_box_cc.cpp
+++ b/src/shearing_box/shearing_box_cc.cpp
@@ -107,7 +107,7 @@ TaskStatus ShearingBoxCC::PackAndSendCC(DvceArray5D<Real> &a, ReconstructionMeth
       }
       member.team_barrier();
 
-      // update data in send buffer with fracational shift
+      // update data in send buffer with fractional shift
       par_for_inner(member, js, je, [&](const int j) {
         sbuf[n].vars(m,j,v,k,i) = a_(j) - (flx(j+1) - flx(j));
       });

--- a/src/shearing_box/shearing_box_fc.cpp
+++ b/src/shearing_box/shearing_box_fc.cpp
@@ -127,7 +127,7 @@ TaskStatus ShearingBoxFC::PackAndSendFC(DvceFaceFld4D<Real> &b,
       }
       member.team_barrier();
 
-      // update data in send buffer with fracational shift
+      // update data in send buffer with fractional shift
       par_for_inner(member, js, je, [&](const int j) {
         sbuf[n].vars(m,j,v,k,i) = a_(j) - (flx(j+1) - flx(j));
       });

--- a/src/shearing_box/shearing_box_srcterms.cpp
+++ b/src/shearing_box/shearing_box_srcterms.cpp
@@ -152,7 +152,7 @@ void ShearingBoxCC::SourceTermsCC(
 //----------------------------------------------------------------------------------------
 //! \fn ShearingBoxFC::SourceTermsFC
 //  \brief Add electric field in rotating frame E = - (v_{K} x B) where v_{K} is
-//  background orbital velocity v_{K} = - q \Omega x in the toriodal (\phi or y) direction
+//  background orbital velocity v_{K} = - q \Omega x in the toroidal (\phi or y) direction
 //  See SG eqs. [49-52] (eqs for orbital advection), and [60]
 //! Only needed in 2D r-z case for Ex and Ey
 

--- a/src/srcterms/turb_driver.cpp
+++ b/src/srcterms/turb_driver.cpp
@@ -440,7 +440,7 @@ TaskStatus TurbulenceDriver::InitializeModes(Driver *pdrive, int stage) {
               yssc_.h_view(nmode) = (nkx==0 || nky==0) ? 0.0 : RanGaussianSt(&(rstate));
               ysss_.h_view(nmode) = (nkx==0 || nky==0) ? 0.0 : RanGaussianSt(&(rstate));
 
-              // imcompressibility
+              // incompressibility
               zccc_.h_view(nmode) =  ikz*( kx*xscs_.h_view(nmode)+ky*ycss_.h_view(nmode));
               zccs_.h_view(nmode) = -ikz*( kx*xscc_.h_view(nmode)+ky*ycsc_.h_view(nmode));
               zcsc_.h_view(nmode) =  ikz*( kx*xsss_.h_view(nmode)-ky*yccs_.h_view(nmode));

--- a/src/utils/cart_grid.hpp
+++ b/src/utils/cart_grid.hpp
@@ -34,7 +34,7 @@ class CartesianGrid {
   // dump on chebyshev or uniform grid, default is uniform
   bool is_cheby;
 
-  // For simplicity, unravell all points into a 1d array
+  // For simplicity, unravel all points into a 1d array
   DualArray3D<Real> interp_vals;   // container for data interpolated to sphere
   void InterpolateToGrid(int nvars, DvceArray5D<Real> &val);  // interpolate to sphere
   void ResetCenter(Real center[3]);  // set indexing for interpolation

--- a/src/utils/random.hpp
+++ b/src/utils/random.hpp
@@ -19,7 +19,7 @@
 //! shuffle and added safeguards.  Returns a uniform random deviate between 0.0 and 1.0
 //! (exclusive of the endpoint values).  Call with idum = a negative integer to
 //! initialize; thereafter, do not alter idum between successive deviates in a sequence.
-//! RNMX should appriximate the largest floating-point value that is less than 1.
+//! RNMX should approximate the largest floating-point value that is less than 1.
 
 #define NTAB 32
 

--- a/src/utils/spherical_surface.cpp
+++ b/src/utils/spherical_surface.cpp
@@ -4,7 +4,7 @@
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
 //! \file gauss_legendre.cpp
-//  \brief Initializes a Gauss-Legendra grid to interpolate data onto
+//  \brief Initializes a Gauss-Legendre grid to interpolate data onto
 
 #include "spherical_surface.hpp"
 

--- a/src/z4c/z4c.hpp
+++ b/src/z4c/z4c.hpp
@@ -64,7 +64,7 @@ class Z4c {
     I_CON_MX, I_CON_MY, I_CON_MZ,
     ncon,
   };
-  // Names of costraint variables
+  // Names of constraint variables
   static char const * const Constraint_names[ncon];
   // Indices of matter fields
   /*enum {

--- a/src/z4c/z4c_adm.cpp
+++ b/src/z4c/z4c_adm.cpp
@@ -246,7 +246,7 @@ void Z4c::Z4cToADM(MeshBlockPack *pmbp) {
 // https://git.tpi.uni-jena.de/bamdev/adm/blob/master/adm_constraints_N.m
 //
 // The constraints are set only in the MeshBlock interior, because derivatives
-// of the ADM quantities are neded to compute them.
+// of the ADM quantities are needed to compute them.
 template <int NGHOST>
 void Z4c::ADMConstraints(MeshBlockPack *pmbp) {
   // capture variables for the kernel


### PR DESCRIPTION
While I was working on a new chemistry module my spellchecker noted a few typos so I went ahead and ran it on everything in `src` and fixed the errors it reported. All the changes are either in comments or in logging, except the indentation fix in `src/CMakeLists.txt`.