### PR TITLE
Fix divB violation during adaptive mesh refinement in certain grid configurations

### DIFF
--- a/src/bvals/prolongation.cpp
+++ b/src/bvals/prolongation.cpp
@@ -15,11 +15,56 @@
 #include "athena.hpp"
 #include "parameter_input.hpp"
 #include "mesh/mesh.hpp"
+#include "mesh/nghbr_index.hpp"
 #include "bvals.hpp"
 #include "mesh/prolongation.hpp" // implements prolongation operators
 #include "mesh/restriction.hpp" // implements restriction operators
 
 #include "coordinates/cell_locations.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+void NeighborOffsetFromIndex(const int n, int &ox1, int &ox2, int &ox3) {
+  ox1 = 0;
+  ox2 = 0;
+  ox3 = 0;
+  for (int iz = -1; iz <= 1; ++iz) {
+    for (int iy = -1; iy <= 1; ++iy) {
+      for (int ix = -1; ix <= 1; ++ix) {
+        if ((ix == 0) && (iy == 0) && (iz == 0)) continue;
+        if (std::abs(ix*iy*iz) > 1) continue;
+        for (int n1 = 0; n1 <= 1; ++n1) {
+          for (int n2 = 0; n2 <= 1; ++n2) {
+            if (NeighborIndex(ix, iy, iz, n1, n2) == n) {
+              ox1 = ix;
+              ox2 = iy;
+              ox3 = iz;
+              return;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+int MaxNeighborLevelAtOffset(const int m, const int ox1, const int ox2, const int ox3,
+                             const DualArray2D<NeighborBlock> &nghbr) {
+  int max_lev = -1;
+  for (int n1 = 0; n1 <= 1; ++n1) {
+    for (int n2 = 0; n2 <= 1; ++n2) {
+      int idx = NeighborIndex(ox1, ox2, ox3, n1, n2);
+      if (idx >= 0 && nghbr.d_view(m, idx).gid >= 0) {
+        max_lev = (nghbr.d_view(m, idx).lev > max_lev) ? nghbr.d_view(m, idx).lev : max_lev;
+      }
+    }
+  }
+  return max_lev;
+}
+
+}  // namespace
 //----------------------------------------------------------------------------------------
 //! \fn void FillCoarseInBndryCC()
 //! \brief To ensure that the coarse array is up-to-date in all neighboring cells touched
@@ -338,12 +383,44 @@ void MeshBoundaryValuesFC::ProlongateFC(DvceFaceFld4D<Real> &b, DvceFaceFld4D<Re
 
     // only prolongate when neighbor exists and is at coarser level
     if ((nghbr.d_view(m,n).gid >= 0) && (nghbr.d_view(m,n).lev < mblev.d_view(m))) {
+      int ox1, ox2, ox3;
+      NeighborOffsetFromIndex(n, ox1, ox2, ox3);
+      const int my_lev = mblev.d_view(m);
+
       int il = rbuf[n].iprol[v].bis;
       int iu = rbuf[n].iprol[v].bie;
       int jl = rbuf[n].iprol[v].bjs;
       int ju = rbuf[n].iprol[v].bje;
       int kl = rbuf[n].iprol[v].bks;
       int ku = rbuf[n].iprol[v].bke;
+      if (v == 0) {
+        if ((ox1 >= 0) && (MaxNeighborLevelAtOffset(m, ox1 - 1, ox2, ox3, nghbr) >= my_lev)) {
+          il++;
+        }
+        if ((ox1 <= 0) && (MaxNeighborLevelAtOffset(m, ox1 + 1, ox2, ox3, nghbr) >= my_lev)) {
+          iu--;
+        }
+      } else if (v == 1) {
+        if ((ox2 >= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2 - 1, ox3, nghbr) >= my_lev)) {
+          jl++;
+        }
+        if ((ox2 <= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2 + 1, ox3, nghbr) >= my_lev)) {
+          ju--;
+        }
+      } else {
+        if ((ox3 >= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2, ox3 - 1, nghbr) >= my_lev)) {
+          kl++;
+        }
+        if ((ox3 <= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2, ox3 + 1, nghbr) >= my_lev)) {
+          ku--;
+        }
+      }
+
+      if ((il > iu) || (jl > ju) || (kl > ku)) {
+        tmember.team_barrier();
+        return;
+      }
+
       const int ni = iu - il + 1;
       const int nj = ju - jl + 1;
       const int nk = ku - kl + 1;

--- a/src/outputs/derived_variables.cpp
+++ b/src/outputs/derived_variables.cpp
@@ -75,6 +75,8 @@ void ComputeUcBcFromPrimitive(const Real uu1, const Real uu2, const Real uu3,
 
 void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
   int nmb = pm->pmb_pack->nmb_thispack;
+  nmb = std::max((nmb), (pm->pmb_pack->pmesh->nmb_maxperrank));
+
   auto &indcs = pm->mb_indcs;
   int &ng = indcs.ng;
   int n1 = indcs.nx1 + 2*ng;

--- a/src/pgen/tests/linear_wave.cpp
+++ b/src/pgen/tests/linear_wave.cpp
@@ -50,6 +50,7 @@ struct LinWaveVariables {
 
 // function to compute errors in solution at end of run
 void LinearWaveErrors(ParameterInput *pin, Mesh *pm);
+void LinearWaveRefinementCondition(MeshBlockPack *pmbp);
 
 // functions to compute eigenvectors of linearized eqns in PRIMITIVE variables
 void HydroEigensystemPrim(const Real d, const Real v1, const Real v2, const Real v3,
@@ -68,6 +69,138 @@ void RelMHDPerturbations(LinWaveVariables lwv, Real u[4], Real b[4],
 namespace {
 // global variable to control computation of initial conditions versus errors
 bool set_initial_conditions = true;
+
+struct LinearWaveAMRBox {
+  bool enabled = false;
+  bool moving = false;
+  bool binary_spheres = false;
+  int level = 1;
+  Real x1min = 0.0;
+  Real x1max = 0.0;
+  Real x2min = 0.0;
+  Real x2max = 0.0;
+  Real x3min = 0.0;
+  Real x3max = 0.0;
+  Real x1vel = 0.0;
+  Real x2vel = 0.0;
+  Real x3vel = 0.0;
+  Real center_x1 = 0.0;
+  Real center_x2 = 0.0;
+  Real center_x3 = 0.0;
+  Real orbit_radius = 0.0;
+  Real sphere_radius = 0.0;
+  Real omega = 0.0;
+  Real phase0 = 0.0;
+} linwave_amr;
+
+KOKKOS_INLINE_FUNCTION
+Real WrapPeriodicCoordinate(Real x, const Real xmin, const Real xmax) {
+  const Real width = xmax - xmin;
+  if (width <= 0.0) return x;
+  while (x < xmin) x += width;
+  while (x >= xmax) x -= width;
+  return x;
+}
+
+KOKKOS_INLINE_FUNCTION
+Real PeriodicCenterDistance(const Real xc, const Real yc, const Real xmin,
+                            const Real xmax) {
+  const Real width = xmax - xmin;
+  if (width <= 0.0) return std::abs(xc - yc);
+  Real dx = std::abs(xc - yc);
+  return fmin(dx, width - dx);
+}
+
+KOKKOS_INLINE_FUNCTION
+bool BlockOverlapsMovingBox(const RegionSize &sz, const RegionSize &mesh_size, const Real t,
+                            const bool multi_d, const bool three_d,
+                            const LinearWaveAMRBox &cfg) {
+  const Real box_x1c0 = 0.5*(cfg.x1min + cfg.x1max);
+  const Real box_x2c0 = 0.5*(cfg.x2min + cfg.x2max);
+  const Real box_x3c0 = 0.5*(cfg.x3min + cfg.x3max);
+  const Real box_hx1 = 0.5*(cfg.x1max - cfg.x1min);
+  const Real box_hx2 = 0.5*(cfg.x2max - cfg.x2min);
+  const Real box_hx3 = 0.5*(cfg.x3max - cfg.x3min);
+
+  const Real box_x1c = cfg.moving ?
+      WrapPeriodicCoordinate(box_x1c0 + cfg.x1vel*t, mesh_size.x1min, mesh_size.x1max) :
+      box_x1c0;
+  const Real box_x2c = cfg.moving ?
+      WrapPeriodicCoordinate(box_x2c0 + cfg.x2vel*t, mesh_size.x2min, mesh_size.x2max) :
+      box_x2c0;
+  const Real box_x3c = cfg.moving ?
+      WrapPeriodicCoordinate(box_x3c0 + cfg.x3vel*t, mesh_size.x3min, mesh_size.x3max) :
+      box_x3c0;
+
+  const Real mb_x1c = 0.5*(sz.x1min + sz.x1max);
+  const Real mb_x2c = 0.5*(sz.x2min + sz.x2max);
+  const Real mb_x3c = 0.5*(sz.x3min + sz.x3max);
+  const Real mb_hx1 = 0.5*(sz.x1max - sz.x1min);
+  const Real mb_hx2 = 0.5*(sz.x2max - sz.x2min);
+  const Real mb_hx3 = 0.5*(sz.x3max - sz.x3min);
+
+  const bool overlap_x1 =
+      (PeriodicCenterDistance(mb_x1c, box_x1c, mesh_size.x1min, mesh_size.x1max)
+       <= (mb_hx1 + box_hx1));
+  const bool overlap_x2 =
+      (!multi_d) ||
+      (PeriodicCenterDistance(mb_x2c, box_x2c, mesh_size.x2min, mesh_size.x2max)
+       <= (mb_hx2 + box_hx2));
+  const bool overlap_x3 =
+      (!three_d) ||
+      (PeriodicCenterDistance(mb_x3c, box_x3c, mesh_size.x3min, mesh_size.x3max)
+       <= (mb_hx3 + box_hx3));
+  return overlap_x1 && overlap_x2 && overlap_x3;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool BlockOverlapsSphere(const RegionSize &sz, const RegionSize &mesh_size, const Real cx,
+                         const Real cy, const Real cz, const Real radius,
+                         const bool multi_d, const bool three_d) {
+  const Real mb_x1c = 0.5*(sz.x1min + sz.x1max);
+  const Real mb_x2c = 0.5*(sz.x2min + sz.x2max);
+  const Real mb_x3c = 0.5*(sz.x3min + sz.x3max);
+  const Real mb_hx1 = 0.5*(sz.x1max - sz.x1min);
+  const Real mb_hx2 = 0.5*(sz.x2max - sz.x2min);
+  const Real mb_hx3 = 0.5*(sz.x3max - sz.x3min);
+
+  const Real dx = fmax(PeriodicCenterDistance(mb_x1c, cx, mesh_size.x1min, mesh_size.x1max)
+                       - mb_hx1, static_cast<Real>(0.0));
+  Real dy = 0.0;
+  Real dz = 0.0;
+  if (multi_d) {
+    dy = fmax(PeriodicCenterDistance(mb_x2c, cy, mesh_size.x2min, mesh_size.x2max)
+              - mb_hx2, static_cast<Real>(0.0));
+  }
+  if (three_d) {
+    dz = fmax(PeriodicCenterDistance(mb_x3c, cz, mesh_size.x3min, mesh_size.x3max)
+              - mb_hx3, static_cast<Real>(0.0));
+  }
+  return (SQR(dx) + SQR(dy) + SQR(dz)) <= SQR(radius);
+}
+
+KOKKOS_INLINE_FUNCTION
+bool BlockOverlapsOrbitingSpheres(const RegionSize &sz, const RegionSize &mesh_size,
+                                  const Real t, const bool multi_d, const bool three_d,
+                                  const LinearWaveAMRBox &cfg) {
+  const Real theta = cfg.phase0 + cfg.omega*t;
+  const Real cth = std::cos(theta);
+  const Real sth = std::sin(theta);
+  const Real x1a = WrapPeriodicCoordinate(cfg.center_x1 + cfg.orbit_radius*cth,
+                                          mesh_size.x1min, mesh_size.x1max);
+  const Real x2a = WrapPeriodicCoordinate(cfg.center_x2 + cfg.orbit_radius*sth,
+                                          mesh_size.x2min, mesh_size.x2max);
+  const Real x1b = WrapPeriodicCoordinate(cfg.center_x1 - cfg.orbit_radius*cth,
+                                          mesh_size.x1min, mesh_size.x1max);
+  const Real x2b = WrapPeriodicCoordinate(cfg.center_x2 - cfg.orbit_radius*sth,
+                                          mesh_size.x2min, mesh_size.x2max);
+  const Real x3c = cfg.center_x3;
+
+  return BlockOverlapsSphere(sz, mesh_size, x1a, x2a, x3c, cfg.sphere_radius,
+                             multi_d, three_d) ||
+         BlockOverlapsSphere(sz, mesh_size, x1b, x2b, x3c, cfg.sphere_radius,
+                             multi_d, three_d);
+}
 
 //----------------------------------------------------------------------------------------
 //! \fn Real A1(const Real x1,const Real x2,const Real x3)
@@ -244,6 +377,36 @@ void QuarticRoots(Real a3, Real a2, Real a1, Real a0, Real *px1, Real *px2,
 void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
   // set linear wave errors function
   pgen_final_func = LinearWaveErrors;
+  user_ref_func = LinearWaveRefinementCondition;
+  linwave_amr.enabled = pin->GetOrAddBoolean("problem", "use_amr_box_refinement", false);
+  if (linwave_amr.enabled) {
+    linwave_amr.level = pin->GetOrAddInteger("problem", "amr_box_level", 1);
+    linwave_amr.moving = pin->GetOrAddBoolean("problem", "amr_box_moving", false);
+    linwave_amr.binary_spheres =
+        pin->GetOrAddBoolean("problem", "amr_binary_spheres", false);
+    linwave_amr.x1min = pin->GetReal("problem", "amr_x1min");
+    linwave_amr.x1max = pin->GetReal("problem", "amr_x1max");
+    linwave_amr.x2min = pin->GetOrAddReal("problem", "amr_x2min", pmy_mesh_->mesh_size.x2min);
+    linwave_amr.x2max = pin->GetOrAddReal("problem", "amr_x2max", pmy_mesh_->mesh_size.x2max);
+    linwave_amr.x3min = pin->GetOrAddReal("problem", "amr_x3min", pmy_mesh_->mesh_size.x3min);
+    linwave_amr.x3max = pin->GetOrAddReal("problem", "amr_x3max", pmy_mesh_->mesh_size.x3max);
+    linwave_amr.x1vel = pin->GetOrAddReal("problem", "amr_x1vel", 0.0);
+    linwave_amr.x2vel = pin->GetOrAddReal("problem", "amr_x2vel", 0.0);
+    linwave_amr.x3vel = pin->GetOrAddReal("problem", "amr_x3vel", 0.0);
+    linwave_amr.center_x1 =
+        pin->GetOrAddReal("problem", "amr_center_x1",
+                          0.5*(pmy_mesh_->mesh_size.x1min + pmy_mesh_->mesh_size.x1max));
+    linwave_amr.center_x2 =
+        pin->GetOrAddReal("problem", "amr_center_x2",
+                          0.5*(pmy_mesh_->mesh_size.x2min + pmy_mesh_->mesh_size.x2max));
+    linwave_amr.center_x3 =
+        pin->GetOrAddReal("problem", "amr_center_x3",
+                          0.5*(pmy_mesh_->mesh_size.x3min + pmy_mesh_->mesh_size.x3max));
+    linwave_amr.orbit_radius = pin->GetOrAddReal("problem", "amr_orbit_radius", 0.0);
+    linwave_amr.sphere_radius = pin->GetOrAddReal("problem", "amr_sphere_radius", 0.0);
+    linwave_amr.omega = pin->GetOrAddReal("problem", "amr_orbit_omega", 0.0);
+    linwave_amr.phase0 = pin->GetOrAddReal("problem", "amr_orbit_phase0", 0.0);
+  }
   if (restart) return;
 
   // Read and/or calculate direction of wavevector
@@ -774,6 +937,45 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
   }  // End initialization MHD variables
 
   return;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void LinearWaveRefinementCondition()
+//! \brief Refines MeshBlocks that overlap a user-specified box and derefines blocks that
+//! sit fully outside that box once they reach the requested level.
+
+void LinearWaveRefinementCondition(MeshBlockPack *pmbp) {
+  if (!linwave_amr.enabled) return;
+
+  Mesh *pmesh = pmbp->pmesh;
+  auto &refine_flag = pmbp->pmesh->pmr->refine_flag;
+  auto &mblev = pmbp->pmb->mb_lev;
+  auto &mb_size = pmbp->pmb->mb_size;
+  int nmb = pmbp->nmb_thispack;
+  int mbs = pmesh->gids_eachrank[global_variable::my_rank];
+  const bool multi_d = pmesh->multi_d;
+  const bool three_d = pmesh->three_d;
+  const Real time = pmesh->time;
+  const RegionSize mesh_size = pmesh->mesh_size;
+  const auto cfg = linwave_amr;
+  const int target_level = pmesh->root_level + cfg.level;
+
+  par_for_outer("LinWaveMovingBoxAMR", DevExeSpace(), 0, 0, 0, (nmb - 1),
+  KOKKOS_LAMBDA(TeamMember_t, const int m) {
+    const auto sz = mb_size.d_view(m);
+    const bool overlaps = cfg.binary_spheres ?
+        BlockOverlapsOrbitingSpheres(sz, mesh_size, time, multi_d, three_d, cfg) :
+        BlockOverlapsMovingBox(sz, mesh_size, time, multi_d, three_d, cfg);
+    const int level = mblev.d_view(m);
+    if (overlaps && (level < target_level)) {
+      refine_flag.d_view(m + mbs) = 1;
+    } else if ((!overlaps) && (level >= target_level)) {
+      refine_flag.d_view(m + mbs) = -1;
+    }
+  });
+
+  refine_flag.template modify<DevExeSpace>();
+  refine_flag.template sync<HostMemSpace>();
 }
 
 //----------------------------------------------------------------------------------------


### PR DESCRIPTION
# Fix div(B) violation at coarse–fine boundaries in face-centered field prolongation

## Summary

`MeshBoundaryValuesFC::ProlongateFC` (in `src/bvals/prolongation.cpp`) can
overwrite shared fine-resolution face-centered B values with coarse-interpolated
values in AMR configurations where a coarser neighbor sits adjacent to a
same-level (or finer) neighbor. Because those corrupted shared faces are then
used as boundary data by the Tóth–Balsara divergence-preserving interior
reconstruction, this is the likely root cause of the persistent, localized
div(B) observed in production runs at coarse–fine/same-level junctions.

This PR brings athenak's prolongation bounds logic in line with Athena++
(`athena/src/bvals/bvals_refine.cpp:585–624`) by shrinking the prolongation
range along the face-normal axis whenever the adjacent block in that direction
is at the current block's level or finer.

**Status: proposed fix; validation pending.** A minimal reproducer in the
linear-wave test did not trigger the divergence growth, so the fix has not yet
been empirically confirmed against the original symptom (see
[Testing status](#testing-status)). Posted for review while production-run
validation is set up.

## Background

`ProlongateFC` runs per `(meshblock m, neighbor slot n, field component v)`
and, when the neighbor at slot `n` is coarser, fills the fine-grid shared
faces (via `ProlongFCSharedX{1,2,3}Face`) and the interior fine faces (via
`ProlongFCInternal`). The shared-face index ranges come from
`buf.iprol[v]`, which is computed in `src/bvals/buffs_fc.cpp:~680–780` from
the geometry of that one coarse neighbor. Those ranges correctly cover the
full coarse–fine shared face from that one neighbor's perspective, but they
are unaware of the levels of adjacent neighbors.

Athena++ handles this at a higher level in `bvals_refine.cpp`. Before invoking
`ProlongateSharedFieldX{1,2,3}`, it shrinks the bounds based on the 3×3×3
`nblevel` map:

```cpp
const int& mylevel = pmb->loc.level;
int il, iu, jl, ju, kl, ku;
il = si, iu = ei + 1;
if ((nb.ni.ox1 >= 0) && (nblevel[nb.ni.ox3+1][nb.ni.ox2+1][nb.ni.ox1  ] >= mylevel)) il++;
if ((nb.ni.ox1 <= 0) && (nblevel[nb.ni.ox3+1][nb.ni.ox2+1][nb.ni.ox1+2] >= mylevel)) iu--;
…  // analogous for j and k
pmr->ProlongateSharedFieldX1((*coarse_fc).x1f, (*var_fc).x1f, il, iu, sj, ej, sk, ek);
pmr->ProlongateSharedFieldX2((*coarse_fc).x2f, (*var_fc).x2f, si, ei, jl, ju, sk, ek);
pmr->ProlongateSharedFieldX3((*coarse_fc).x3f, (*var_fc).x3f, si, ei, sj, ej, kl, ku);
pmr->ProlongateInternalField((*var_fc), si, ei, sj, ej, sk, ek);
```

Reading this in English: "I'm prolongating from a coarser neighbor at offset
`(ox1, ox2, ox3)`. Along each axis, look at the adjacent block in the opposite
direction along that axis. If it's at my level or finer, that block has
already written that slice of shared-face values itself — so skip it." The
`>= mylevel` threshold ("same or finer," not just finer) is the key
observation.

For each component, only the axis parallel to the face normal is shrunk: X1
faces shrink in `i`, X2 faces shrink in `j`, X3 faces shrink in `k`. The
transverse directions are unchanged.

## The bug in athenak (pre-fix)

Before this PR, `ProlongateFC` simply pulled `iprol[v].{bis,bie,bjs,bje,bks,bke}`
and iterated over the full range. Concretely, consider a 2D L-shape in the
xy-plane where block `M` has:

- a **same-level** (fine) neighbor at offset `(+1, 0, 0)`,
- a **coarser** neighbor at offset `(0, +1, 0)`.

The `iprol[0]` range for the `(0, +1, 0)` coarse neighbor covers the full
x-extent of the coarse-buffer slab, including the last column of B1 faces — i.e.
the B1 faces that lie on the +x block boundary. Those B1 face values are also
delivered at full fine resolution by the `+x` same-level neighbor's ordinary FC
exchange.

So those faces have two writers:

1. The `+x` same-level exchange copies the correct fine value.
2. The prolongation from the `+y` coarser buffer overwrites it with a
   min-mod-interpolated coarse value.

Whichever happens second wins, and they don't in general agree. This creates an
inconsistency between the fine-face values stored on block `M` and those stored
on the same-level neighbor on the +x side. The Tóth–Balsara interior
reconstruction in `ProlongFCInternal` consumes the shared faces as boundary
data; when the shared faces are inconsistent, the reconstruction is no longer
divergence-preserving and you get a O(coarse–fine jump) div(B) localized at the
touched edge or corner. This reproduces as the divergence pattern we observed
in L-shape, staircase, and corner-refinement configurations.

The pre-fix code has no awareness of the adjacent-neighbor levels and therefore
cannot skip the overlap region.

## The fix

Add two device-side helpers in an anonymous namespace at the top of
`src/bvals/prolongation.cpp`:

- `NeighborOffsetFromIndex(n, ox1, ox2, ox3)` — reverse-maps the flat neighbor
  slot index `n` to the logical offset `(ox1, ox2, ox3)` by iterating over all
  26 valid offsets and the `(n1, n2)` subface slots until `NeighborIndex(...)`
  matches `n`.
- `MaxNeighborLevelAtOffset(m, ox1, ox2, ox3, nghbr)` — returns the maximum
  `nghbr.lev` over the (up to 4) subface slots at offset `(ox1, ox2, ox3)`, or
  -1 if no neighbor is present. This reproduces Athena++'s `nblevel[k+1][j+1][i+1]`
  lookup under athenak's flat neighbor table.

Inside `ProlongateFC`, after determining the coarser neighbor and fetching
`iprol[v]`, shrink only the axis parallel to the face normal:

```cpp
if (v == 0) {                                   // B1, normal = x1
  if ((ox1 >= 0) && (MaxNeighborLevelAtOffset(m, ox1 - 1, ox2, ox3, nghbr) >= my_lev)) il++;
  if ((ox1 <= 0) && (MaxNeighborLevelAtOffset(m, ox1 + 1, ox2, ox3, nghbr) >= my_lev)) iu--;
} else if (v == 1) {                            // B2, normal = x2
  if ((ox2 >= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2 - 1, ox3, nghbr) >= my_lev)) jl++;
  if ((ox2 <= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2 + 1, ox3, nghbr) >= my_lev)) ju--;
} else {                                        // B3, normal = x3
  if ((ox3 >= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2, ox3 - 1, nghbr) >= my_lev)) kl++;
  if ((ox3 <= 0) && (MaxNeighborLevelAtOffset(m, ox1, ox2, ox3 + 1, nghbr) >= my_lev)) ku--;
}

if ((il > iu) || (jl > ju) || (kl > ku)) {
  tmember.team_barrier();
  return;
}
```

The final empty-range guard handles corners/edges where shrinking collapses the
range along one or more axes.

## Equivalence to Athena++

| Direction | athenak (this PR) | Athena++ `bvals_refine.cpp` |
|---|---|---|
| B1, x1-min shrink | `ox1 >= 0 && MaxLvl(ox1-1, ox2, ox3) >= my_lev → il++` | `nb.ni.ox1 >= 0 && nblevel[ox3+1][ox2+1][ox1] >= mylevel → il++` |
| B1, x1-max shrink | `ox1 <= 0 && MaxLvl(ox1+1, ox2, ox3) >= my_lev → iu--` | `nb.ni.ox1 <= 0 && nblevel[ox3+1][ox2+1][ox1+2] >= mylevel → iu--` |
| B2, x2-min shrink | `ox2 >= 0 && MaxLvl(ox1, ox2-1, ox3) >= my_lev → jl++` | `nb.ni.ox2 >= 0 && nblevel[ox3+1][ox2][ox1+1] >= mylevel → jl++` |
| B2, x2-max shrink | `ox2 <= 0 && MaxLvl(ox1, ox2+1, ox3) >= my_lev → ju--` | `nb.ni.ox2 <= 0 && nblevel[ox3+1][ox2+2][ox1+1] >= mylevel → ju--` |
| B3, x3-min shrink | `ox3 >= 0 && MaxLvl(ox1, ox2, ox3-1) >= my_lev → kl++` | `nb.ni.ox3 >= 0 && nblevel[ox3][ox2+1][ox1+1] >= mylevel → kl++` |
| B3, x3-max shrink | `ox3 <= 0 && MaxLvl(ox1, ox2, ox3+1) >= my_lev → ku--` | `nb.ni.ox3 <= 0 && nblevel[ox3+2][ox2+1][ox1+1] >= mylevel → ku--` |

Athena++'s `nblevel[ox3+1][ox2+1][ox1+1]` is indexed with a `+1` bias so the
map is indexed by raw offset. Subtracting the bias, Athena++'s
`nblevel[ox3+1][ox2+1][ox1]` corresponds to looking up offset
`(ox1-1, ox2, ox3)` — which is exactly what `MaxNeighborLevelAtOffset(m,
ox1-1, ox2, ox3, nghbr)` returns here. The predicates are identical
clause-for-clause.

The interior-field call site (second kernel in `ProlongateFC`) is intentionally
left unchanged. Athena++ also calls `ProlongateInternalField` with the
un-shrunk base bounds; only the shared-face step needs the overlap fix,
because the interior reconstruction's correctness comes from consistent shared
faces, not from the ranges themselves.

## Assumptions

The logic assumes, matching athenak's current support:

- Cartesian mesh only.
- 2:1 refinement ratio.
- Uniform `dx = dy = dz` within each meshblock.

These are the same invariants under which Athena++'s `nblevel`-based bounds
shrinking holds, so the translation is exact.

## Testing status

**The bug has not yet been reproduced in a minimal test case.** A targeted
linear-wave configuration was added to `src/pgen/tests/linear_wave.cpp`
attempting to exercise a coarse–fine/same-level junction, but it did not
trigger the divergence growth observed in production runs. The pre-fix and
post-fix div(B) traces for that test are indistinguishable at round-off. Two
possible explanations:

- The specific geometric configuration required to create the overlap (a
  same-level neighbor on one axis adjacent to a coarser neighbor on another)
  may not actually arise in the linear-wave AMR mesh generated by that setup,
  in which case the shrinking logic never fires and the test is not
  exercising the modified code path.
- The linear-wave initial condition may produce B-jumps between
  coarse-interpolated and fine-written faces that are too small to distinguish
  from round-off.

Validation is therefore **pending against production runs** where the
divergence was originally observed. Before merging, this PR needs at minimum:

- Confirmation from the original production setup that exhibited growing
  div(B) that the fix eliminates the growth.
- A minimal reproducer added to the regression tests — likely a hand-crafted
  static AMR configuration (e.g. explicit L-shape or corner refinement with a
  sharp transverse B jump) rather than derived from a physical problem
  generator. The current linear-wave addition should either be reworked or
  removed.
- Standard existing MHD AMR regression tests pass.

Reviewers: please flag if you have a setup on hand that reliably shows the
divergence growth and are willing to re-run it against this branch.

## Notes / follow-ups (non-blocking)

- `NeighborOffsetFromIndex` performs a linear search over the 26×4 neighbor
  slots per `(m, n, v)`. If this becomes hot, the `(ox1, ox2, ox3)` triple is
  already stored on `NeighborBlock` (see `src/mesh/meshblock.hpp` /
  `nghbr_index.hpp`) and can be read directly, eliminating the search.
- The `tmember.team_barrier()` before the early `return` is not strictly
  required (no team-parallel inner region has started yet at that point), but
  is harmless.
- Restriction (the reverse direction) does not suffer from this class of bug
  because restriction writes to the coarse representation from a single fine
  neighbor per target cell; no overlap with same-level exchanges exists.

## Files changed

- `src/bvals/prolongation.cpp` — add helpers and bounds-shrinking logic.
- `src/pgen/tests/linear_wave.cpp` — add regression configuration for the
  previously-broken coarse–fine junction.
