### PR TITLE
Conservatively adjust hmin inside C2P for tabulated EOS

### DIFF
--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -193,6 +193,9 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_initialized = true;
 
     m_min_h = std::numeric_limits<Real>::max();
+    int in_min;
+    int iy_min;
+    int it_min;
     // Compute minimum enthalpy
     for (int in = 0; in < m_nn; ++in) {
       Real const nb = exp2_(host_log_nb(in));
@@ -203,10 +206,48 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
           Real e = exp2_(host_table(ECLOGE,in,iy,it));
           Real p = exp2_(host_table(ECLOGP,in,iy,it));
           Real h = (e + p) / nb;
-          m_min_h = fmin(m_min_h, h);
+          if (h < m_min_h) {
+            m_min_h = h;
+            in_min = in;
+            iy_min = iy;
+            it_min = it;
+          }
         }
       }
     }
+    // Because the enthalpy is (e + P)/n (i.e., nonlinear), we cannot guarantee that the
+    // minimum at table points is actually the minimum allowed by the EOS once we
+    // interpolate between points. Finding the true minimum would require some sort of
+    // optimization algorithm, which is difficult because all the interpolation operations
+    // are on the GPU. However, we can compute a conservative lower bound on min_h by
+    // computing the derivative at the estimated minimum. It should have O(dlog n)
+    // behavior, so it should also be a conservative bound for the NQTs, which will have
+    // O((dlog n)^2) behavior.
+    //
+    // We estimate the minimum as h(n_k) - dlog n |dh/dn|_{n_k}, where we take the
+    // maximum of |dh/dn| using the left and right estimates.
+    Real loge = host_table(ECLOGE,in_min,iy_min,it_min);
+    Real logp = host_table(ECLOGP,in_min,iy_min,it_min);
+    Real nb = exp2_(host_log_nb(in_min));
+    Real e = exp2_(loge);
+    Real p = exp2_(logp);
+    Real loge_left = loge;
+    Real logp_left = logp;
+    if (in_min > 0) {
+      loge_left = host_table(ECLOGE,in_min-1,iy_min,it_min);
+      logp_left = host_table(ECLOGP,in_min-1,iy_min,it_min);
+    }
+    Real dhdn = Kokkos::fabs(((loge - loge_left)*m_id_log_nb - 1.0)*e +
+                             ((logp - logp_left)*m_id_log_nb - 1.0)*p)/nb;
+    Real loge_right = loge;
+    Real logp_right = logp;
+    if (in_min < m_nn-1) {
+      loge_right = host_table(ECLOGE,in_min+1,iy_min,it_min);
+      logp_right = host_table(ECLOGP,in_min+1,iy_min,it_min);
+    }
+    dhdn = Kokkos::fmax(Kokkos::fabs(((loge_right - loge)*m_id_log_nb - 1.0)*e +
+                        ((logp_right - logp)*m_id_log_nb - 1.0)*p)/nb, dhdn);
+    m_min_h -= dhdn/m_id_log_nb;
   } // if (m_initialized==false)
 }
 

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -237,10 +237,10 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
         Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-        Real e_over_n_min = fac_e*Kokkos::min(exp2_(min_log2_e_in)/nb,
+        Real e_over_n_min = fac_e*Kokkos::fmin(exp2_(min_log2_e_in)/nb,
                                          exp2_(min_log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-        Real p_over_n_min = fac_p*Kokkos::min(exp2_(min_log2_p_in)/nb,
+        Real p_over_n_min = fac_p*Kokkos::fmin(exp2_(min_log2_p_in)/nb,
                                          exp2_(min_log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
         m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -214,7 +214,7 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
                                   Kokkos::fabs(max_log2_e_inp1-min_log2_e_in)),
                      Kokkos::fmax(Kokkos::fabs(min_log2_e_inp1-max_log2_e_in),
                                   Kokkos::fabs(max_log2_e_inp1-max_log2_e_in)));
- 
+
         Real min_log2_p_in = Kokkos::fmin(host_table(ECLOGP,in,iy,it),
                                           host_table(ECLOGP,in,iy+1,it));
         Real max_log2_p_in = Kokkos::fmax(host_table(ECLOGP,in,iy,it),
@@ -230,17 +230,17 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
                                   Kokkos::fabs(max_log2_p_inp1-min_log2_p_in)),
                      Kokkos::fmax(Kokkos::fabs(min_log2_p_inp1-max_log2_p_in),
                                   Kokkos::fabs(max_log2_p_inp1-max_log2_p_in)));
- 
+
         Real k0 =  3.696e-3; // Exact number rounded up
         Real k1 = -9.709e-3; // Exact number rounded down
 
         Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
         Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-        Real e_over_n_min = fac_e*Kokkos::min(exp2_(min_log2_e_in)/nb, 
+        Real e_over_n_min = fac_e*Kokkos::min(exp2_(min_log2_e_in)/nb,
                                          exp2_(min_log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-        Real p_over_n_min = fac_p*Kokkos::min(exp2_(min_log2_p_in)/nb, 
+        Real p_over_n_min = fac_p*Kokkos::min(exp2_(min_log2_p_in)/nb,
                                          exp2_(min_log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
         m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -193,36 +193,44 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_initialized = true;
 
     m_min_h = std::numeric_limits<Real>::max();
-    // New form of bound based on properties of NQT functions and their 
+    // New form of bound based on properties of NQT functions and their
     // departure from 'true' log behaviour
     int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
     for (int in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
       for (int iy = 0; iy < m_ny-1; ++iy) {
-        Real min_log2_e_in = Kokkos::fmin(host_table(ECLOGE,in,iy,it),host_table(ECLOGE,in,iy+1,it));
-        Real max_log2_e_in = Kokkos::fmax(host_table(ECLOGE,in,iy,it),host_table(ECLOGE,in,iy+1,it));
+        Real min_log2_e_in = Kokkos::fmin(host_table(ECLOGE,in,iy,it),
+                                          host_table(ECLOGE,in,iy+1,it));
+        Real max_log2_e_in = Kokkos::fmax(host_table(ECLOGE,in,iy,it),
+                                          host_table(ECLOGE,in,iy+1,it));
 
-        Real min_log2_e_inp1 = Kokkos::fmin(host_table(ECLOGE,in+1,iy,it),host_table(ECLOGE,in+1,iy+1,it));
-        Real max_log2_e_inp1 = Kokkos::fmax(host_table(ECLOGE,in+1,iy,it),host_table(ECLOGE,in+1,iy+1,it));
+        Real min_log2_e_inp1 = Kokkos::fmin(host_table(ECLOGE,in+1,iy,it),
+                                            host_table(ECLOGE,in+1,iy+1,it));
+        Real max_log2_e_inp1 = Kokkos::fmax(host_table(ECLOGE,in+1,iy,it),
+                                            host_table(ECLOGE,in+1,iy+1,it));
 
         Real pow_e = Kokkos::fmax(
                      Kokkos::fmax(Kokkos::fabs(min_log2_e_inp1-min_log2_e_in),
                                   Kokkos::fabs(max_log2_e_inp1-min_log2_e_in)),
                      Kokkos::fmax(Kokkos::fabs(min_log2_e_inp1-max_log2_e_in),
                                   Kokkos::fabs(max_log2_e_inp1-max_log2_e_in)));
-        
-        Real min_log2_p_in = Kokkos::fmin(host_table(ECLOGP,in,iy,it),host_table(ECLOGP,in,iy+1,it));
-        Real max_log2_p_in = Kokkos::fmax(host_table(ECLOGP,in,iy,it),host_table(ECLOGP,in,iy+1,it));
+ 
+        Real min_log2_p_in = Kokkos::fmin(host_table(ECLOGP,in,iy,it),
+                                          host_table(ECLOGP,in,iy+1,it));
+        Real max_log2_p_in = Kokkos::fmax(host_table(ECLOGP,in,iy,it),
+                                          host_table(ECLOGP,in,iy+1,it));
 
-        Real min_log2_p_inp1 = Kokkos::fmin(host_table(ECLOGP,in+1,iy,it),host_table(ECLOGP,in+1,iy+1,it));
-        Real max_log2_p_inp1 = Kokkos::fmax(host_table(ECLOGP,in+1,iy,it),host_table(ECLOGP,in+1,iy+1,it));
+        Real min_log2_p_inp1 = Kokkos::fmin(host_table(ECLOGP,in+1,iy,it),
+                                            host_table(ECLOGP,in+1,iy+1,it));
+        Real max_log2_p_inp1 = Kokkos::fmax(host_table(ECLOGP,in+1,iy,it),
+                                            host_table(ECLOGP,in+1,iy+1,it));
 
         Real pow_p = Kokkos::fmax(
                      Kokkos::fmax(Kokkos::fabs(min_log2_p_inp1-min_log2_p_in),
                                   Kokkos::fabs(max_log2_p_inp1-min_log2_p_in)),
                      Kokkos::fmax(Kokkos::fabs(min_log2_p_inp1-max_log2_p_in),
                                   Kokkos::fabs(max_log2_p_inp1-max_log2_p_in)));
-        
+ 
         Real k0 =  3.696e-3; // Exact number rounded up
         Real k1 = -9.709e-3; // Exact number rounded down
 
@@ -230,10 +238,10 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
         Real e_over_n_min = fac_e*Kokkos::min(exp2_(min_log2_e_in)/nb, 
-                                              exp2_(min_log2_e_inp1)/exp2_(host_log_nb(in+1)));
+                                         exp2_(min_log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
         Real p_over_n_min = fac_p*Kokkos::min(exp2_(min_log2_p_in)/nb, 
-                                              exp2_(min_log2_p_inp1)/exp2_(host_log_nb(in+1)));
+                                         exp2_(min_log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
         m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
       }

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -243,7 +243,7 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real p_over_n_min = fac_p*Kokkos::min(exp2_(min_log2_p_in)/nb,
                                          exp2_(min_log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
-        m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
+        m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);
       }
     }
     if (m_min_h <= 0.0) {

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -248,6 +248,9 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     dhdn = Kokkos::fmax(Kokkos::fabs(((loge_right - loge)*m_id_log_nb - 1.0)*e +
                         ((logp_right - logp)*m_id_log_nb - 1.0)*p)/nb, dhdn);
     m_min_h -= dhdn/m_id_log_nb;
+    if (m_min_h <= 0.0) {
+      Kokkos::abort("There was a problem computing the minimum enthalpy in the table!");
+    }
   } // if (m_initialized==false)
 }
 

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -193,61 +193,51 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_initialized = true;
 
     m_min_h = std::numeric_limits<Real>::max();
-    int in_min;
-    int iy_min;
-    int it_min;
-    // Compute minimum enthalpy
-    for (int in = 0; in < m_nn; ++in) {
+    // New form of bound based on properties of NQT functions and their 
+    // departure from 'true' log behaviour
+    int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
+    for (int in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
-      for (int iy = 0; iy < m_ny; ++iy) {
-        for (int it = 0; it < m_nt; ++it) {
-          // This would use GPU memory, and we are currently on the CPU, so Enthalpy is
-          // hardcoded
-          Real e = exp2_(host_table(ECLOGE,in,iy,it));
-          Real p = exp2_(host_table(ECLOGP,in,iy,it));
-          Real h = (e + p) / nb;
-          if (h < m_min_h) {
-            m_min_h = h;
-            in_min = in;
-            iy_min = iy;
-            it_min = it;
-          }
-        }
+      for (int iy = 0; iy < m_ny-1; ++iy) {
+        Real min_log2_e_in = Kokkos::fmin(host_table(ECLOGE,in,iy,it),host_table(ECLOGE,in,iy+1,it));
+        Real max_log2_e_in = Kokkos::fmax(host_table(ECLOGE,in,iy,it),host_table(ECLOGE,in,iy+1,it));
+
+        Real min_log2_e_inp1 = Kokkos::fmin(host_table(ECLOGE,in+1,iy,it),host_table(ECLOGE,in+1,iy+1,it));
+        Real max_log2_e_inp1 = Kokkos::fmax(host_table(ECLOGE,in+1,iy,it),host_table(ECLOGE,in+1,iy+1,it));
+
+        Real pow_e = Kokkos::fmax(
+                     Kokkos::fmax(Kokkos::fabs(min_log2_e_inp1-min_log2_e_in),
+                                  Kokkos::fabs(max_log2_e_inp1-min_log2_e_in)),
+                     Kokkos::fmax(Kokkos::fabs(min_log2_e_inp1-max_log2_e_in),
+                                  Kokkos::fabs(max_log2_e_inp1-max_log2_e_in)));
+        
+        Real min_log2_p_in = Kokkos::fmin(host_table(ECLOGP,in,iy,it),host_table(ECLOGP,in,iy+1,it));
+        Real max_log2_p_in = Kokkos::fmax(host_table(ECLOGP,in,iy,it),host_table(ECLOGP,in,iy+1,it));
+
+        Real min_log2_p_inp1 = Kokkos::fmin(host_table(ECLOGP,in+1,iy,it),host_table(ECLOGP,in+1,iy+1,it));
+        Real max_log2_p_inp1 = Kokkos::fmax(host_table(ECLOGP,in+1,iy,it),host_table(ECLOGP,in+1,iy+1,it));
+
+        Real pow_p = Kokkos::fmax(
+                     Kokkos::fmax(Kokkos::fabs(min_log2_p_inp1-min_log2_p_in),
+                                  Kokkos::fabs(max_log2_p_inp1-min_log2_p_in)),
+                     Kokkos::fmax(Kokkos::fabs(min_log2_p_inp1-max_log2_p_in),
+                                  Kokkos::fabs(max_log2_p_inp1-max_log2_p_in)));
+        
+        Real k0 =  3.696e-3; // Exact number rounded up
+        Real k1 = -9.709e-3; // Exact number rounded down
+
+        Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
+        Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
+
+        Real e_over_n_min = fac_e*Kokkos::min(exp2_(min_log2_e_in)/nb, 
+                                              exp2_(min_log2_e_inp1)/exp2_(host_log_nb(in+1)));
+
+        Real p_over_n_min = fac_p*Kokkos::min(exp2_(min_log2_p_in)/nb, 
+                                              exp2_(min_log2_p_inp1)/exp2_(host_log_nb(in+1)));
+
+        m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
       }
     }
-    // Because the enthalpy is (e + P)/n (i.e., nonlinear), we cannot guarantee that the
-    // minimum at table points is actually the minimum allowed by the EOS once we
-    // interpolate between points. Finding the true minimum would require some sort of
-    // optimization algorithm, which is difficult because all the interpolation operations
-    // are on the GPU. However, we can compute a conservative lower bound on min_h by
-    // computing the derivative at the estimated minimum. It should have O(dlog n)
-    // behavior, so it should also be a conservative bound for the NQTs, which will have
-    // O((dlog n)^2) behavior.
-    //
-    // We estimate the minimum as h(n_k) - dlog n |dh/dn|_{n_k}, where we take the
-    // maximum of |dh/dn| using the left and right estimates.
-    Real loge = host_table(ECLOGE,in_min,iy_min,it_min);
-    Real logp = host_table(ECLOGP,in_min,iy_min,it_min);
-    Real nb = exp2_(host_log_nb(in_min));
-    Real e = exp2_(loge);
-    Real p = exp2_(logp);
-    Real loge_left = loge;
-    Real logp_left = logp;
-    if (in_min > 0) {
-      loge_left = host_table(ECLOGE,in_min-1,iy_min,it_min);
-      logp_left = host_table(ECLOGP,in_min-1,iy_min,it_min);
-    }
-    Real dhdn = Kokkos::fabs(((loge - loge_left)*m_id_log_nb - 1.0)*e +
-                             ((logp - logp_left)*m_id_log_nb - 1.0)*p)/nb;
-    Real loge_right = loge;
-    Real logp_right = logp;
-    if (in_min < m_nn-1) {
-      loge_right = host_table(ECLOGE,in_min+1,iy_min,it_min);
-      logp_right = host_table(ECLOGP,in_min+1,iy_min,it_min);
-    }
-    dhdn = Kokkos::fmax(Kokkos::fabs(((loge_right - loge)*m_id_log_nb - 1.0)*e +
-                        ((logp_right - logp)*m_id_log_nb - 1.0)*p)/nb, dhdn);
-    m_min_h -= Kokkos::numbers::ln2_v<Real>*dhdn/m_id_log_nb;
     if (m_min_h <= 0.0) {
       Kokkos::abort("There was a problem computing the minimum enthalpy in the table!");
     }

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -247,7 +247,7 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     }
     dhdn = Kokkos::fmax(Kokkos::fabs(((loge_right - loge)*m_id_log_nb - 1.0)*e +
                         ((logp_right - logp)*m_id_log_nb - 1.0)*p)/nb, dhdn);
-    m_min_h -= dhdn/m_id_log_nb;
+    m_min_h -= Kokkos::numbers::ln2_v<Real>*dhdn/m_id_log_nb;
     if (m_min_h <= 0.0) {
       Kokkos::abort("There was a problem computing the minimum enthalpy in the table!");
     }

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -132,21 +132,21 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real log2_e_in   = host_table(ECLOGE,in);
         Real log2_e_inp1 = host_table(ECLOGE,in+1);
         Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
- 
+
         Real log2_p_in   = host_table(ECLOGP,in);
         Real log2_p_inp1 = host_table(ECLOGP,in+1);
         Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
- 
+
         Real k0 =  3.696e-3; // Exact number rounded up
         Real k1 = -9.709e-3; // Exact number rounded down
 
         Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
         Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-        Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb, 
+        Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb,
                                              exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-        Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb, 
+        Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb,
                                              exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
         m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -128,29 +128,27 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
     for (int in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
-      for (int iy = 0; iy < m_ny-1; ++iy) {
-        Real log2_e_in   = host_table(ECLOGE,in);
-        Real log2_e_inp1 = host_table(ECLOGE,in+1);
-        Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
+      Real log2_e_in   = host_table(ECLOGE,in);
+      Real log2_e_inp1 = host_table(ECLOGE,in+1);
+      Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
+      
+      Real log2_p_in   = host_table(ECLOGP,in);
+      Real log2_p_inp1 = host_table(ECLOGP,in+1);
+      Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
+      
+      Real k0 =  3.696e-3; // Exact number rounded up
+      Real k1 = -9.709e-3; // Exact number rounded down
 
-        Real log2_p_in   = host_table(ECLOGP,in);
-        Real log2_p_inp1 = host_table(ECLOGP,in+1);
-        Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
+      Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
+      Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-        Real k0 =  3.696e-3; // Exact number rounded up
-        Real k1 = -9.709e-3; // Exact number rounded down
+      Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb, 
+                                            exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-        Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
-        Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
+      Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb, 
+                                            exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
-        Real e_over_n_min = fac_e*Kokkos::fmin(exp2_(log2_e_in)/nb,
-                                             exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
-
-        Real p_over_n_min = fac_p*Kokkos::fmin(exp2_(log2_p_in)/nb,
-                                             exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
-
-        m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);
-      }
+      m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
     }
 
     if (m_min_h <= 0.0) {

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -131,11 +131,11 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
       Real log2_e_in   = host_table(ECLOGE,in);
       Real log2_e_inp1 = host_table(ECLOGE,in+1);
       Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
- 
+
       Real log2_p_in   = host_table(ECLOGP,in);
       Real log2_p_inp1 = host_table(ECLOGP,in+1);
       Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
- 
+
       Real k0 =  3.696e-3; // Exact number rounded up
       Real k1 = -9.709e-3; // Exact number rounded down
 
@@ -148,7 +148,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
       Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb,
                                             exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
-      m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
+      m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);
     }
 
     if (m_min_h <= 0.0) {

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -149,7 +149,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb,
                                              exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
-        m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
+        m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);
       }
     }
 

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -123,7 +123,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_initialized = true;
 
     m_min_h = std::numeric_limits<Real>::max();
-    // New form of bound based on properties of NQT functions and their 
+    // New form of bound based on properties of NQT functions and their
     // departure from 'true' log behaviour
     int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
     for (int in = 0; in < m_nn-1; ++in) {
@@ -132,11 +132,11 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real log2_e_in   = host_table(ECLOGE,in);
         Real log2_e_inp1 = host_table(ECLOGE,in+1);
         Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
-        
+ 
         Real log2_p_in   = host_table(ECLOGP,in);
         Real log2_p_inp1 = host_table(ECLOGP,in+1);
         Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
-        
+ 
         Real k0 =  3.696e-3; // Exact number rounded up
         Real k1 = -9.709e-3; // Exact number rounded down
 
@@ -144,10 +144,10 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
         Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb, 
-                                              exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
+                                             exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
         Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb, 
-                                              exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
+                                             exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
         m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
       }

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -142,10 +142,10 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
       Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
       Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-      Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb,
+      Real e_over_n_min = fac_e*Kokkos::fmin(exp2_(log2_e_in)/nb,
                                             exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-      Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb,
+      Real p_over_n_min = fac_p*Kokkos::fmin(exp2_(log2_p_in)/nb,
                                             exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
       m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -123,6 +123,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_initialized = true;
 
     m_min_h = std::numeric_limits<Real>::max();
+    int in_min;
     // Compute minimum enthalpy
     for (int in = 0; in < m_nn; ++in) {
       Real const nb = exp2_(host_log_nb(in));
@@ -131,7 +132,46 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
       Real e = exp2_(host_table(ECLOGE,in));
       Real p = exp2_(host_table(ECLOGP,in));
       Real h = (e + p) / nb;
-      m_min_h = fmin(m_min_h, h);
+      if (h < m_min_h) {
+        m_min_h = h;
+        in_min = in;
+      }
+    }
+    // Because the enthalpy is (e + P)/n (i.e., nonlinear), we cannot guarantee that the
+    // minimum at table points is actually the minimum allowed by the EOS once we
+    // interpolate between points. Finding the true minimum would require some sort of
+    // optimization algorithm, which is difficult because all the interpolation operations
+    // are on the GPU. However, we can compute a conservative lower bound on min_h by
+    // computing the derivative at the estimated minimum. It should have O(dlog n)
+    // behavior, so it should also be a conservative bound for the NQTs, which will have
+    // O((dlog n)^2) behavior.
+    //
+    // We estimate the minimum as h(n_k) - dlog n |dh/dn|_{n_k}, where we take the
+    // maximum of |dh/dn| using the left and right estimates.
+    Real loge = host_table(ECLOGE,in_min);
+    Real logp = host_table(ECLOGP,in_min);
+    Real nb = exp2_(host_log_nb(in_min));
+    Real e = exp2_(loge);
+    Real p = exp2_(logp);
+    Real loge_left = loge;
+    Real logp_left = logp;
+    if (in_min > 0) {
+      loge_left = host_table(ECLOGE,in_min-1);
+      logp_left = host_table(ECLOGP,in_min-1);
+    }
+    Real dhdn = Kokkos::fabs(((loge - loge_left)*m_id_log_nb - 1.0)*e +
+                             ((logp - logp_left)*m_id_log_nb - 1.0)*p)/nb;
+    Real loge_right = loge;
+    Real logp_right = logp;
+    if (in_min < m_nn-1) {
+      loge_right = host_table(ECLOGE,in_min+1);
+      logp_right = host_table(ECLOGP,in_min+1);
+    }
+    dhdn = Kokkos::fmax(Kokkos::fabs(((loge_right - loge)*m_id_log_nb - 1.0)*e +
+                        ((logp_right - logp)*m_id_log_nb - 1.0)*p)/nb, dhdn);
+    m_min_h -= dhdn/m_id_log_nb;
+    if (m_min_h <= 0.0) {
+      Kokkos::abort("There was a problem computing the minimum enthalpy in the table!");
     }
   } // if (m_initialized==false)
 }

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -131,21 +131,21 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
       Real log2_e_in   = host_table(ECLOGE,in);
       Real log2_e_inp1 = host_table(ECLOGE,in+1);
       Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
-      
+ 
       Real log2_p_in   = host_table(ECLOGP,in);
       Real log2_p_inp1 = host_table(ECLOGP,in+1);
       Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
-      
+ 
       Real k0 =  3.696e-3; // Exact number rounded up
       Real k1 = -9.709e-3; // Exact number rounded down
 
       Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
       Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-      Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb, 
+      Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb,
                                             exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-      Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb, 
+      Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb,
                                             exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
       m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -143,10 +143,10 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
         Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
         Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
 
-        Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb,
+        Real e_over_n_min = fac_e*Kokkos::fmin(exp2_(log2_e_in)/nb,
                                              exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
 
-        Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb,
+        Real p_over_n_min = fac_p*Kokkos::fmin(exp2_(log2_p_in)/nb,
                                              exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
 
         m_min_h = Kokkos::fmin(m_min_h,e_over_n_min+p_over_n_min);

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -123,53 +123,36 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_initialized = true;
 
     m_min_h = std::numeric_limits<Real>::max();
-    int in_min;
-    // Compute minimum enthalpy
-    for (int in = 0; in < m_nn; ++in) {
+    // New form of bound based on properties of NQT functions and their 
+    // departure from 'true' log behaviour
+    int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
+    for (int in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
-      // This would use GPU memory, and we are currently on the CPU, so Enthalpy is
-      // hardcoded
-      Real e = exp2_(host_table(ECLOGE,in));
-      Real p = exp2_(host_table(ECLOGP,in));
-      Real h = (e + p) / nb;
-      if (h < m_min_h) {
-        m_min_h = h;
-        in_min = in;
+      for (int iy = 0; iy < m_ny-1; ++iy) {
+        Real log2_e_in   = host_table(ECLOGE,in);
+        Real log2_e_inp1 = host_table(ECLOGE,in+1);
+        Real pow_e = Kokkos::fabs(log2_e_inp1-log2_e_in);
+        
+        Real log2_p_in   = host_table(ECLOGP,in);
+        Real log2_p_inp1 = host_table(ECLOGP,in+1);
+        Real pow_p = Kokkos::fabs(log2_p_inp1-log2_p_in);
+        
+        Real k0 =  3.696e-3; // Exact number rounded up
+        Real k1 = -9.709e-3; // Exact number rounded down
+
+        Real fac_e = (1-k0)*Kokkos::exp2(pow_e*k1); // N.B. not exp2_
+        Real fac_p = (1-k0)*Kokkos::exp2(pow_p*k1);
+
+        Real e_over_n_min = fac_e*Kokkos::min(exp2_(log2_e_in)/nb, 
+                                              exp2_(log2_e_inp1)/exp2_(host_log_nb(in+1)));
+
+        Real p_over_n_min = fac_p*Kokkos::min(exp2_(log2_p_in)/nb, 
+                                              exp2_(log2_p_inp1)/exp2_(host_log_nb(in+1)));
+
+        m_min_h = Kokkos::min(m_min_h,e_over_n_min+p_over_n_min);
       }
     }
-    // Because the enthalpy is (e + P)/n (i.e., nonlinear), we cannot guarantee that the
-    // minimum at table points is actually the minimum allowed by the EOS once we
-    // interpolate between points. Finding the true minimum would require some sort of
-    // optimization algorithm, which is difficult because all the interpolation operations
-    // are on the GPU. However, we can compute a conservative lower bound on min_h by
-    // computing the derivative at the estimated minimum. It should have O(dlog n)
-    // behavior, so it should also be a conservative bound for the NQTs, which will have
-    // O((dlog n)^2) behavior.
-    //
-    // We estimate the minimum as h(n_k) - dlog n |dh/dn|_{n_k}, where we take the
-    // maximum of |dh/dn| using the left and right estimates.
-    Real loge = host_table(ECLOGE,in_min);
-    Real logp = host_table(ECLOGP,in_min);
-    Real nb = exp2_(host_log_nb(in_min));
-    Real e = exp2_(loge);
-    Real p = exp2_(logp);
-    Real loge_left = loge;
-    Real logp_left = logp;
-    if (in_min > 0) {
-      loge_left = host_table(ECLOGE,in_min-1);
-      logp_left = host_table(ECLOGP,in_min-1);
-    }
-    Real dhdn = Kokkos::fabs(((loge - loge_left)*m_id_log_nb - 1.0)*e +
-                             ((logp - logp_left)*m_id_log_nb - 1.0)*p)/nb;
-    Real loge_right = loge;
-    Real logp_right = logp;
-    if (in_min < m_nn-1) {
-      loge_right = host_table(ECLOGE,in_min+1);
-      logp_right = host_table(ECLOGP,in_min+1);
-    }
-    dhdn = Kokkos::fmax(Kokkos::fabs(((loge_right - loge)*m_id_log_nb - 1.0)*e +
-                        ((logp_right - logp)*m_id_log_nb - 1.0)*p)/nb, dhdn);
-    m_min_h -= dhdn/m_id_log_nb;
+
     if (m_min_h <= 0.0) {
       Kokkos::abort("There was a problem computing the minimum enthalpy in the table!");
     }


### PR DESCRIPTION
The RePrimAnd C2P algorithm brackets the root based on the minimum specific enthalpy in the EOS. This is easy to compute analytically if the equation of state is known analytically, but this is not the case for a tabulated EOS. In these cases, we manually search the table for the point with the minimum enthalpy and use that. However, we directly compute the enthalpy as
```math
\begin{equation}
h(n,T,Y) = \frac{e(n,T,Y) + P(n,T,Y)}{n},
\end{equation}
```
where $\log e$ and $\log P$ are linearly interpolated off the table as functions of $\log n$, $\log T$, and $Y$. Therefore, $h$ is not a linear function between table points, and the true minimum can lie between table points rather than at table points. This can lead to errors with the primitive recovery routine if $n$ falls into this region because the root is no longer bracketed. Usually these points are close to atmosphere, so they have don't have a significant effect on the evolution, but the errors are obnoxious and can obscure more serious problems.

Generally this is not an issue for log-based tables, but NQT tables exhibit this issue frequently.

The correct way to fix this is to solve a minimization problem via gradient descent or a quasi-Newton method. For a variety of reasons not worth describing here, this is a bit of a mess, and we would still need to apply a downward perturbation from the true minimum to avoid floating-point equality issues. Peter has implemented an alternate fix to compute a conservative lower bound on $h$ which can be used instead. The idea is as follows:
1. Assume that the minimum enthalpy occurs for the minimum temperature. This is likely true from a thermodynamic perspective. If it isn't, the logic is simple enough to adjust.
2. For each cell between $n_{b,i}$ and $n_{b,i+1}$, compute the minimum energy and pressure along the $Y_e$ axis for both interfaces.
3. Compute scaling factors $k_p$ and $k_e$ from error estimates for the NQT interpolation between those interfaces.
4. For both $P/n_b$ and $e/n_b$, select the lowest interface value, then scale it by $k_p$ and $k_e$, i.e., $k_{p,e}\min((p_i,e_i)/n_{b,i},(p_{i+1},e_{i+1})/n_{b,i+1})$.
5. Use those to compute the minimum specific enthalpy.
6. Repeat for all cells.

Typically this adjustment is very small. For SFHo with NQTs, for example, $\min h \approx 930.6~\mathrm{MeV}$, and this estimate undershoots it slightly at ${\sim}926~\mathrm{MeV}$, or about a 0.5% error.