### PR TITLE
feat: allow `run_test_suit.py --test` to execute multiple tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # build directories
 build*/
+__pycache__
+
+# Temporary testing files
+tst/test_log.txt
 
 # Athena output files
 *.tab

--- a/tst/run_test_suite.py
+++ b/tst/run_test_suite.py
@@ -17,7 +17,9 @@ Notes:
   - Scripts that run tests on GPU must have '_gpu' in name
   - For more information, check online automatic testing wiki page.
 """
+
 import os
+import pathlib
 import sys
 import pytest
 import argparse
@@ -48,6 +50,26 @@ def test(args):
         sys.exit(exit_code)
 
 
+def verify_test_files(test_paths):
+    """Determine what types of test are in test_paths"""
+    test_types = {"cpu": False, "mpicpu": False, "gpu": False}
+    for entry in test_paths:
+        path = pathlib.Path(entry)
+        if path.is_file():
+            files = [path]
+        elif path.is_dir():
+            files = list(path.rglob("*.py"))
+        else:
+            raise RuntimeError("{path} does not exist.")
+
+        for f in files:
+            for suffix in ["cpu", "mpicpu", "gpu"]:
+                if suffix in str(f):
+                    test_types[suffix] = True
+
+    return test_types
+
+
 # Set up argument parser
 parser = argparse.ArgumentParser(description="Run AthenaK test suite.")
 parser.add_argument(
@@ -64,7 +86,17 @@ parser.add_argument(
 parser.add_argument(
     "--gpu", nargs="*", help="Run test on GPU. Can add optional cmake arguments."
 )
-parser.add_argument("--test", type=str, help="Run a specific test by name.")
+parser.add_argument(
+    "--test",
+    nargs="+",
+    help=(
+        "Run a specific test or group of tests by name. You can specify a space"
+        " seperated list of python test files or directories and all the tests "
+        "specified and in the directories will run. If you also specify --gpu, "
+        "--cpu, or --mpicpu then only tests that match will run, you can specify "
+        "multiple"
+    ),
+)
 
 
 args = parser.parse_args()
@@ -81,36 +113,45 @@ if args.style:
     test(["test_suite/style"])
 
 original_dir = os.getcwd()
-tests = "test_suite/"
+tests = ["test_suite/"]
 
 if args.test is not None:
-    tests = args.test
-    for suffix in ["cpu", "mpicpu", "gpu"]:
-        if "_" + suffix in tests:
-            if getattr(args, suffix) is None:
-                setattr(args, suffix, [])
-        else:
-            setattr(args, suffix, None)
+    tests = list(args.test)
 
-    if "_cpu" not in tests and "_mpicpu" not in tests and "_gpu" not in tests:
-        print(
-            "Invalid test name. Please ensure it contains '_cpu', '_mpicpu', or '_gpu'."
-        )
-        sys.exit(1)
+    runnable_types = verify_test_files(tests)
 
-tests = os.path.abspath(tests)
+    # If a specific type of test specified then verify that there are tests to run
+    if args.cpu is not None and not runnable_types["cpu"]:
+        raise RuntimeError(f"No CPU tests were found in {tests} when requested.")
+    if args.mpicpu is not None and not runnable_types["mpicpu"]:
+        raise RuntimeError(f"No MPI-CPU tests were found in {tests} when requested.")
+    if args.gpu is not None and not runnable_types["gpu"]:
+        raise RuntimeError(f"No GPU tests were found in {tests} when requested.")
+
+    # If no test types were specified then determine the types that needs to run
+    if args.cpu is None and args.mpicpu is None and args.gpu is None:
+        for key in runnable_types:
+            if runnable_types[key]:
+                setattr(args, key, [])
+
+    if args.cpu is None and args.mpicpu is None and args.gpu is None:
+        raise RuntimeError("{test} does not contain any valid test files.")
+
+tests = [os.path.abspath(p) for p in tests]
 
 if args.cpu is not None:
     testutils.clean_make(flags=cmake_flags(args.cpu, []))
-    test([tests, "-k", "_cpu"])  # run all scripts with _cpu in name
+    test(tests + ["-k", "_cpu"])  # run all scripts with _cpu in name
+    os.chdir(original_dir)
 
 if args.mpicpu is not None:
     testutils.clean_make(flags=cmake_flags(args.mpicpu, ["-D", "Athena_ENABLE_MPI=ON"]))
-    test([tests, "-k", "_mpicpu"])  # run all scripts with _mpicpu in name
+    test(tests + ["-k", "_mpicpu"])  # run all scripts with _mpicpu in name
+    os.chdir(original_dir)
 
 if args.gpu is not None:
     testutils.clean_make(flags=cmake_flags(args.gpu, ["-D", "Kokkos_ENABLE_CUDA=On"]))
-    test([tests, "-k", "_gpu"])  # run all scripts with _gpu in name
+    test(tests + ["-k", "_gpu"])  # run all scripts with _gpu in name
+    os.chdir(original_dir)
 
-os.chdir(original_dir)
 testutils.clean()

--- a/tst/test_suite/testutils.py
+++ b/tst/test_suite/testutils.py
@@ -60,7 +60,7 @@ def run_command(command: List[str], text: bool = False) -> bool:
     return process.returncode == 0
 
 
-def cmake(flags: List[str] = [], **kwargs) -> bool:
+def cmake(flags: List[str] = None, **kwargs) -> bool:
     """
     Runs the CMake command to configure the build system.
 
@@ -74,6 +74,9 @@ def cmake(flags: List[str] = [], **kwargs) -> bool:
     Raises:
         RuntimeError: If the CMake command fails.
     """
+    if flags is None:
+        flags = []
+
     original_dir = os.getcwd()
     try:
         os.chdir(ATHENAK_PATH)
@@ -113,7 +116,7 @@ def make(threads: int = os.cpu_count(), **kwargs) -> bool:
     return True
 
 
-def run(inputfile: str, flags=[], **kwargs) -> bool:
+def run(inputfile: str, flags=None, **kwargs) -> bool:
     """
     Executes a test case using the AthenaK binary.
 
@@ -128,6 +131,9 @@ def run(inputfile: str, flags=[], **kwargs) -> bool:
     Raises:
         AssertionError: If the test case execution fails.
     """
+    if flags is None:
+        flags = []
+
     command = ["./athena", "-i", inputfile] + flags
     if not run_command(command, **kwargs):
         logging.error(f"Failed to execute {inputfile} with flags {flags}")
@@ -136,7 +142,7 @@ def run(inputfile: str, flags=[], **kwargs) -> bool:
 
 
 def mpi_run(
-    inputfile: str, flags=[], threads: int = min(16, os.cpu_count()), **kwargs
+    inputfile: str, flags=None, threads: int = min(16, os.cpu_count()), **kwargs
 ) -> bool:
     """
     Executes a test case using the AthenaK binary with MPI support.
@@ -153,6 +159,10 @@ def mpi_run(
     Raises:
         AssertionError: If the test case execution fails.
     """
+
+    if flags is None:
+        flags = []
+
     command = ["mpirun", "-np", str(threads), "./athena", "-i", inputfile] + flags
     if not run_command(command, **kwargs):
         logging.error(


### PR DESCRIPTION
## Summary

The primary goal here is to be able to do something like `python run_test_suite --test test_suit/chemistry` and have it run all the chemistry tests. While implementing this a few other features came for free or with minor additions.

- You can now specify multiple test types like `run_test_suite.py --cpu --gpu` and it will run all CPU and GPU tests sequentially.
- You can pass a list of arguments to `--test` and it will run all the tests specified or in the specified directories recursively
  - You can tell it to only run a specific subset of the tests by also specifying some combination of `--cpu`, `--gpu`, and `--mpicpu` so if you only want to run the CPU tests in `nr` and `gr` then you can write `run_test_suite.py --tests test_suite/nr test_suite/gr --cpu`

Other minor changes:
- Added `__pycache__` to `.gitignore`
- Removed mutable default arguments in `testutils.py`. Mutable default arguments in python have a host of issues due to them saving arguments between invocations and were the primary reason why we couldn't run multiple test types in one invocation.


## Proposed Changes to the Wiki

This change requires updating the wiki, here's my proposed updated version of the Automatic Tests page; I'll add it once this PR is merged

[AutoTest.md](https://github.com/user-attachments/files/27640808/AutoTest.md)
