### PR TITLE
Add logic to deal with unequal mass-ratios in Lorene

### DIFF
--- a/src/pgen/lorene_bns.cpp
+++ b/src/pgen/lorene_bns.cpp
@@ -24,6 +24,7 @@
 #include "coordinates/adm.hpp"
 #include "z4c/z4c.hpp"
 #include "z4c/z4c_amr.hpp"
+#include "z4c/compact_object_tracker.hpp"
 #include "coordinates/coordinates.hpp"
 #include "coordinates/cell_locations.hpp"
 #include "eos/eos.hpp"
@@ -277,6 +278,31 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
     std::cout << "sep = " << sep << std::endl;
   }
 
+  // For unequal-mass binaries, the COM is shifted, such that it
+  // lies at the grid origin. To get the correct positions for the
+  // CO tracker and the magnetic field seed, we need to specify the
+  // component gravitational masses (where M2 is the heavier star as
+  // in Lorene).
+  double M1 = pin->GetReal("problem", "M1");
+  double M2 = pin->GetReal("problem", "M2");
+  double center_m = - (M2 / (M1 + M2)) * sep;
+  double center_p = + (M1 / (M1 + M2)) * sep;
+
+  Real NS1_COM_pos[3] = {center_m, 0.0, 0.0};
+  Real NS2_COM_pos[3] = {center_p, 0.0, 0.0};
+  pmbp->pz4c->ptracker[0]->SetPos(NS1_COM_pos);
+  pmbp->pz4c->ptracker[1]->SetPos(NS2_COM_pos);
+
+  if (global_variable::my_rank == 0) {
+    std::cout << "Adjusted CompactObjectTracker position by COM." << std::endl;
+    std::cout << "NS1: cx = " << pmbp->pz4c->ptracker[0]->GetPos(0)
+              << ", cy = " << pmbp->pz4c->ptracker[0]->GetPos(1)
+              << ", cz = " << pmbp->pz4c->ptracker[0]->GetPos(2) << std::endl;
+    std::cout << "NS2: cx = " << pmbp->pz4c->ptracker[1]->GetPos(0)
+              << ", cy = " << pmbp->pz4c->ptracker[1]->GetPos(1)
+              << ", cz = " << pmbp->pz4c->ptracker[1]->GetPos(2) << std::endl;
+  }
+
   // Cleanup
   delete bns;
 
@@ -328,10 +354,10 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
     Real dx2 = size.d_view(m).dx2;
     Real dx3 = size.d_view(m).dx3;
 
-    a1(m,k,j,i) = A1(x1v - 0.5*sep, x2f, x3f, I_0, r_0) +
-                  A1(x1v + 0.5*sep, x2f, x3f, I_0, r_0);
-    a2(m,k,j,i) = A2(x1f - 0.5*sep, x2v, x3f, I_0, r_0) +
-                  A2(x1f + 0.5*sep, x2v, x3f, I_0, r_0);
+    a1(m,k,j,i) = A1(x1v - center_m, x2f, x3f, I_0, r_0) +
+                  A1(x1v - center_p, x2f, x3f, I_0, r_0);
+    a2(m,k,j,i) = A2(x1f - center_m, x2v, x3f, I_0, r_0) +
+                  A2(x1f - center_p, x2v, x3f, I_0, r_0);
     a3(m,k,j,i) = 0.0;
 
     // When neighboring MeshBock is at finer level, compute vector potential as sum of
@@ -365,10 +391,10 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
       Real xl = x1v + 0.25*dx1;
       Real xr = x1v - 0.25*dx1;
-      a1(m,k,j,i) = 0.5*((A1(xl-0.5*sep, x2f, x3f, I_0, r_0) +
-                         A1(xl+0.5*sep, x2f, x3f, I_0, r_0)) +
-                         (A1(xr-0.5*sep, x2f, x3f, I_0, r_0) +
-                         A1(xr+0.5*sep, x2f, x3f, I_0, r_0)));
+      a1(m,k,j,i) = 0.5*((A1(xl - center_m, x2f, x3f, I_0, r_0) +
+                          A1(xl - center_p, x2f, x3f, I_0, r_0)) +
+                         (A1(xr - center_m, x2f, x3f, I_0, r_0) +
+                          A1(xr - center_p, x2f, x3f, I_0, r_0)));
     }
 
     // Correct A2 at x1-faces, x3-faces, and x1x3-edges
@@ -398,10 +424,10 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
       Real xl = x2v + 0.25*dx2;
       Real xr = x2v - 0.25*dx2;
-      a2(m,k,j,i) = 0.5*((A2(x1f-0.5*sep, xl, x3f, I_0, r_0) +
-                         A2(x1f+0.5*sep, xl, x3f, I_0, r_0)) +
-                         (A2(x1f-0.5*sep, xr, x3f, I_0, r_0) +
-                         A2(x1f+0.5*sep, xr, x3f, I_0, r_0)));
+      a2(m,k,j,i) = 0.5*((A2(x1f - center_m, xl, x3f, I_0, r_0) +
+                          A2(x1f - center_p, xl, x3f, I_0, r_0)) +
+                         (A2(x1f - center_m, xr, x3f, I_0, r_0) +
+                          A2(x1f - center_p, xr, x3f, I_0, r_0)));
     }
   });
 


### PR DESCRIPTION
This small change adds two additional parameters to the ```<problem>``` block: the component masses ```M1``` and ```M2```. These are used to compare the positions based on the fact, that the COM is at the grid origin. These adjusted positions are then used to adjust the positions in the ```CompactObjectTracker``` and to get the position of the magnetic field right. GR-Athena++ uses a different approach: they construct additional Lorene interpolators for the +x and -x axis and then iteratively search for the position of the maximum density. The position of the maximum density in that case is dictated by the number of interpolation points, which I think is not the best approach as it can add small errors. Here, the gravitational masses are known and Lorene always treats the second star as the second one, so there should be no issue. Attached is a low resolution example for a system with M1=1.35 and M2=1.85, so the shift becomes evident enough. The red crosses are placed at plus/minus half the separation as originally done in Lorene. Without the correction, the magnetic field is slightly off from the NS center.
<img width="1600" height="1200" alt="magID_lorene_noshift" src="https://github.com/user-attachments/assets/8ce1631c-37ea-4982-8fca-3598633a8e63" />
<img width="1600" height="1200" alt="magID_lorene_shift" src="https://github.com/user-attachments/assets/9fa94354-7fc9-455e-a26c-253f462486fc" />
