### PR TITLE
Fix memory leak in particles MPI communication (#716)

### DIFF
--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -254,10 +254,17 @@ particles::ParticlesBoundaryValues::ParticlesBoundaryValues(
   // create unique communicator for particles
   MPI_Comm_dup(MPI_COMM_WORLD, &mpi_comm_part);
 #endif
+#if MPI_PARALLEL_ENABLED
+  MPI_Type_contiguous(3, MPI_INT, &mpi_ituple);
+  MPI_Type_commit(&mpi_ituple);
+#endif
 }
 
 //----------------------------------------------------------------------------------------
 // destructor
 
 particles::ParticlesBoundaryValues::~ParticlesBoundaryValues() {
+#if MPI_PARALLEL_ENABLED
+  MPI_Type_free(&mpi_ituple);
+#endif
 }

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -267,6 +267,7 @@ class ParticlesBoundaryValues {
   std::vector<MPI_Request> rrecv_req, rsend_req;  // vectors of requests for Reals
   std::vector<MPI_Request> irecv_req, isend_req;  // vectors of requests for ints
   MPI_Comm mpi_comm_part;                       // unique MPI communicators for particles
+  MPI_Datatype mpi_ituple;
 #endif
 
   //functions

--- a/src/bvals/bvals_part.cpp
+++ b/src/bvals/bvals_part.cpp
@@ -233,10 +233,6 @@ TaskStatus ParticlesBoundaryValues::CountSendsAndRecvs() {
     sends_allranks[n + nsends_displ[global_variable::my_rank]] = sends_thisrank[n];
   }
 
-  // Share tuples using MPI derived data type for tuple of 3*int
-  MPI_Datatype mpi_ituple;
-  MPI_Type_contiguous(3, MPI_INT, &mpi_ituple);
-  MPI_Type_commit(&mpi_ituple);
   MPI_Allgatherv(MPI_IN_PLACE, nsends_eachrank[global_variable::my_rank],
                    mpi_ituple, sends_allranks.data(), nsends_eachrank.data(),
                    nsends_displ.data(), mpi_ituple, mpi_comm_part);


### PR DESCRIPTION
Fixes #716. Moved mpi_ituple creation to constructor/destructor to prevent memory leak.