### PR TITLE
Elliptica BHNS/BNS magnetic fields, EOS interface and CompactObjectTracker getters

### DIFF
--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -268,7 +268,7 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
                           idr->field[i_vz][idx]};
 
           // Check for garbage values thrown in by Elliptica.
-          if (idr->field[i_rho][idx] <= rho_cut || 
+          if (idr->field[i_rho][idx] <= rho_cut ||
               !Kokkos::isfinite(idr->field[i_rho][idx])) {
             rho = 0.0;
             host_w0(m, IPR, k, j, i) = 0.0;

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -87,8 +87,9 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
     "grhd_rho,grhd_p,grhd_epsl,grhd_vx,grhd_vy,grhd_vz";
 
   // MHD parameters
+  Real gauss_cgs_to_geo = 8.3519664583273e+19
   Real rho_cut = pin->GetOrAddReal("problem", "rho_cut", 1e-5);
-  Real b_max   = pin->GetOrAddReal("problem", "b_max", 1e12) / 8.3519664583273e+19;
+  Real b_max   = pin->GetOrAddReal("problem", "b_max", 1e12) / gauss_cgs_to_geo;
   Real r_0     = pin->GetOrAddReal("problem", "r_0_current", 5.0);
   Real I_0     = 4 * r_0 * b_max / (23.0 * M_PI);
 
@@ -263,23 +264,22 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
           // energy density, which is invariant, and use that with the 1D EOS.
           Real egas = idr->field[i_rho][idx] * (1.0 + idr->field[i_eps][idx]);
           Real &rho = host_w0(m, IDN, k, j, i);
+          rho = eos.template GetRhoFromE<tov::LocationTag::Host>(egas);
           Real vu[3] = {idr->field[i_vx][idx],
-                          idr->field[i_vy][idx],
-                          idr->field[i_vz][idx]};
+                        idr->field[i_vy][idx],
+                        idr->field[i_vz][idx]};
 
           // Check for garbage values thrown in by Elliptica.
-          if (idr->field[i_rho][idx] <= rho_cut ||
-              !Kokkos::isfinite(idr->field[i_rho][idx])) {
+          if (rho <= rho_cut || !Kokkos::isfinite(rho)) {
             rho = 0.0;
             host_w0(m, IPR, k, j, i) = 0.0;
             vu[0] = 0.0;
             vu[1] = 0.0;
             vu[2] = 0.0;
-          } else {
-            rho = eos.template GetRhoFromE<tov::LocationTag::Host>(egas);
-            host_w0(m, IPR, k, j, i) = eos.template
-                                      GetPFromRho<tov::LocationTag::Host>(rho);
           }
+
+          host_w0(m, IPR, k, j, i) = eos.template
+                                      GetPFromRho<tov::LocationTag::Host>(rho);
 
           // If the electron fraction is available, find it in the 1D EOS.
           if constexpr (use_ye) {

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -268,7 +268,8 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
                           idr->field[i_vz][idx]};
 
           // Check for garbage values thrown in by Elliptica.
-          if (idr->field[i_rho][idx] <= rho_cut || !Kokkos::isfinite(idr->field[i_rho][idx])) {
+          if (idr->field[i_rho][idx] <= rho_cut || 
+              !Kokkos::isfinite(idr->field[i_rho][idx])) {
             rho = 0.0;
             host_w0(m, IPR, k, j, i) = 0.0;
             vu[0] = 0.0;

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -87,7 +87,7 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
     "grhd_rho,grhd_p,grhd_epsl,grhd_vx,grhd_vy,grhd_vz";
 
   // MHD parameters
-  Real gauss_cgs_to_geo = 8.3519664583273e+19
+  Real gauss_cgs_to_geo = 8.3519664583273e+19;
   Real rho_cut = pin->GetOrAddReal("problem", "rho_cut", 1e-5);
   Real b_max   = pin->GetOrAddReal("problem", "b_max", 1e12) / gauss_cgs_to_geo;
   Real r_0     = pin->GetOrAddReal("problem", "r_0_current", 5.0);

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -340,6 +340,8 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
   // the seed of the magnetic field is at the right position.
   Real NS_x = 0.0, NS_y = 0.0, NS_z = 0.0;
   Real BH_x = 0.0, BH_y = 0.0, BH_z = 0.0;
+  Real NS1_x = 0.0, NS1_y = 0.0, NS1_z = 0.0;
+  Real NS2_x = 0.0, NS2_y = 0.0, NS2_z = 0.0;
   Real CM_x_corr = 0.0;
   Real CM_y_corr = 0.0;
   Real CM_z_corr = 0.0;
@@ -353,6 +355,18 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
     CM_x_corr = idr->get_param_dbl("BHNS_x_CM",idr);
     CM_y_corr = idr->get_param_dbl("BHNS_y_CM",idr);
     CM_z_corr = idr->get_param_dbl("BHNS_z_CM",idr);
+  }
+
+  if (BNS) {
+    NS1_x = idr->get_param_dbl("NS1_center_x",idr);
+    NS1_y = idr->get_param_dbl("NS1_center_y",idr);
+    NS1_z = idr->get_param_dbl("NS1_center_z",idr);
+    NS2_x = idr->get_param_dbl("NS2_center_x",idr);
+    NS2_y = idr->get_param_dbl("NS2_center_y",idr);
+    NS2_z = idr->get_param_dbl("NS2_center_z",idr);
+    CM_x_corr = idr->get_param_dbl("NSNS_x_CM",idr);
+    CM_y_corr = idr->get_param_dbl("NSNS_y_CM",idr);
+    CM_z_corr = idr->get_param_dbl("NSNS_z_CM",idr);
   }
 
   // The center of mass shift also needs to be adjusted within
@@ -387,6 +401,23 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
                   << ", cy = " << pmbp->pz4c->ptracker[0]->GetPos(1)
                   << ", cz = " << pmbp->pz4c->ptracker[0]->GetPos(2) << std::endl;
       }
+    }
+  }
+
+  if (BNS) {
+    Real COM_corr_NS1[3] = {NS1_x - CM_x_corr, NS1_y - CM_y_corr, NS1_z - CM_z_corr};
+    Real COM_corr_NS2[3] = {NS2_x - CM_x_corr, NS2_y - CM_y_corr, NS2_z - CM_z_corr};
+    pmbp->pz4c->ptracker[0]->SetPos(COM_corr_NS1);
+    pmbp->pz4c->ptracker[1]->SetPos(COM_corr_NS2);
+
+    if (global_variable::my_rank == 0) {
+      std::cout << "Adjusted CompactObjectTracker position by COM." << std::endl;
+      std::cout << "NS1: cx = " << pmbp->pz4c->ptracker[0]->GetPos(0)
+                << ", cy = " << pmbp->pz4c->ptracker[0]->GetPos(1)
+                << ", cz = " << pmbp->pz4c->ptracker[0]->GetPos(2) << std::endl;
+      std::cout << "NS2: cx = " << pmbp->pz4c->ptracker[1]->GetPos(0)
+                << ", cy = " << pmbp->pz4c->ptracker[1]->GetPos(1)
+                << ", cz = " << pmbp->pz4c->ptracker[1]->GetPos(2) << std::endl;
     }
   }
   
@@ -441,10 +472,10 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
 
     // Distinguish between BNS and BHNS
     if (BNS) {
-      a1(m,k,j,i) = A1(x1v - 0.5 * sep, x2f, x3f, I_0, r_0) +
-                    A1(x1v + 0.5 * sep, x2f, x3f, I_0, r_0);
-      a2(m,k,j,i) = A2(x1f - 0.5 * sep, x2v, x3f, I_0, r_0) +
-                    A2(x1f + 0.5 * sep, x2v, x3f, I_0, r_0);
+      a1(m,k,j,i) = A1(x1v, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                    A1(x1v, x2f + 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
+      a2(m,k,j,i) = A2(x1f, x2v - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                    A2(x1f, x2v + 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
       a3(m,k,j,i) = 0.0;
     } else if (BHNS) {
       if (NS_y > 0.0){
@@ -495,10 +526,10 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
       Real xr = x1v - 0.25 * dx1;
 
       if (BNS) {
-        a1(m,k,j,i) = 0.5*((A1(xl - 0.5 * sep, x2f, x3f, I_0, r_0) +
-                         A1(xl + 0.5 * sep, x2f, x3f, I_0, r_0)) +
-                         (A1(xr - 0.5 * sep, x2f, x3f, I_0, r_0) +
-                         A1(xr + 0.5 * sep, x2f, x3f, I_0, r_0)));
+        a1(m,k,j,i) = 0.5*((A1(xl, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                            A1(xl, x2f + 0.5 * sep + CM_y_corr, x3f, I_0, r_0)) +
+                           (A1(xr, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                            A1(xr, x2f + 0.5 * sep + CM_y_corr, x3f, I_0, r_0)));
       } else if (BHNS) {
         if (NS_y > 0.0) {
           a1(m,k,j,i) = 0.5*(A1(xl, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
@@ -541,10 +572,10 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
       Real xr = x2v - 0.25 * dx2;
 
       if (BNS) {
-        a2(m,k,j,i) = 0.5*((A2(x1f - 0.5 * sep, xl, x3f, I_0, r_0) +
-                         A2(x1f + 0.5 * sep, xl, x3f, I_0, r_0)) +
-                         (A2(x1f - 0.5 * sep, xr, x3f, I_0, r_0) +
-                         A2(x1f + 0.5 * sep, xr, x3f, I_0, r_0)));
+        a2(m,k,j,i) = 0.5*((A2(x1f, xl - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                            A2(x1f, xl + 0.5 * sep + CM_y_corr, x3f, I_0, r_0)) +
+                           (A2(x1f, xr - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                            A2(x1f, xr + 0.5 * sep + CM_y_corr, x3f, I_0, r_0)));
       } else if (BHNS) {
         if (NS_y > 0.0) {
           a2(m,k,j,i) = 0.5*(A2(x1f, xl - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -108,7 +108,7 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
 
   // Enable electron fraction if the EOS supports it.
   constexpr bool use_ye = tov::UsesYe<TOVEOS>;
-  
+
   if (global_variable::my_rank == 0) {
     std::cout << "Allocated coordinates of size " << width << std::endl;
   }
@@ -263,10 +263,10 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
           // energy density, which is invariant, and use that with the 1D EOS.
           Real egas = idr->field[i_rho][idx] * (1.0 + idr->field[i_eps][idx]);
           Real &rho = host_w0(m, IDN, k, j, i);
-          Real vu[3] = {idr->field[i_vx][idx], 
+          Real vu[3] = {idr->field[i_vx][idx],
                           idr->field[i_vy][idx],
                           idr->field[i_vz][idx]};
-          
+
           // Check for garbage values thrown in by Elliptica.
           if (idr->field[i_rho][idx] <= rho_cut || !Kokkos::isfinite(idr->field[i_rho][idx])) {
             rho = 0.0;
@@ -311,7 +311,7 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
       }
     }
   }
-  
+
   if (global_variable::my_rank == 0) {
     std::cout << "Host mirrors filled." << std::endl;
   }
@@ -333,7 +333,7 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
   }
 
   // NS position for the computation of vector potential for BHNS.
-  // grid_set_NS = left means that the NS is at -y and 
+  // grid_set_NS = left means that the NS is at -y and
   // grid_set_NS = right means that the NS is at +y.
   // Also, the binary is shifted so that the center of mass
   // is at the center of the grid. We need to adjust this, such that
@@ -420,10 +420,10 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
                 << ", cz = " << pmbp->pz4c->ptracker[1]->GetPos(2) << std::endl;
     }
   }
-  
+
   // Cleanup
   elliptica_id_reader_free(idr);
-  
+
   if (global_variable::my_rank == 0) {
     std::cout << "Elliptica freed." << std::endl;
   }
@@ -478,7 +478,7 @@ void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
                     A2(x1f, x2v + 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
       a3(m,k,j,i) = 0.0;
     } else if (BHNS) {
-      if (NS_y > 0.0){
+      if (NS_y > 0.0) {
         a1(m,k,j,i) = A1(x1v, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
         a2(m,k,j,i) = A2(x1f, x2v - 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
         a3(m,k,j,i) = 0.0;

--- a/src/pgen/elliptica_bns.cpp
+++ b/src/pgen/elliptica_bns.cpp
@@ -19,6 +19,7 @@
 #include "coordinates/adm.hpp"
 #include "z4c/z4c.hpp"
 #include "z4c/z4c_amr.hpp"
+#include "z4c/compact_object_tracker.hpp"
 #include "coordinates/coordinates.hpp"
 #include "coordinates/cell_locations.hpp"
 #include "dyn_grmhd/dyn_grmhd.hpp"
@@ -29,19 +30,25 @@
 #include "mesh/mesh.hpp"
 #include "mhd/mhd.hpp"
 #include "parameter_input.hpp"
+#include "utils/tov/tov_utils.hpp"
+#include "utils/tov/tov_polytrope.hpp"
+#include "utils/tov/tov_piecewise_poly.hpp"
+#include "utils/tov/tov_tabulated.hpp"
 
-void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm);
-void EllipticaBNSRefinementCondition(MeshBlockPack *pmbp);
+void EllipticaBinaryHistory(HistoryData *pdata, Mesh *pm);
+void EllipticaBinaryRefinementCondition(MeshBlockPack *pmbp);
+
+// Prototypes for magnetic vector potential
+KOKKOS_INLINE_FUNCTION
+static Real A1(Real x, Real y, Real z, Real I_0, Real r_0);
+KOKKOS_INLINE_FUNCTION
+static Real A2(Real x, Real y, Real z, Real I_0, Real r_0);
 
 //----------------------------------------------------------------------------------------
-//! \fn ProblemGenerator::UserProblem_()
-//! \brief Problem Generator for BNS with Elliptica
-void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
-  user_hist_func = &EllipticaBNSHistory;
-  user_ref_func = &EllipticaBNSRefinementCondition;
-
-  if (restart) return;
-
+//! \fn SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_)
+//! \brief Setup of the BHNS/BNS binary with Elliptica
+template<class TOVEOS>
+void SetupBinary(ParameterInput *pin, Mesh* pmy_mesh_) {
   MeshBlockPack *pmbp = pmy_mesh_->pmb_pack;
   auto &indcs         = pmy_mesh_->mb_indcs;
   auto &size          = pmbp->pmb->mb_size;
@@ -77,7 +84,13 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
     "alpha,betax,betay,betaz,"
     "adm_gxx,adm_gxy,adm_gxz,adm_gyy,adm_gyz,adm_gzz,"
     "adm_Kxx,adm_Kxy,adm_Kxz,adm_Kyy,adm_Kyz,adm_Kzz,"
-    "grhd_rho,grhd_p,grhd_vx,grhd_vy,grhd_vz";
+    "grhd_rho,grhd_p,grhd_epsl,grhd_vx,grhd_vy,grhd_vz";
+
+  // MHD parameters
+  Real rho_cut = pin->GetOrAddReal("problem", "rho_cut", 1e-5);
+  Real b_max   = pin->GetOrAddReal("problem", "b_max", 1e12) / 8.3519664583273e+19;
+  Real r_0     = pin->GetOrAddReal("problem", "r_0_current", 5.0);
+  Real I_0     = 4 * r_0 * b_max / (23.0 * M_PI);
 
   int ncells1 = indcs.nx1 + 2 * (indcs.ng);
   int ncells2 = indcs.nx2 + 2 * (indcs.ng);
@@ -90,7 +103,15 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
   Real *y_coords = new Real[width];
   Real *z_coords = new Real[width];
 
-  std::cout << "Allocated coordinates of size " << width << std::endl;
+  // Set up the 1D EOS.
+  TOVEOS eos{pin};
+
+  // Enable electron fraction if the EOS supports it.
+  constexpr bool use_ye = tov::UsesYe<TOVEOS>;
+  
+  if (global_variable::my_rank == 0) {
+    std::cout << "Allocated coordinates of size " << width << std::endl;
+  }
 
   // Populate coordinates for Elliptica
   // TODO(JMF): Replace with a Kokkos loop on
@@ -134,7 +155,10 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
   idr->x_coords = x_coords;
   idr->y_coords = y_coords;
   idr->z_coords = z_coords;
-  std::cout << "Coordinates assigned." << std::endl;
+
+  if (global_variable::my_rank == 0) {
+    std::cout << "Coordinates assigned." << std::endl;
+  }
   elliptica_id_reader_interpolate(idr);
 
   // Free the coordinates, since we'll no longer need them.
@@ -142,7 +166,9 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
   delete[] y_coords;
   delete[] z_coords;
 
-  std::cout << "Coordinates freed." << std::endl;
+  if (global_variable::my_rank == 0) {
+    std::cout << "Coordinates freed." << std::endl;
+  }
 
   // Capture variables for kernel; note that when Z4c is enabled, the gauge
   // variables are part of the Z4c class.
@@ -168,7 +194,9 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
   host_adm.vK_dd.InitWithShallowSlice(
     host_u_adm, adm::ADM::I_ADM_KXX, adm::ADM::I_ADM_KZZ);
 
-  std::cout << "Host mirrors created." << std::endl;
+  if (global_variable::my_rank == 0) {
+    std::cout << "Host mirrors created." << std::endl;
+  }
 
   // Save Elliptica field indices for shorthand and a small optimization.
   const int i_alpha = idr->indx("alpha");
@@ -192,11 +220,14 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
 
   const int i_rho = idr->indx("grhd_rho");
   const int i_p   = idr->indx("grhd_p");
+  const int i_eps = idr->indx("grhd_epsl");
   const int i_vx  = idr->indx("grhd_vx");
   const int i_vy  = idr->indx("grhd_vy");
   const int i_vz  = idr->indx("grhd_vz");
 
-  std::cout << "Label indices saved." << std::endl;
+  if (global_variable::my_rank == 0) {
+    std::cout << "Label indices saved." << std::endl;
+  }
 
   // TODO(JMF): Replace with a Kokkos loop on
   // Kokkos::DefaultHostExecutionSpace() to improve performance.
@@ -227,11 +258,33 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
           host_adm.vK_dd(m, 2, 2, k, j, i) = idr->field[i_Kzz][idx];
 
           // Extract hydro quantities
-          host_w0(m, IDN, k, j, i) = idr->field[i_rho][idx];
-          host_w0(m, IPR, k, j, i) = idr->field[i_p][idx];
-          Real vu[3]               = {
-            idr->field[i_vx][idx], idr->field[i_vy][idx],
-            idr->field[i_vz][idx]};
+          // Note that Elliptica does not necessarily use the same baryon rest-mass as
+          // AthenaK. The most reasonable thing to do, then, is to extract the total
+          // energy density, which is invariant, and use that with the 1D EOS.
+          Real egas = idr->field[i_rho][idx] * (1.0 + idr->field[i_eps][idx]);
+          Real &rho = host_w0(m, IDN, k, j, i);
+          Real vu[3] = {idr->field[i_vx][idx], 
+                          idr->field[i_vy][idx],
+                          idr->field[i_vz][idx]};
+          
+          // Check for garbage values thrown in by Elliptica.
+          if (idr->field[i_rho][idx] <= rho_cut || !Kokkos::isfinite(idr->field[i_rho][idx])) {
+            rho = 0.0;
+            host_w0(m, IPR, k, j, i) = 0.0;
+            vu[0] = 0.0;
+            vu[1] = 0.0;
+            vu[2] = 0.0;
+          } else {
+            rho = eos.template GetRhoFromE<tov::LocationTag::Host>(egas);
+            host_w0(m, IPR, k, j, i) = eos.template
+                                      GetPFromRho<tov::LocationTag::Host>(rho);
+          }
+
+          // If the electron fraction is available, find it in the 1D EOS.
+          if constexpr (use_ye) {
+            host_w0(m, IYF, k, j, i) = eos.template
+                                       GetYeFromRho<tov::LocationTag::Host>(rho);
+          }
 
           // Before we store the velocity, we need to make sure it's physical
           // and calculate the Lorentz factor. If the velocity is superluminal,
@@ -258,57 +311,342 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
       }
     }
   }
+  
+  if (global_variable::my_rank == 0) {
+    std::cout << "Host mirrors filled." << std::endl;
+  }
 
-  std::cout << "Host mirrors filled." << std::endl;
+  // Binary separation for different systems
+  Real sep;
+  bool BHNS, BNS;
+  if (std::strcmp(idr->system,"BH_NS_binary_initial_data") == 0) {
+    sep = idr->get_param_dbl("BHNS_separation",idr);
+    BNS = false; BHNS = true;
+  } else if (std::strcmp(idr->system,"NS_NS_binary_initial_data") == 0) {
+    sep = idr->get_param_dbl("NSNS_separation",idr);
+    BNS = true; BHNS = false;
+  } else {
+    sep = 0.0; BNS = false; BHNS = false;
+  }
+  if (global_variable::my_rank == 0) {
+    std::cout << "Separation = " << sep << std::endl;
+  }
 
+  // NS position for the computation of vector potential for BHNS.
+  // grid_set_NS = left means that the NS is at -y and 
+  // grid_set_NS = right means that the NS is at +y.
+  // Also, the binary is shifted so that the center of mass
+  // is at the center of the grid. We need to adjust this, such that
+  // the seed of the magnetic field is at the right position.
+  Real NS_x = 0.0, NS_y = 0.0, NS_z = 0.0;
+  Real BH_x = 0.0, BH_y = 0.0, BH_z = 0.0;
+  Real CM_x_corr = 0.0;
+  Real CM_y_corr = 0.0;
+  Real CM_z_corr = 0.0;
+  if (BHNS) {
+    NS_x = idr->get_param_dbl("NS_center_x",idr);
+    NS_y = idr->get_param_dbl("NS_center_y",idr);
+    NS_z = idr->get_param_dbl("NS_center_z",idr);
+    BH_x = idr->get_param_dbl("BH_center_x",idr);
+    BH_y = idr->get_param_dbl("BH_center_y",idr);
+    BH_z = idr->get_param_dbl("BH_center_z",idr);
+    CM_x_corr = idr->get_param_dbl("BHNS_x_CM",idr);
+    CM_y_corr = idr->get_param_dbl("BHNS_y_CM",idr);
+    CM_z_corr = idr->get_param_dbl("BHNS_z_CM",idr);
+  }
+
+  // The center of mass shift also needs to be adjusted within
+  // the compact object tracker to accurately track the position
+  // of the binary.
+  if (BHNS) {
+    Real COM_corr_NS[3] = {NS_x - CM_x_corr, NS_y - CM_y_corr, NS_z - CM_z_corr};
+    Real COM_corr_BH[3] = {BH_x - CM_x_corr, BH_y - CM_y_corr, BH_z - CM_z_corr};
+    if (pmbp->pz4c->ptracker[0]->GetType() == 0) { // CompactObjectTracker::BlackHole == 0
+      pmbp->pz4c->ptracker[0]->SetPos(COM_corr_BH);
+      pmbp->pz4c->ptracker[1]->SetPos(COM_corr_NS);
+
+      if (global_variable::my_rank == 0) {
+        std::cout << "Adjusted CompactObjectTracker position by COM." << std::endl;
+        std::cout << "BH: cx = " << pmbp->pz4c->ptracker[0]->GetPos(0)
+                  << ", cy = " << pmbp->pz4c->ptracker[0]->GetPos(1)
+                  << ", cz = " << pmbp->pz4c->ptracker[0]->GetPos(2) << std::endl;
+        std::cout << "NS: cx = " << pmbp->pz4c->ptracker[1]->GetPos(0)
+                  << ", cy = " << pmbp->pz4c->ptracker[1]->GetPos(1)
+                  << ", cz = " << pmbp->pz4c->ptracker[1]->GetPos(2) << std::endl;
+      }
+    } else {
+      pmbp->pz4c->ptracker[1]->SetPos(COM_corr_BH);
+      pmbp->pz4c->ptracker[0]->SetPos(COM_corr_NS);
+
+      if (global_variable::my_rank == 0) {
+        std::cout << "Adjusted CompactObjectTracker position by COM." << std::endl;
+        std::cout << "BH: cx = " << pmbp->pz4c->ptracker[1]->GetPos(0)
+                  << ", cy = " << pmbp->pz4c->ptracker[1]->GetPos(1)
+                  << ", cz = " << pmbp->pz4c->ptracker[1]->GetPos(2) << std::endl;
+        std::cout << "NS: cx = " << pmbp->pz4c->ptracker[0]->GetPos(0)
+                  << ", cy = " << pmbp->pz4c->ptracker[0]->GetPos(1)
+                  << ", cz = " << pmbp->pz4c->ptracker[0]->GetPos(2) << std::endl;
+      }
+    }
+  }
+  
   // Cleanup
   elliptica_id_reader_free(idr);
-
-  std::cout << "Elliptica freed." << std::endl;
+  
+  if (global_variable::my_rank == 0) {
+    std::cout << "Elliptica freed." << std::endl;
+  }
 
   // Copy the data to the GPU.
   Kokkos::deep_copy(u_adm, host_u_adm);
   Kokkos::deep_copy(w0, host_w0);
   Kokkos::deep_copy(u_z4c, host_u_z4c);
 
-  std::cout << "Data copied." << std::endl;
+  if (global_variable::my_rank == 0) {
+    std::cout << "Data copied." << std::endl;
+  }
 
-  // TODO(JMF): Add magnetic fields
+  // Compute vector potential over all faces
+  DvceArray4D<Real> a1, a2, a3;
+  Kokkos::realloc(a1, nmb, ncells3, ncells2, ncells1);
+  Kokkos::realloc(a2, nmb, ncells3, ncells2, ncells1);
+  Kokkos::realloc(a3, nmb, ncells3, ncells2, ncells1);
+
+  auto &nghbr = pmbp->pmb->nghbr;
+  auto &mblev = pmbp->pmb->mb_lev;
+
+  par_for("pgen_vector_potential", DevExeSpace(), 0, nmb-1, ks, ke+1, js, je+1, is, ie+1,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real &x1min = size.d_view(m).x1min;
+    Real &x1max = size.d_view(m).x1max;
+    int nx1 = indcs.nx1;
+    Real x1v = CellCenterX(i - is, nx1, x1min, x1max);
+    Real x1f   = LeftEdgeX(i - is, nx1, x1min, x1max);
+
+    Real &x2min = size.d_view(m).x2min;
+    Real &x2max = size.d_view(m).x2max;
+    int nx2 = indcs.nx2;
+    Real x2v = CellCenterX(j - js, nx2, x2min, x2max);
+    Real x2f   = LeftEdgeX(j - js, nx2, x2min, x2max);
+
+    Real &x3min = size.d_view(m).x3min;
+    Real &x3max = size.d_view(m).x3max;
+    int nx3 = indcs.nx3;
+    Real x3v = CellCenterX(k - ks, nx3, x3min, x3max);
+    Real x3f   = LeftEdgeX(k - ks, nx3, x3min, x3max);
+
+    Real dx1 = size.d_view(m).dx1;
+    Real dx2 = size.d_view(m).dx2;
+    Real dx3 = size.d_view(m).dx3;
+
+    // Distinguish between BNS and BHNS
+    if (BNS) {
+      a1(m,k,j,i) = A1(x1v - 0.5 * sep, x2f, x3f, I_0, r_0) +
+                    A1(x1v + 0.5 * sep, x2f, x3f, I_0, r_0);
+      a2(m,k,j,i) = A2(x1f - 0.5 * sep, x2v, x3f, I_0, r_0) +
+                    A2(x1f + 0.5 * sep, x2v, x3f, I_0, r_0);
+      a3(m,k,j,i) = 0.0;
+    } else if (BHNS) {
+      if (NS_y > 0.0){
+        a1(m,k,j,i) = A1(x1v, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
+        a2(m,k,j,i) = A2(x1f, x2v - 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
+        a3(m,k,j,i) = 0.0;
+      } else {
+        a1(m,k,j,i) = A1(x1v, x2f + 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
+        a2(m,k,j,i) = A2(x1f, x2v + 0.5 * sep + CM_y_corr, x3f, I_0, r_0);
+        a3(m,k,j,i) = 0.0;
+      }
+    } else {
+      a1(m,k,j,i) = 0.0;
+      a2(m,k,j,i) = 0.0;
+      a3(m,k,j,i) = 0.0;
+    }
+
+    // When neighboring MeshBock is at finer level, compute vector potential as sum of
+    // values at fine grid resolution.  This guarantees flux on shared fine/coarse
+    // faces is identical.
+
+    // Correct A1 at x2-faces, x3-faces, and x2x3-edges
+    if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
+        (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
+        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,28).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,29).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,30).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,31).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,40).lev > mblev.d_view(m) && j==js && k==ks) ||
+        (nghbr.d_view(m,41).lev > mblev.d_view(m) && j==js && k==ks) ||
+        (nghbr.d_view(m,42).lev > mblev.d_view(m) && j==je+1 && k==ks) ||
+        (nghbr.d_view(m,43).lev > mblev.d_view(m) && j==je+1 && k==ks) ||
+        (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
+        (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
+        (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
+        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+      Real xl = x1v + 0.25 * dx1;
+      Real xr = x1v - 0.25 * dx1;
+
+      if (BNS) {
+        a1(m,k,j,i) = 0.5*((A1(xl - 0.5 * sep, x2f, x3f, I_0, r_0) +
+                         A1(xl + 0.5 * sep, x2f, x3f, I_0, r_0)) +
+                         (A1(xr - 0.5 * sep, x2f, x3f, I_0, r_0) +
+                         A1(xr + 0.5 * sep, x2f, x3f, I_0, r_0)));
+      } else if (BHNS) {
+        if (NS_y > 0.0) {
+          a1(m,k,j,i) = 0.5*(A1(xl, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                             A1(xr, x2f - 0.5 * sep + CM_y_corr, x3f, I_0, r_0));
+        } else {
+          a1(m,k,j,i) = 0.5*(A1(xl, x2f + 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                             A1(xr, x2f + 0.5 * sep + CM_y_corr, x3f, I_0, r_0));
+        }
+      } else {
+        a1(m,k,j,i) = 0.0;
+      }
+    }
+
+    // Correct A2 at x1-faces, x3-faces, and x1x3-edges
+    if ((nghbr.d_view(m,0 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,1 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,2 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,3 ).lev > mblev.d_view(m) && i==is) ||
+        (nghbr.d_view(m,4 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
+        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,28).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,29).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,30).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,31).lev > mblev.d_view(m) && k==ke+1) ||
+        (nghbr.d_view(m,32).lev > mblev.d_view(m) && i==is && k==ks) ||
+        (nghbr.d_view(m,33).lev > mblev.d_view(m) && i==is && k==ks) ||
+        (nghbr.d_view(m,34).lev > mblev.d_view(m) && i==ie+1 && k==ks) ||
+        (nghbr.d_view(m,35).lev > mblev.d_view(m) && i==ie+1 && k==ks) ||
+        (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
+        (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
+        (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
+        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+      Real xl = x2v + 0.25 * dx2;
+      Real xr = x2v - 0.25 * dx2;
+
+      if (BNS) {
+        a2(m,k,j,i) = 0.5*((A2(x1f - 0.5 * sep, xl, x3f, I_0, r_0) +
+                         A2(x1f + 0.5 * sep, xl, x3f, I_0, r_0)) +
+                         (A2(x1f - 0.5 * sep, xr, x3f, I_0, r_0) +
+                         A2(x1f + 0.5 * sep, xr, x3f, I_0, r_0)));
+      } else if (BHNS) {
+        if (NS_y > 0.0) {
+          a2(m,k,j,i) = 0.5*(A2(x1f, xl - 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                             A2(x1f, xr - 0.5 * sep + CM_y_corr, x3f, I_0, r_0));
+        } else {
+          a2(m,k,j,i) = 0.5*(A2(x1f, xl + 0.5 * sep + CM_y_corr, x3f, I_0, r_0) +
+                             A2(x1f, xr + 0.5 * sep + CM_y_corr, x3f, I_0, r_0));
+        }
+      } else {
+        a2(m,k,j,i) = 0.0;
+      }
+    }
+  });
+
   auto &b0 = pmbp->pmhd->b0;
-  par_for(
-    "pgen_Bfc", DevExeSpace(), 0, nmb - 1, ks, ke, js, je, is, ie,
-    KOKKOS_LAMBDA(int m, int k, int j, int i) {
-      b0.x1f(m, k, j, i) = 0.0;
-      b0.x2f(m, k, j, i) = 0.0;
-      b0.x3f(m, k, j, i) = 0.0;
+  par_for("pgen_Bfc", DevExeSpace(), 0, nmb-1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    // Compute face-centered fields from curl(A).
+    Real dx1 = size.d_view(m).dx1;
+    Real dx2 = size.d_view(m).dx2;
+    Real dx3 = size.d_view(m).dx3;
 
-      if (i == ie) {
-        b0.x1f(m, k, j, i + 1) = 0.0;
-      }
-      if (j == je) {
-        b0.x2f(m, k, j + 1, i) = 0.0;
-      }
-      if (k == ke) {
-        b0.x3f(m, k + 1, j, i) = 0.0;
-      }
-    });
+    b0.x1f(m,k,j,i) = ((a3(m,k,j+1,i) - a3(m,k,j,i)) / dx2 -
+                          (a2(m,k+1,j,i) - a2(m,k,j,i)) / dx3);
+    b0.x2f(m,k,j,i) = ((a1(m,k+1,j,i) - a1(m,k,j,i)) / dx3 -
+                          (a3(m,k,j,i+1) - a3(m,k,j,i)) / dx1);
+    b0.x3f(m,k,j,i) = ((a2(m,k,j,i+1) - a2(m,k,j,i)) / dx1 -
+                          (a1(m,k,j+1,i) - a1(m,k,j,i)) / dx2);
 
-  std::cout << "Face-centered fields zeroed." << std::endl;
+    // Include extra face-component at edge of block in each direction
+    if (i == ie) {
+      b0.x1f(m,k,j,i+1) = ((a3(m,k,j+1,i+1) - a3(m,k,j,i+1)) / dx2 -
+                           (a2(m,k+1,j,i+1) - a2(m,k,j,i+1)) / dx3);
+    }
+    if (j == je) {
+      b0.x2f(m,k,j+1,i) = ((a1(m,k+1,j+1,i) - a1(m,k,j+1,i)) / dx3 -
+                           (a3(m,k,j+1,i+1) - a3(m,k,j+1,i)) / dx1);
+    }
+    if (k == ke) {
+      b0.x3f(m,k+1,j,i) = ((a2(m,k+1,j,i+1) - a2(m,k+1,j,i)) / dx1 -
+                           (a1(m,k+1,j+1,i) - a1(m,k+1,j,i)) / dx2);
+    }
+  });
+
+  if (global_variable::my_rank == 0) {
+    std::cout << "Face-centered fields calculated." << std::endl;
+  }
 
   // Compute cell-centered fields
   auto &bcc0 = pmbp->pmhd->bcc0;
-  par_for(
-    "pgen_bcc", DevExeSpace(), 0, nmb - 1, ks, ke, js, je, is, ie,
-    KOKKOS_LAMBDA(int m, int k, int j, int i) {
-      bcc0(m, IBX, k, j, i) =
-        0.5 * (b0.x1f(m, k, j, i) + b0.x1f(m, k, j, i + 1));
-      bcc0(m, IBY, k, j, i) =
-        0.5 * (b0.x2f(m, k, j, i) + b0.x2f(m, k, j + 1, i));
-      bcc0(m, IBZ, k, j, i) =
-        0.5 * (b0.x3f(m, k, j, i) + b0.x3f(m, k + 1, j, i));
-    });
+  par_for("pgen_bcc", DevExeSpace(), 0, nmb - 1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    bcc0(m,IBX,k,j,i) = 0.5 * (b0.x1f(m,k,j,i) + b0.x1f(m,k,j,i+1));
+    bcc0(m,IBY,k,j,i) = 0.5 * (b0.x2f(m,k,j,i) + b0.x2f(m,k,j+1,i));
+    bcc0(m,IBZ,k,j,i) = 0.5 * (b0.x3f(m,k,j,i) + b0.x3f(m,k+1,j,i));
+  });
 
-  std::cout << "Cell-centered fields calculated." << std::endl;
+  if (global_variable::my_rank == 0) {
+    std::cout << "Cell-centered fields calculated." << std::endl;
+  }
+
+  return;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn ProblemGenerator::UserProblem()
+//! \brief Problem Generator for Binary with Elliptica
+void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
+  MeshBlockPack *pmbp = pmy_mesh_->pmb_pack;
+  if (pmbp->pdyngr == nullptr || pmbp->pz4c == nullptr) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl
+              << "Binary data requires <mhd> and <z4c> blocks." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  user_hist_func = &EllipticaBinaryHistory;
+  user_ref_func = &EllipticaBinaryRefinementCondition;
+
+  if (restart) return;
+
+  // Select the correct EOS template based on the EOS we need.
+  if (pmbp->pdyngr->eos_policy == DynGRMHD_EOS::eos_ideal) {
+    SetupBinary<tov::PolytropeEOS>(pin, pmy_mesh_);
+  } else if (pmbp->pdyngr->eos_policy == DynGRMHD_EOS::eos_compose) {
+    SetupBinary<tov::TabulatedEOS>(pin, pmy_mesh_);
+  } else if (pmbp->pdyngr->eos_policy == DynGRMHD_EOS::eos_hybrid) {
+    SetupBinary<tov::TabulatedEOS>(pin, pmy_mesh_);
+  } else if (pmbp->pdyngr->eos_policy == DynGRMHD_EOS::eos_piecewise_poly) {
+    SetupBinary<tov::PiecewisePolytropeEOS>(pin, pmy_mesh_);
+  } else {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+              << "Unknown EOS requested for Elliptica problem" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  auto &indcs = pmy_mesh_->mb_indcs;
+  auto &size = pmbp->pmb->mb_size;
+  int &ng = indcs.ng;
+  int ncells1 = indcs.nx1 + 2*ng;
+  int ncells2 = (indcs.nx2 > 1) ? (indcs.nx2 + 2*ng) : 1;
+  int ncells3 = (indcs.nx3 > 1) ? (indcs.nx3 + 2*ng) : 1;
 
   pmbp->pdyngr->PrimToConInit(
     0, (ncells1 - 1), 0, (ncells2 - 1), 0, (ncells3 - 1));
@@ -328,7 +666,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
 }
 
 // History function
-void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm) {
+void EllipticaBinaryHistory(HistoryData *pdata, Mesh *pm) {
   // Select the number of outputs and create labels for them.
   int &nmhd       = pm->pmb_pack->pmhd->nmhd;
   pdata->nhist    = 2;
@@ -340,18 +678,15 @@ void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm) {
   auto &adm = pm->pmb_pack->padm->adm;
 
   // loop over all MeshBlocks in this pack
-  auto &indcs     = pm->pmb_pack->pmesh->mb_indcs;
-  int is          = indcs.is;
-  int nx1         = indcs.nx1;
-  int js          = indcs.js;
-  int nx2         = indcs.nx2;
-  int ks          = indcs.ks;
-  int nx3         = indcs.nx3;
+  auto &indcs = pm->pmb_pack->pmesh->mb_indcs;
+  int is = indcs.is; int nx1 = indcs.nx1;
+  int js = indcs.js; int nx2 = indcs.nx2;
+  int ks = indcs.ks; int nx3 = indcs.nx3;
   const int nmkji = (pm->pmb_pack->nmb_thispack) * nx3 * nx2 * nx1;
-  const int nkji  = nx3 * nx2 * nx1;
-  const int nji   = nx2 * nx1;
-  Real rho_max    = std::numeric_limits<Real>::max();
-  Real alpha_min  = -rho_max;
+  const int nkji = nx3 * nx2 * nx1;
+  const int nji = nx2 * nx1;
+  Real rho_max = std::numeric_limits<Real>::max();
+  Real alpha_min = -rho_max;
   Kokkos::parallel_reduce(
     "TOVHistSums", Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
     KOKKOS_LAMBDA(const int &idx, Real &mb_max, Real &mb_alp_min) {
@@ -363,7 +698,7 @@ void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm) {
       k += ks;
       j += js;
 
-      mb_max     = fmax(mb_max, w0_(m, IDN, k, j, i));
+      mb_max = fmax(mb_max, w0_(m, IDN, k, j, i));
       mb_alp_min = fmin(mb_alp_min, adm.alpha(m, k, j, i));
     },
     Kokkos::Max<Real>(rho_max), Kokkos::Min<Real>(alpha_min));
@@ -373,16 +708,12 @@ void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm) {
   // it work as intended.
 #if MPI_PARALLEL_ENABLED
   if (global_variable::my_rank == 0) {
-    MPI_Reduce(
-      MPI_IN_PLACE, &rho_max, 1, MPI_ATHENA_REAL, MPI_MAX, 0, MPI_COMM_WORLD);
-    MPI_Reduce(
-      MPI_IN_PLACE, &alpha_min, 1, MPI_ATHENA_REAL, MPI_MIN, 0, MPI_COMM_WORLD);
+    MPI_Reduce(MPI_IN_PLACE, &rho_max, 1, MPI_ATHENA_REAL, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(MPI_IN_PLACE, &alpha_min, 1, MPI_ATHENA_REAL, MPI_MIN, 0, MPI_COMM_WORLD);
   } else {
-    MPI_Reduce(
-      &rho_max, &rho_max, 1, MPI_ATHENA_REAL, MPI_MAX, 0, MPI_COMM_WORLD);
-    MPI_Reduce(
-      &alpha_min, &alpha_min, 1, MPI_ATHENA_REAL, MPI_MAX, 0, MPI_COMM_WORLD);
-    rho_max   = 0.;
+    MPI_Reduce(&rho_max, &rho_max, 1, MPI_ATHENA_REAL, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&alpha_min, &alpha_min, 1, MPI_ATHENA_REAL, MPI_MAX, 0, MPI_COMM_WORLD);
+    rho_max = 0.;
     alpha_min = 0.;
   }
 #endif
@@ -392,6 +723,22 @@ void EllipticaBNSHistory(HistoryData *pdata, Mesh *pm) {
   pdata->hdata[1] = alpha_min;
 }
 
-void EllipticaBNSRefinementCondition(MeshBlockPack *pmbp) {
+void EllipticaBinaryRefinementCondition(MeshBlockPack *pmbp) {
   pmbp->pz4c->pamr->Refine(pmbp);
+}
+
+KOKKOS_INLINE_FUNCTION
+static Real A1(Real x, Real y, Real z, Real I_0, Real r_0) {
+  Real w2 = SQR(x) + SQR(y);
+  Real r2 = w2 + SQR(z);
+  return -y * M_PI * SQR(r_0)*I_0 / pow(SQR(r_0) + r2, 1.5) *
+         (1.0 + 15.0/8.0*SQR(r_0)*(SQR(r_0)+w2)/SQR(SQR(r_0)+r2));
+}
+
+KOKKOS_INLINE_FUNCTION
+static Real A2(Real x, Real y, Real z, Real I_0, Real r_0) {
+  Real w2 = SQR(x) + SQR(y);
+  Real r2 = w2 + SQR(z);
+  return x * M_PI * SQR(r_0)*I_0 / pow(SQR(r_0) + r2, 1.5) *
+         (1.0 + 15.0/8.0*SQR(r_0)*(SQR(r_0)+w2)/SQR(SQR(r_0)+r2));
 }

--- a/src/utils/tov/tov_tabulated.hpp
+++ b/src/utils/tov/tov_tabulated.hpp
@@ -182,7 +182,7 @@ class TabulatedEOS {
       return 0.0;
     }
     Real rho = GetRhoFromVar<loc>(le, m_log_e);
-
+    
     // for negative densities, return the 
     // minimum density in the table
     if (rho < 0.0) {

--- a/src/utils/tov/tov_tabulated.hpp
+++ b/src/utils/tov/tov_tabulated.hpp
@@ -182,8 +182,8 @@ class TabulatedEOS {
       return 0.0;
     }
     Real rho = GetRhoFromVar<loc>(le, m_log_e);
-    
-    // for negative densities, return the 
+
+    // for negative densities, return the
     // minimum density in the table
     if (rho < 0.0) {
       return exp(lrho_min);

--- a/src/utils/tov/tov_tabulated.hpp
+++ b/src/utils/tov/tov_tabulated.hpp
@@ -178,15 +178,13 @@ class TabulatedEOS {
   KOKKOS_INLINE_FUNCTION
   Real GetRhoFromE(Real e) const {
     Real le = log(e);
-    if (le < le_min) {
+
+    // Guard against negative total energy
+    // densities and garbage values.
+    if (le < le_min || e < 0.0) {
       return 0.0;
     }
 
-    // for negative total energy densities, return the
-    // minimum density in the table
-    if (e < 0.0) {
-      return exp(lrho_min);
-    }
     return GetRhoFromVar<loc>(le, m_log_e);
   }
 

--- a/src/utils/tov/tov_tabulated.hpp
+++ b/src/utils/tov/tov_tabulated.hpp
@@ -181,14 +181,13 @@ class TabulatedEOS {
     if (le < le_min) {
       return 0.0;
     }
-    Real rho = GetRhoFromVar<loc>(le, m_log_e);
 
-    // for negative densities, return the
+    // for negative total energy densities, return the
     // minimum density in the table
-    if (rho < 0.0) {
+    if (e < 0.0) {
       return exp(lrho_min);
     }
-    return rho;
+    return GetRhoFromVar<loc>(le, m_log_e);
   }
 
   template<LocationTag loc>

--- a/src/utils/tov/tov_tabulated.hpp
+++ b/src/utils/tov/tov_tabulated.hpp
@@ -181,7 +181,14 @@ class TabulatedEOS {
     if (le < le_min) {
       return 0.0;
     }
-    return GetRhoFromVar<loc>(le, m_log_e);
+    Real rho = GetRhoFromVar<loc>(le, m_log_e);
+
+    // for negative densities, return the 
+    // minimum density in the table
+    if (rho < 0.0) {
+      return exp(lrho_min);
+    }
+    return rho;
   }
 
   template<LocationTag loc>

--- a/src/z4c/compact_object_tracker.cpp
+++ b/src/z4c/compact_object_tracker.cpp
@@ -67,6 +67,8 @@ CompactObjectTracker::CompactObjectTracker(Mesh *pmesh, ParameterInput *pin, int
   pos[1] = pin->GetOrAddReal("z4c", "co_" + nstr + "_y", 0.0);
   pos[2] = pin->GetOrAddReal("z4c", "co_" + nstr + "_z", 0.0);
 
+  mass = pin->GetOrAddReal("z4c", "co_" + nstr + "_mass", 0.0);
+
   reflevel = pin->GetOrAddInteger("z4c", "co_" + nstr + "_reflevel", -1);
   radius = pin->GetOrAddReal("z4c", "co_" + nstr + "_radius", 0.0);
 

--- a/src/z4c/compact_object_tracker.hpp
+++ b/src/z4c/compact_object_tracker.hpp
@@ -56,6 +56,14 @@ class CompactObjectTracker {
   inline Real GetRadius() const {
     return radius;
   }
+  //! Get initial mass
+  inline Real GetMass() {
+    return mass;
+  }
+  //! Get CO type
+  inline CompactObjectType GetType() {
+    return type;
+  }
 
  private:
   bool owns_compact_object;
@@ -64,6 +72,7 @@ class CompactObjectTracker {
   Real vel[NDIM];
   int reflevel;         // requested minimum refinement level (-1 for infinity)
   Real radius;          // nominal radius of the object (for the AMR driver)
+  Real mass;            // mass needed for FastFlow
   Mesh const *pmesh;
   int out_every;
   std::ofstream ofile;


### PR DESCRIPTION
The elliptica_bns pgen now recomputes the density and pressure from the invariant total energy density instead of taking the Elliptica density and pressure right away. Magnetic fields have been added for BNS and BHNS systems as in the Lorene pgen. The pgen also accounts for unequal mass ratios in both BNS and BHNS cases, shifts the magnetic field seed and corrects the CompactObjectTracker location. All of this happens automatically and no manual adjustment is needed. For that reason, I added two getter functions to the ```CompactObjectTracker``` class to get the CO type and also a new parameter: the ```mass```. This is essential for the horizon finder in the ```fastflow``` branch and is also good to have. Attached are low resolution initial data tests that show that in the case of unequal mass ratios, we correctly place the magnetic field.
<img width="1600" height="1200" alt="magID_elliptica" src="https://github.com/user-attachments/assets/ab3a1477-1e81-4a9f-9be0-e89ec58605d4" />
<img width="1600" height="1200" alt="magID_elliptica_bns_shift" src="https://github.com/user-attachments/assets/c221fe3c-a93e-48d6-8109-ae68eb7f0824" />
