### PR TITLE
Switch to hardcoded min/max rather than Kokkos::min/max

### DIFF
--- a/src/z4c/z4c_wave_extr.cpp
+++ b/src/z4c/z4c_wave_extr.cpp
@@ -47,8 +47,8 @@ Real fac(int n) {
 void swsh(Real * ylmR, Real * ylmI, int l, int m, Real theta, Real phi) {
   Real wignerd = 0;
   int k1,k2,k;
-  k1 = Kokkos::max(0, m-2);
-  k2 = Kokkos::min(l+m,l-2);
+  k1 = (m-2 > 0) ? m-2 : 0;
+  k2 = (l+m < l-2) ? l+m : l-2;
   for (k = k1; k<k2+1; ++k) {
     wignerd += pow((-1),k)*sqrt(fac(l+m)*fac(l-m)*fac(l+2)*fac(l-2))
       *pow(Kokkos::cos(theta/2.0),2*l+m-2-2*k)*pow(Kokkos::sin(theta/2.0),2*k+2-m)


### PR DESCRIPTION
I don't know why this is an issue, but apparently the `Kokkos::min` and `Kokkos::max` functions are broken on Apollo, at least in our version of Kokkos, which leads to junk waveforms. I did not catch this issue with #731 because I tested with `fmax` and `fmin`, then replaced them with `max` and `min` at the last minute when I realized I was working with integers.

The definitions inside Kokkos are perfectly sane, so I assume there's some weird bug hidden somewhere that causes broken implementations of `min` and `max` to exist inside the Kokkos namespace and supersede the templated Kokkos versions. I don't know if this is a bug inside Kokkos or Athena or a problem with the specific compiler I'm using.

Anyway, hard-coding the min/max calculations works fine. Hopefully this is the last time I have to fix this issue. Maybe this is some good motivation to write some sane unit tests for waveform extraction and other relatively intricate operations.