### PR TITLE
Modified energy limiting for PrimitiveSolver

### DIFF
--- a/src/eos/primitive-solver/eos_compose.hpp
+++ b/src/eos/primitive-solver/eos_compose.hpp
@@ -92,7 +92,7 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
     assert (m_initialized);
     if (n < min_n) {
       return min_T;
-    } else if (e <= MinimumEnergy(n, Y)) {
+    } else if (e <= 0.0) {
       return min_T;
     }
     Real log_e = log2_(e);

--- a/src/eos/primitive-solver/eos_compose.hpp
+++ b/src/eos/primitive-solver/eos_compose.hpp
@@ -481,7 +481,8 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
     Real lthi = m_log_t[ihi];
     Real ltlo = m_log_t[ilo];
 
-    Real lt = m_log_t[ilo] - flo*(lthi - ltlo)/(fhi - flo);
+    //Real lt = m_log_t[ilo] - flo*(lthi - ltlo)/(fhi - flo);
+    Real lt = (ltlo*fhi - lthi*flo)/(fhi - flo);
     return exp2_(lt);
   }
 

--- a/src/eos/primitive-solver/primitive_solver.hpp
+++ b/src/eos/primitive-solver/primitive_solver.hpp
@@ -103,21 +103,21 @@ class PrimitiveSolver {
       //const Real rbarsq = rsq*xsq + (mux + muxsq)*rbsq;
       const Real rbarsq = x*(rsq*x + mu*(x + 1.0)*rbsq);
       //const Real qbar = q - 0.5*bsq - 0.5*musq*xsq*(bsq*rsq - rbsq);
-      const Real qbar = q - 0.5*bsq - 0.5*musq*xsq*fma(bsq, rsq, -rbsq);
+      const Real qbar = q - 0.5*bsq - 0.5*musq*xsq*Kokkos::fma(bsq, rsq, -rbsq);
       const Real mb = peos->GetBaryonMass();
 
       // Now we can estimate the velocity.
       //const Real v_max = peos->GetMaxVelocity();
       const Real h_min = peos->GetMinimumEnthalpy();
-      const Real vsq_max = fmin(rsq/(h_min*h_min + rsq),
+      const Real vsq_max = Kokkos::fmin(rsq/(h_min*h_min + rsq),
                                     peos->GetMaxVelocity()*peos->GetMaxVelocity());
-      const Real vhatsq = fmin(musq*rbarsq, vsq_max);
+      const Real vhatsq = Kokkos::fmin(musq*rbarsq, vsq_max);
 
       // Using the velocity estimate, predict the Lorentz factor.
       // NOTE: for extreme velocities, this alternative form of W may be more accurate:
       // Wsq = 1/(eps*(2 - eps)) = 1/(eps*(1 + v)), where eps = 1 - v.
       //const Real What = 1.0/std::sqrt(1.0 - vhatsq);
-      const Real iWhat = sqrt(1.0 - vhatsq);
+      const Real iWhat = Kokkos::sqrt(1.0 - vhatsq);
 
       // Now estimate the number density.
       Real rhohat = D*iWhat;
@@ -139,10 +139,10 @@ class PrimitiveSolver {
       // Now we can get two different estimates for nu = h/W.
       Real nu_a = hhat*iWhat;
       //Real ahat = Phat / ehat;
-      Real nu_b = eoverD + Phat/D;
+      Real nu_b = (D*eoverD + Phat)/D;
       //Real nu_b = (1.0 + ahat)*eoverD;
       //Real nu_b = (1.0 + ahat)*eoverD;
-      Real nuhat = fmax(nu_a, nu_b);
+      Real nuhat = Kokkos::fmax(nu_a, nu_b);
 
       // Finally, we can get an estimate for muhat.
       Real muhat = 1.0/(nuhat + mu*rbarsq);

--- a/src/eos/primitive-solver/primitive_solver.hpp
+++ b/src/eos/primitive-solver/primitive_solver.hpp
@@ -127,16 +127,13 @@ class PrimitiveSolver {
       // Estimate the energy density.
       Real eoverD = qbar - mu*rbarsq + 1.0;
       Real ehat = D*eoverD;
-      peos->ApplyEnergyLimits(ehat, nhat, Y);
-      //eoverD = ehat/D;
 
       // Now we can get an estimate of the temperature, and from that, the pressure and
       // enthalpy.
       Real That = peos->GetTemperatureFromE(nhat, ehat, Y);
-      //peos->ApplyTemperatureLimits(That);
-      //ehat = peos->GetEnergy(nhat, That, Y);
+      peos->ApplyTemperatureLimits(That);
+      ehat = peos->GetEnergy(nhat, That, Y);
       Real Phat = peos->GetPressure(nhat, That, Y);
-      //Real hhat = peos->GetEnthalpy(nhat, That, Y);
       Real hhat = (ehat + Phat)/(mb*nhat);
 
       // Now we can get two different estimates for nu = h/W.


### PR DESCRIPTION
This is designed to fix #746, and it is linked to #737. While the bizarre changes to floating-point behavior when compiling for CUDA with optimizations remain unresolved, my hunch is that the PrimitiveSolver failures are actually present in the other configurations as well, and I only observe it in one branch due to floating-point issues pushing the code into a particular regime.

The issue actually seems to be related to the limiting behavior inside the root function:
```c++
// Estimate the energy density
Real eoverD = qbar - mu*rbarsq + 1.0;
Real ehat = D*eoverD;
peos->ApplyEnergyLimits(ehat, nhat, Y);

// Now we can get an estimate of the temperature, and from that, the pressure and
// enthalpy.
Real That = peos->GetTemperatureFromE(nhat, ehat, Y);
//peos->ApplyTemperatureLimits(That);
//ehat = peos->GetEnergy(nhat, That, Y);
```

The `ApplyEnergyLimits` function makes a call to `MinimumEnergy`, which, as discussed in #737, doesn't actually seem to be correct for a tabulated EOS. This can create a kink in the root function that completely stalls convergence:
<img width="640" height="443" alt="image" src="https://github.com/user-attachments/assets/3e051acf-4f82-4df9-8a7a-b68b11b3ac12" />

The original reason for this logic was twofold:
1. Ensure that the recovered temperature is physical.
2. Ensure that the energy going into `GetTemperatureFromE` is inside the table for `EOSCompOSE`.

Point 1 can still be achieved without `ApplyEnergyLimits` by uncommenting `ApplyTemperatureLimits` and `GetEnergy` after `GetTemperatureFromE`. This actually turns out to be cheaper for a tabulated EOS, anyway, because `ApplyEnergyLimits` makes two calls to `GetEnergy`, while $\min T$ and $\max T$ are constants. `EOSCompOSE` can't return an unphysical temperature, so this really just a way of sanitizing the outputs for the other equations of state.

Point 2 made `ApplyEnergyLimits` necessary because `EOSCompOSE` didn't consistently sanitize inputs. This is no longer the case, so the energy limiting is now redundant.

This PR also makes some minor changes as part of piecemeal efforts toward #614 by adding `Kokkos::` to some of the C math functions I spotted. Lastly, there are two calculations that have been tweaked to use versions that are mathematically identical but hopefully have better floating-point stability.