### PR TITLE
Hotfix/diffusion

### DIFF
--- a/inputs/tests/viscosity.athinput
+++ b/inputs/tests/viscosity.athinput
@@ -32,7 +32,7 @@ nx2       = 1         # Number of cells in each MeshBlock, X2-dir
 nx3       = 1         # Number of cells in each MeshBlock, X3-dir
 
 <time>
-evolution  = dynamic   # dynamic/kinematic/static
+evolution  = kinematic   # dynamic/kinematic/static
 integrator = rk2       # time integration algorithm
 cfl_number = 0.4       # The Courant, Friedrichs, & Lewy (CFL) Number
 nlim       = -1        # cycle limit
@@ -42,7 +42,7 @@ ndiag      = 1         # cycles between diagostic output
 <hydro>
 eos         = ideal    # EOS type
 reconstruct = wenoz    # spatial reconstruction method
-rsolver     = hllc     # Riemann-solver to be used
+rsolver     = advect     # Riemann-solver to be used
 gamma       = 1.66667  # gamma = C_p/C_v
 viscosity   = 1.0     # coefficient of isotropic kinematic viscosity
 

--- a/src/athena.hpp
+++ b/src/athena.hpp
@@ -55,8 +55,7 @@ using Real = double;
 
 // constants that determine array index of Hydro/MHD variables
 // array indices for conserved: density, momemtum, total energy
-enum VariableIndex {IDN=0, IM1=1, IVX=1, IM2=2, IVY=2, IM3=3, IVZ=3, IEN=4,
-                    ITM=4, IPR=4, IYF=5};
+enum VariableIndex {IDN=0, IM1=1, IVX=1, IM2=2, IVY=2, IM3=3, IVZ=3, IEN=4, IPR=4, IYF=5};
 // array indices for components of magnetic field
 enum BFieldIndex {IBX=0, IBY=1, IBZ=2, NMAG=3};
 // array indices for metric matrices in GR

--- a/src/diffusion/conduction.cpp
+++ b/src/diffusion/conduction.cpp
@@ -58,29 +58,19 @@ Real TempDepKappa(Real temp, Real limit) {
 // Note first argument passes string ("hydro" or "mhd") denoting in wihch class this
 // object is being constructed, and therefore which <block> in the input file from which
 // the parameters are read.
-// Note that the coefficient of thermal conduction, kappa, corresponds to conductivity,
-// not diffusivity. This is different from the coefficient used in Athena++.
+// Note that the coefficients of thermal conduction, alpha_iso, etc., correspond to
+// diffusivities. The conductivity is kappa = (dens)*alpha, and the energy flux
+// q = -kappa * (dT/dx) = - alpha * d * *dT/dx)
 
 Conduction::Conduction(std::string block, MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
-  // Read parameters for isotropic thermal conduction (if any)
-  if (pin->DoesParameterExist(block,"isotropic_conduction")) {
-    iso_cond_type = pin->GetString(block,"isotropic_conduction");
-    // Check for valid type
-    if ((iso_cond_type.compare("constant") != 0) &&
-        (iso_cond_type.compare("spitzer") != 0) &&
-        (iso_cond_type.compare("spitzer_limited") != 0)) {
-      std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-                << "Invalid choice for isotropic thermal conduction type" << std::endl;
-      std::exit(EXIT_FAILURE);
-    }
-    // constant conductivity
-    if (iso_cond_type.compare("constant") == 0) {
-      kappa_iso = pin->GetReal(block,"kappa_iso");
-    }
-    kappa_iso_limit = pin->GetOrAddReal(block,"kappa_iso_limit",
-                      static_cast<Real>(std::numeric_limits<float>::max()));
-  }
+  // Read parameters for thermal diffusivity (if any)
+  alpha_iso = pin->GetOrAddReal(block,"alpha_iso", 0.0);
+  alpha_aniso = pin->GetOrAddReal(block,"alpha_aniso", 0.0);
+  alpha_spitzer = pin->GetOrAddBoolean(block,"alpha_spitzer", false);
+  // Limit on thermal heat flux (saturated conduction)
+  q_limit = pin->GetOrAddReal(block,"q_limit",
+                     static_cast<Real>(std::numeric_limits<float>::max()));
 }
 
 //----------------------------------------------------------------------------------------
@@ -96,22 +86,25 @@ Conduction::~Conduction() {
 
 void Conduction::AddHeatFluxes(const DvceArray5D<Real> &w0, const EOS_Data &eos,
     DvceFaceFld5D<Real> &flx) {
-  if (iso_cond_type.compare("constant") == 0) {
-    AddIsotropicHeatFluxConstCond(w0, eos, flx);
-  } else if ((iso_cond_type.compare("spitzer") == 0) ||
-             (iso_cond_type.compare("spitzer_limited") == 0)) {
-    AddIsotropicHeatFluxSpitzerCond(w0, eos, flx);
+  if (alpha_iso != 0) {
+    AddHeatFluxIso(w0, eos, flx);
+  }
+  if (alpha_aniso != 0) {
+    AddHeatFluxAniso(w0, eos, flx);
+  }
+  if (alpha_spitzer) {
+    AddHeatFluxSpitzer(w0, eos, flx);
   }
   return;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void AddIsotropicHeatFluxConstCond()
+//! \fn void AddHeatFluxIso()
 //! \brief Adds isotropic heat flux computed using constant conductivity to face-centered
 //! fluxes of conserved variables
 
-void Conduction::AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w0,
-    const EOS_Data &eos, DvceFaceFld5D<Real> &flx) {
+void Conduction::AddHeatFluxIso(const DvceArray5D<Real> &w0, const EOS_Data &eos,
+    DvceFaceFld5D<Real> &flx) {
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int is = indcs.is, ie = indcs.ie;
   int js = indcs.js, je = indcs.je;
@@ -119,15 +112,17 @@ void Conduction::AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w0,
   int nmb1 = pmy_pack->nmb_thispack - 1;
   auto size = pmy_pack->pmb->mb_size;
   Real gm1 = eos.gamma-1.0;
-  Real &kappa_ = kappa_iso;
+  Real &alpha_ = alpha_iso;
 
   // fluxes in x1-direction
   auto &flx1 = flx.x1f;
   par_for("conduct1", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie+1,
   KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
-    Real dtempdx = (w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i) - w0(m,IEN,k,j,i-1)/w0(m,IDN,k,j,i-1))
-              * gm1 / size.d_view(m).dx1;
-    flx1(m,IEN,k,j,i) -= kappa_ * dtempdx;
+    Real tempr = w0(m,IEN,k,j,i  )/w0(m,IDN,k,j,i  );
+    Real templ = w0(m,IEN,k,j,i-1)/w0(m,IDN,k,j,i-1);
+    Real dtempdx = (tempr - templ) * gm1 / size.d_view(m).dx1;
+    Real densf = 0.5*(w0(m,IDN,k,j,i) + w0(m,IDN,k,j,i-1));
+    flx1(m,IEN,k,j,i) -= alpha_ * densf * dtempdx;
   });
   if (pmy_pack->pmesh->one_d) {return;}
 
@@ -135,9 +130,11 @@ void Conduction::AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w0,
   auto &flx2 = flx.x2f;
   par_for("conduct2",DevExeSpace(), 0, nmb1, ks, ke, js, je+1, is, ie,
   KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
-    Real dtempdx = (w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i) - w0(m,IEN,k,j-1,i)/w0(m,IDN,k,j-1,i))
-                * gm1 / size.d_view(m).dx2;
-    flx2(m,IEN,k,j,i) -= kappa_ * dtempdx;
+    Real tempr = w0(m,IEN,k,j  ,i)/w0(m,IDN,k,j  ,i);
+    Real templ = w0(m,IEN,k,j-1,i)/w0(m,IDN,k,j-1,i);
+    Real dtempdx = (tempr - templ) * gm1 / size.d_view(m).dx2;
+    Real densf = 0.5*(w0(m,IDN,k,j,i) + w0(m,IDN,k,j-1,i));
+    flx2(m,IEN,k,j,i) -= alpha_ * densf * dtempdx;
   });
   if (pmy_pack->pmesh->two_d) {return;}
 
@@ -145,10 +142,21 @@ void Conduction::AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w0,
   auto &flx3 = flx.x3f;
   par_for("conduct3",DevExeSpace(), 0, nmb1, ks, ke+1, js, je, is, ie,
   KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
-    Real dtempdx = (w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i) - w0(m,IEN,k-1,j,i)/w0(m,IDN,k-1,j,i))
-                * gm1 / size.d_view(m).dx3;
-    flx3(m,IEN,k,j,i) -= kappa_ * dtempdx;
+    Real tempr = w0(m,IEN,k  ,j,i)/w0(m,IDN,k  ,j,i);
+    Real templ = w0(m,IEN,k-1,j,i)/w0(m,IDN,k-1,j,i);
+    Real dtempdx = (tempr - templ) * gm1 / size.d_view(m).dx3;
+    Real densf = 0.5*(w0(m,IDN,k,j,i) + w0(m,IDN,k-1,j,i));
+    flx3(m,IEN,k,j,i) -= alpha_ * densf * dtempdx;
   });
+  return;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void AddHeatFluxAniso()
+//! \brief Current a no-op function, to be added later
+
+void Conduction::AddHeatFluxAniso(const DvceArray5D<Real> &w0, const EOS_Data &eos,
+    DvceFaceFld5D<Real> &flx) {
   return;
 }
 
@@ -157,8 +165,8 @@ void Conduction::AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w0,
 //! \brief Adds heat flux to face-centered fluxes of conserved variables with
 //! temperature-dependent conductivity
 
-void Conduction::AddIsotropicHeatFluxSpitzerCond(const DvceArray5D<Real> &w0,
-    const EOS_Data &eos, DvceFaceFld5D<Real> &flx) {
+void Conduction::AddHeatFluxSpitzer(const DvceArray5D<Real> &w0, const EOS_Data &eos,
+   DvceFaceFld5D<Real> &flx) {
 /*
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int is = indcs.is, ie = indcs.ie;
@@ -319,19 +327,10 @@ void Conduction::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_da
 //  }
 
   // set flag for Spitzer conductivity
-  bool spitzer = false;
-  if ((iso_cond_type.compare("spitzer") == 0) ||
-      (iso_cond_type.compare("spitzer_limited") == 0)) {
-    spitzer = true;
-  }
-  Real limit_ = kappa_iso_limit;
-  Real temp_unit=0.0, kappa_unit=0.0;
-
-  if (spitzer) {
-    Real temp_unit = pmy_pack->punit->temperature_cgs();
-    Real kappa_unit = pmy_pack->punit->pressure_cgs()*pmy_pack->punit->velocity_cgs()*
+  bool spitzer_ = alpha_spitzer;
+  Real temp_unit = pmy_pack->punit->temperature_cgs();
+  Real kappa_unit = pmy_pack->punit->pressure_cgs()*pmy_pack->punit->velocity_cgs()*
                       pmy_pack->punit->length_cgs()/pmy_pack->punit->temperature_cgs();
-  }
 
   // capture variables for kernel
   auto &indcs = pmy_pack->pmesh->mb_indcs;
@@ -346,7 +345,7 @@ void Conduction::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_da
   auto &three_d = pmy_pack->pmesh->three_d;
   auto &size = pmy_pack->pmb->mb_size;
   Real gm1 = eos_data.gamma-1.0;
-  Real kappa0 = kappa_iso;
+  Real alpha0 = alpha_iso;
 
   // find smallest timestep for thermal conduction in each cell
   // Note loop over all cells needed even for constant conductivity
@@ -360,18 +359,18 @@ void Conduction::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_da
     k += ks;
     j += js;
 
-    Real kappa_ = kappa0;
-    if (spitzer) {
-      Real temp = w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
-      kappa_ = TempDepKappa(temp*temp_unit, limit_)/kappa_unit;
-    }
+    Real alpha_ = alpha0;
+//    if (spitzer_) {
+//      Real temp = w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
+//      kappa_ = TempDepKappa(temp*temp_unit, limit_)/kappa_unit;
+//    }
 
-    min_dt = fmin(min_dt, SQR(size.d_view(m).dx1)/kappa_*w0_(m,IDN,k,j,i)/gm1);
+    min_dt = fmin(min_dt, SQR(size.d_view(m).dx1)/alpha_*w0_(m,IDN,k,j,i)/gm1);
     if (multi_d) {
-      min_dt = fmin(min_dt, SQR(size.d_view(m).dx2)/kappa_*w0_(m,IDN,k,j,i)/gm1);
+      min_dt = fmin(min_dt, SQR(size.d_view(m).dx2)/alpha_*w0_(m,IDN,k,j,i)/gm1);
     }
     if (three_d) {
-      min_dt = fmin(min_dt, SQR(size.d_view(m).dx3)/kappa_*w0_(m,IDN,k,j,i)/gm1);
+      min_dt = fmin(min_dt, SQR(size.d_view(m).dx3)/alpha_*w0_(m,IDN,k,j,i)/gm1);
     }
   }, Kokkos::Min<Real>(dtnew));
   dtnew *= fac;

--- a/src/diffusion/conduction.hpp
+++ b/src/diffusion/conduction.hpp
@@ -25,18 +25,17 @@ class Conduction {
 
   // data
   Real dtnew;
-  Real kappa;         // thermal conductivity
-  bool tdep_kappa;    // temperature-dependent conductivity
-  Real kappa_ceiling; // ceiling of thermal conductivity
-  bool sat_hflux;     // saturtion of heat flux
+  std::string iso_cond_type; // "constant", "spitzer", or "spitzer_limited"
+  Real kappa_iso;            // isotropic thermal conductivity
+  Real kappa_iso_limit;      // limit to isotropic thermal conductivity
 
-  // function to add heat fluxes to Hydro and/or MHD fluxes
-  void AddHeatFlux(const DvceArray5D<Real> &w, const EOS_Data &eos,
-                   DvceFaceFld5D<Real> &f);
-  void IsotropicHeatFlux(const DvceArray5D<Real> &w, const EOS_Data &eos,
-                         DvceFaceFld5D<Real> &f);
-  void TempDependentHeatFlux(const DvceArray5D<Real> &w, const EOS_Data &eos,
-                             DvceFaceFld5D<Real> &f);
+  // functions
+  void AddHeatFluxes(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                     DvceFaceFld5D<Real> &f);
+  void AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                                     DvceFaceFld5D<Real> &f);
+  void AddIsotropicHeatFluxSpitzerCond(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                                       DvceFaceFld5D<Real> &f);
   void NewTimeStep(const DvceArray5D<Real> &w, const EOS_Data &eos_data);
 
  private:

--- a/src/diffusion/conduction.hpp
+++ b/src/diffusion/conduction.hpp
@@ -25,17 +25,20 @@ class Conduction {
 
   // data
   Real dtnew;
-  std::string iso_cond_type; // "constant", "spitzer", or "spitzer_limited"
-  Real kappa_iso;            // isotropic thermal conductivity
-  Real kappa_iso_limit;      // limit to isotropic thermal conductivity
+  Real alpha_iso;       // isotropic thermal diffusivity
+  Real alpha_aniso;     // anisotropic thermal diffusivity
+  bool alpha_spitzer;   // switch to turn on Spitzer conductivity
+  Real q_limit;         // saturated heat flux limit
 
   // functions
   void AddHeatFluxes(const DvceArray5D<Real> &w, const EOS_Data &eos,
                      DvceFaceFld5D<Real> &f);
-  void AddIsotropicHeatFluxConstCond(const DvceArray5D<Real> &w, const EOS_Data &eos,
-                                     DvceFaceFld5D<Real> &f);
-  void AddIsotropicHeatFluxSpitzerCond(const DvceArray5D<Real> &w, const EOS_Data &eos,
-                                       DvceFaceFld5D<Real> &f);
+  void AddHeatFluxIso(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                      DvceFaceFld5D<Real> &f);
+  void AddHeatFluxAniso(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                        DvceFaceFld5D<Real> &f);
+  void AddHeatFluxSpitzer(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                          DvceFaceFld5D<Real> &f);
   void NewTimeStep(const DvceArray5D<Real> &w, const EOS_Data &eos_data);
 
  private:

--- a/src/diffusion/resistivity.cpp
+++ b/src/diffusion/resistivity.cpp
@@ -25,17 +25,7 @@
 Resistivity::Resistivity(MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
   // Read parameters for Ohmic resistivity (if any)
-  if (pin->DoesParameterExist("mhd","ohmic_resistivity")) {
-    iso_resist_type = pin->GetString("mhd","ohmic_resistivity");
-    // Check for valid type
-    if (iso_resist_type.compare("constant") != 0) {
-      std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-                << "Invalid choice for Ohmic resistivity type" << std::endl;
-      std::exit(EXIT_FAILURE);
-    }
-    // constant resistivity
-    eta_ohm = pin->GetReal("mhd","eta_ohm");
-  }
+  eta_ohm = pin->GetOrAddReal("mhd","eta_ohm",0.0);
 }
 
 //----------------------------------------------------------------------------------------
@@ -51,7 +41,9 @@ Resistivity::~Resistivity() {
 
 void Resistivity::AddResistiveEMFs(const DvceFaceFld4D<Real> &b0,
     DvceEdgeFld4D<Real> &efld) {
-  AddEMFConstantResist(b0, efld);
+  if (eta_ohm != 0.0) {
+    AddEMFConstantResist(b0, efld);
+  }
   return;
 }
 
@@ -63,7 +55,9 @@ void Resistivity::AddResistiveEMFs(const DvceFaceFld4D<Real> &b0,
 
 void Resistivity::AddResistiveFluxes(const DvceFaceFld4D<Real> &b0,
     DvceFaceFld5D<Real> &flx) {
-  AddFluxConstantResist(b0, flx);
+  if (eta_ohm != 0.0) {
+    AddFluxConstantResist(b0, flx);
+  }
   return;
 }
 

--- a/src/diffusion/resistivity.cpp
+++ b/src/diffusion/resistivity.cpp
@@ -26,7 +26,7 @@ Resistivity::Resistivity(MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
   // Read parameters for Ohmic resistivity (if any)
   if (pin->DoesParameterExist("mhd","ohmic_resistivity")) {
-    iso_resist_type = pin->GetString("mhd","ohmic_resisitivity");
+    iso_resist_type = pin->GetString("mhd","ohmic_resistivity");
     // Check for valid type
     if (iso_resist_type.compare("constant") != 0) {
       std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl

--- a/src/diffusion/resistivity.hpp
+++ b/src/diffusion/resistivity.hpp
@@ -24,11 +24,15 @@ class Resistivity {
 
   // data
   Real dtnew;
+  std::string iso_resist_type;  // only "constant" implemented
   Real eta_ohm;
 
   // functions to add resistive E-Field and energy flux
-  void OhmicEField(const DvceFaceFld4D<Real> &b0, DvceEdgeFld4D<Real> &efld);
-  void OhmicEnergyFlux(const DvceFaceFld4D<Real> &b, DvceFaceFld5D<Real> &flx);
+  void AddResistiveEMFs(const DvceFaceFld4D<Real> &b0, DvceEdgeFld4D<Real> &efld);
+  void AddResistiveFluxes(const DvceFaceFld4D<Real> &b0, DvceFaceFld5D<Real> &flx);
+  void AddEMFConstantResist(const DvceFaceFld4D<Real> &b0, DvceEdgeFld4D<Real> &efld);
+  void AddFluxConstantResist(const DvceFaceFld4D<Real> &b, DvceFaceFld5D<Real> &flx);
+  void NewTimeStep(const DvceArray5D<Real> &w, const EOS_Data &eos_data);
 
  private:
   MeshBlockPack* pmy_pack;

--- a/src/diffusion/resistivity.hpp
+++ b/src/diffusion/resistivity.hpp
@@ -24,7 +24,6 @@ class Resistivity {
 
   // data
   Real dtnew;
-  std::string iso_resist_type;  // only "constant" implemented
   Real eta_ohm;
 
   // functions to add resistive E-Field and energy flux

--- a/src/diffusion/viscosity.cpp
+++ b/src/diffusion/viscosity.cpp
@@ -29,18 +29,9 @@
 
 Viscosity::Viscosity(std::string block, MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
-  // Read parameters for isotropic viscosity (if any)
-  if (pin->DoesParameterExist(block,"isotropic_viscosity")) {
-    iso_visc_type = pin->GetString(block,"isotropic_viscosity");
-    // Check for valid type
-    if (iso_visc_type.compare("constant") != 0) {
-      std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-                << "Invalid choice for isotropic viscosity type" << std::endl;
-      std::exit(EXIT_FAILURE);
-    }
-    // constant conductivity
-    nu_iso = pin->GetReal(block,"nu_iso");
-  }
+  // Read parameters for viscosity (if any)
+  nu_iso = pin->GetOrAddReal(block,"nu_iso",0.0);
+  nu_aniso = pin->GetOrAddReal(block,"nu_aniso",0.0);
 }
 
 //----------------------------------------------------------------------------------------
@@ -57,16 +48,21 @@ Viscosity::~Viscosity() {
 
 void Viscosity::AddViscousFluxes(const DvceArray5D<Real> &w0, const EOS_Data &eos,
     DvceFaceFld5D<Real> &flx) {
-  AddIsotropicViscousFluxConstVisc(w0, eos, flx);
+  if (nu_iso != 0.0) {
+    AddViscousFluxIso(w0, eos, flx);
+  }
+  if (nu_iso != 0.0) {
+    AddViscousFluxAniso(w0, eos, flx);
+  }
   return;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn void AddIsoViscousFlux
+//! \fn void AddViscousFluxIso
 //  \brief Adds viscous fluxes to face-centered fluxes of conserved variables
 
-void Viscosity::AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w0,
-    const EOS_Data &eos, DvceFaceFld5D<Real> &flx) {
+void Viscosity::AddViscousFluxIso(const DvceArray5D<Real> &w0, const EOS_Data &eos,
+    DvceFaceFld5D<Real> &flx) {
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int is = indcs.is, ie = indcs.ie;
   int js = indcs.js, je = indcs.je;
@@ -76,6 +72,7 @@ void Viscosity::AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w0,
   auto size = pmy_pack->pmb->mb_size;
   bool &multi_d = pmy_pack->pmesh->multi_d;
   bool &three_d = pmy_pack->pmesh->three_d;
+  Real nu_iso_ = nu_iso;
 
   // fluxes in x1-direction
   int scr_level = 0;
@@ -117,7 +114,7 @@ void Viscosity::AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w0,
 
     // Sum viscous fluxes into fluxes of conserved variables; including energy fluxes
     par_for_inner(member, is, ie+1, [&](const int i) {
-      Real nud = 0.5*nu_iso*(w0(m,IDN,k,j,i) + w0(m,IDN,k,j,i-1));
+      Real nud = 0.5*nu_iso_*(w0(m,IDN,k,j,i) + w0(m,IDN,k,j,i-1));
       flx1(m,IVX,k,j,i) -= nud*fvx(i);
       flx1(m,IVY,k,j,i) -= nud*fvy(i);
       flx1(m,IVZ,k,j,i) -= nud*fvz(i);
@@ -162,7 +159,7 @@ void Viscosity::AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w0,
 
     // Sum viscous fluxes into fluxes of conserved variables; including energy fluxes
     par_for_inner(member, is, ie, [&](const int i) {
-      Real nud = 0.5*nu_iso*(w0(m,IDN,k,j,i) + w0(m,IDN,k,j-1,i));
+      Real nud = 0.5*nu_iso_*(w0(m,IDN,k,j,i) + w0(m,IDN,k,j-1,i));
       flx2(m,IVX,k,j,i) -= nud*fvx(i);
       flx2(m,IVY,k,j,i) -= nud*fvy(i);
       flx2(m,IVZ,k,j,i) -= nud*fvz(i);
@@ -201,7 +198,7 @@ void Viscosity::AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w0,
 
     // Sum viscous fluxes into fluxes of conserved variables; including energy fluxes
     par_for_inner(member, is, ie, [&](const int i) {
-      Real nud = 0.5*nu_iso*(w0(m,IDN,k,j,i) + w0(m,IDN,k-1,j,i));
+      Real nud = 0.5*nu_iso_*(w0(m,IDN,k,j,i) + w0(m,IDN,k-1,j,i));
       flx3(m,IVX,k,j,i) -= nud*fvx(i);
       flx3(m,IVY,k,j,i) -= nud*fvy(i);
       flx3(m,IVZ,k,j,i) -= nud*fvz(i);
@@ -213,6 +210,15 @@ void Viscosity::AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w0,
     });
   });
 
+  return;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn void AddViscousFluxAniso
+//  \brief Currently no-op function, to be added later
+
+void Viscosity::AddViscousFluxAniso(const DvceArray5D<Real> &w0, const EOS_Data &eos,
+    DvceFaceFld5D<Real> &flx) {
   return;
 }
 

--- a/src/diffusion/viscosity.hpp
+++ b/src/diffusion/viscosity.hpp
@@ -27,11 +27,15 @@ class Viscosity {
 
   // data
   Real dtnew;
-  Real nu_iso;     // coefficient of isotropic kinematic shear viscosity
+  std::string iso_visc_type; // only "constant" implemented
+  Real nu_iso;               // coefficient of isotropic kinematic shear viscosity
 
   // function to add viscous fluxes to Hydro and/or MHD fluxes
-  void IsotropicViscousFlux(const DvceArray5D<Real> &w, const Real nu,
-                            const EOS_Data &eos, DvceFaceFld5D<Real> &f);
+  void AddViscousFluxes(const DvceArray5D<Real> &w, const EOS_Data &eos,
+                        DvceFaceFld5D<Real> &f);
+  void AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w,const EOS_Data &eos,
+                                        DvceFaceFld5D<Real> &f);
+  void NewTimeStep(const DvceArray5D<Real> &w, const EOS_Data &eos_data);
 
  private:
   MeshBlockPack* pmy_pack;

--- a/src/diffusion/viscosity.hpp
+++ b/src/diffusion/viscosity.hpp
@@ -27,14 +27,16 @@ class Viscosity {
 
   // data
   Real dtnew;
-  std::string iso_visc_type; // only "constant" implemented
-  Real nu_iso;               // coefficient of isotropic kinematic shear viscosity
+  Real nu_iso;      // coefficient of isotropic kinematic shear viscosity
+  Real nu_aniso;    // coefficient of anisotropic kinematic shear viscosity
 
   // function to add viscous fluxes to Hydro and/or MHD fluxes
   void AddViscousFluxes(const DvceArray5D<Real> &w, const EOS_Data &eos,
                         DvceFaceFld5D<Real> &f);
-  void AddIsotropicViscousFluxConstVisc(const DvceArray5D<Real> &w,const EOS_Data &eos,
-                                        DvceFaceFld5D<Real> &f);
+  void AddViscousFluxIso(const DvceArray5D<Real> &w,const EOS_Data &eos,
+                         DvceFaceFld5D<Real> &f);
+  void AddViscousFluxAniso(const DvceArray5D<Real> &w,const EOS_Data &eos,
+                           DvceFaceFld5D<Real> &f);
   void NewTimeStep(const DvceArray5D<Real> &w, const EOS_Data &eos_data);
 
  private:

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -28,7 +28,6 @@ struct EOS_Data {
   Real gamma;        // ratio of specific heats for ideal gas
   Real iso_cs;       // isothermal sound speed
   bool is_ideal;     // flag to denote ideal gas EOS
-  bool use_e, use_t; // use internal energy density (e) or temperature (t) as primitive
   Real dfloor, pfloor, tfloor, sfloor;  // density, pressure, temperature, entropy floors
   Real gamma_max;    // ceiling on Lorentz factor in SR/GR
 

--- a/src/eos/ideal_grhyd.cpp
+++ b/src/eos/ideal_grhyd.cpp
@@ -27,8 +27,6 @@ IdealGRHydro::IdealGRHydro(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("hydro","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
   eos_data.gamma_max = pin->GetOrAddReal("hydro","gamma_max",(FLT_MAX));  // gamma ceiling
 }
 

--- a/src/eos/ideal_grmhd.cpp
+++ b/src/eos/ideal_grmhd.cpp
@@ -25,8 +25,6 @@ IdealGRMHD::IdealGRMHD(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("mhd","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
   eos_data.gamma_max = pin->GetOrAddReal("mhd","gamma_max",(FLT_MAX));  // gamma ceiling
 }
 

--- a/src/eos/ideal_hyd.cpp
+++ b/src/eos/ideal_hyd.cpp
@@ -19,8 +19,6 @@ IdealHydro::IdealHydro(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("hydro","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/eos/ideal_mhd.cpp
+++ b/src/eos/ideal_mhd.cpp
@@ -19,8 +19,6 @@ IdealMHD::IdealMHD(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("mhd","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/eos/ideal_srhyd.cpp
+++ b/src/eos/ideal_srhyd.cpp
@@ -23,8 +23,6 @@ IdealSRHydro::IdealSRHydro(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("hydro","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
   eos_data.gamma_max = pin->GetOrAddReal("hydro","gamma_max",(FLT_MAX));  // gamma ceiling
 }
 

--- a/src/eos/ideal_srmhd.cpp
+++ b/src/eos/ideal_srmhd.cpp
@@ -21,8 +21,6 @@ IdealSRMHD::IdealSRMHD(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("mhd","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
   eos_data.gamma_max = pin->GetOrAddReal("mhd","gamma_max",(FLT_MAX));  // gamma ceiling
 }
 

--- a/src/eos/isothermal_hyd.cpp
+++ b/src/eos/isothermal_hyd.cpp
@@ -20,8 +20,6 @@ IsothermalHydro::IsothermalHydro(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = false;
   eos_data.iso_cs = pin->GetReal("hydro","iso_sound_speed");
   eos_data.gamma = 0.0;
-  eos_data.use_e = false;
-  eos_data.use_t = false;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/eos/isothermal_mhd.cpp
+++ b/src/eos/isothermal_mhd.cpp
@@ -20,8 +20,6 @@ IsothermalMHD::IsothermalMHD(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = false;
   eos_data.iso_cs = pin->GetReal("mhd","iso_sound_speed");
   eos_data.gamma = 0.0;
-  eos_data.use_e = false;
-  eos_data.use_t = false;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/eos/noop_dyngrmhd.cpp
+++ b/src/eos/noop_dyngrmhd.cpp
@@ -22,7 +22,5 @@ NoOpDynGRMHD::NoOpDynGRMHD(MeshBlockPack *pp, ParameterInput *pin) :
   eos_data.is_ideal = true;
   eos_data.gamma = pin->GetReal("mhd","gamma");
   eos_data.iso_cs = 0.0;
-  eos_data.use_e = true;  // ideal gas EOS always uses internal energy
-  eos_data.use_t = false;
   eos_data.gamma_max = pin->GetOrAddReal("mhd","gamma_max",(FLT_MAX));  // gamma ceiling
 }

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -81,7 +81,13 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
 
   // Thermal conduction (if requested in input file)
   if (pin->DoesParameterExist("hydro","isotropic_conduction")) {
-    pcond = new Conduction("hydro", ppack, pin);
+    if (peos->eos_data.is_ideal) {
+      pcond = new Conduction("hydro", ppack, pin);
+    } else {
+      std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+                << "Thermal conduction in hydro requires ideal gas EOS" << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
   } else {
     pcond = nullptr;
   }

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -73,15 +73,14 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   nscalars = pin->GetOrAddInteger("hydro","nscalars",0);
 
   // Viscosity (if requested in input file)
-  if (pin->DoesParameterExist("hydro","viscosity")) {
+  if (pin->DoesParameterExist("hydro","isotropic_viscosity")) {
     pvisc = new Viscosity("hydro", ppack, pin);
   } else {
     pvisc = nullptr;
   }
 
   // Thermal conduction (if requested in input file)
-  if (pin->DoesParameterExist("hydro","conductivity") ||
-      pin->DoesParameterExist("hydro","tdep_conductivity")) {
+  if (pin->DoesParameterExist("hydro","isotropic_conduction")) {
     pcond = new Conduction("hydro", ppack, pin);
   } else {
     pcond = nullptr;

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -80,7 +80,9 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   }
 
   // Thermal conduction (if requested in input file)
-  if (pin->DoesParameterExist("hydro","isotropic_conduction")) {
+  if (pin->DoesParameterExist("hydro","alpha_iso") ||
+      pin->DoesParameterExist("hydro","alpha_aniso") ||
+      pin->DoesParameterExist("hydro","alpha_spitzer")) {
     if (peos->eos_data.is_ideal) {
       pcond = new Conduction("hydro", ppack, pin);
     } else {

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -73,7 +73,8 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   nscalars = pin->GetOrAddInteger("hydro","nscalars",0);
 
   // Viscosity (if requested in input file)
-  if (pin->DoesParameterExist("hydro","isotropic_viscosity")) {
+  if (pin->DoesParameterExist("hydro","nu_iso") ||
+      pin->DoesParameterExist("hydro","nu_aniso")) {
     pvisc = new Viscosity("hydro", ppack, pin);
   } else {
     pvisc = nullptr;

--- a/src/hydro/hydro_newdt.cpp
+++ b/src/hydro/hydro_newdt.cpp
@@ -18,6 +18,7 @@
 #include "eos/eos.hpp"
 #include "hydro.hpp"
 #include "diffusion/conduction.hpp"
+#include "diffusion/viscosity.hpp"
 #include "srcterms/srcterms.hpp"
 
 namespace hydro {
@@ -126,6 +127,9 @@ TaskStatus Hydro::NewTimeStep(Driver *pdrive, int stage) {
   // compute timestep for diffusion
   if (pcond != nullptr) {
     pcond->NewTimeStep(w0, peos->eos_data);
+  }
+  if (pvisc != nullptr) {
+    pvisc->NewTimeStep(w0, peos->eos_data);
   }
   // compute source terms timestep
   if (psrc != nullptr) {

--- a/src/hydro/hydro_tasks.cpp
+++ b/src/hydro/hydro_tasks.cpp
@@ -180,12 +180,12 @@ TaskStatus Hydro::Fluxes(Driver *pdrive, int stage) {
     CalculateFluxes<Hydro_RSolver::hlle_gr>(pdrive, stage);
   }
 
-  // Add viscous, heat-flux, etc fluxes
-  if (pvisc != nullptr) {
-    pvisc->IsotropicViscousFlux(w0, pvisc->nu_iso, peos->eos_data, uflx);
-  }
+  // Add diffusion fluxes
   if (pcond != nullptr) {
-    pcond->AddHeatFlux(w0, peos->eos_data, uflx);
+    pcond->AddHeatFluxes(w0, peos->eos_data, uflx);
+  }
+  if (pvisc != nullptr) {
+    pvisc->AddViscousFluxes(w0, peos->eos_data, uflx);
   }
 
   // call FOFC if necessary

--- a/src/hydro/rsolvers/advect_hyd.hpp
+++ b/src/hydro/rsolvers/advect_hyd.hpp
@@ -7,12 +7,12 @@
 //========================================================================================
 //! \file advect_hyd.hpp
 //! \brief Riemann solver for pure advection problems (v = constant).  Simply computes the
-//! upwind flux of each variable.  Can only be used for isothermal EOS.
+//! upwind flux of each variable.
 
 namespace hydro {
 //----------------------------------------------------------------------------------------
 //! \fn void Advect
-//! \brief An advection Riemann solver for hydrodynamics (isothermal)
+//! \brief An advection Riemann solver for hydrodynamics
 
 KOKKOS_INLINE_FUNCTION
 void Advect(TeamMember_t const &member, const EOS_Data &eos,
@@ -27,13 +27,19 @@ void Advect(TeamMember_t const &member, const EOS_Data &eos,
     if (wl(ivx,i) >= 0.0) {
       flx(m,IDN,k,j,i) = wl(IDN,i)*wl(ivx,i);
       flx(m,ivx,k,j,i) = wl(IDN,i)*wl(ivx,i)*wl(ivx,i);
-      flx(m,ivy,k,j,i) = 0.0;
-      flx(m,ivz,k,j,i) = 0.0;
+      flx(m,ivy,k,j,i) = wl(ivy,i)*wl(ivx,i);
+      flx(m,ivz,k,j,i) = wl(ivz,i)*wl(ivx,i);
+      if (eos.is_ideal) {
+        flx(m,IEN,k,j,i) = wl(IEN,i)*wl(ivx,i);
+      }
     } else {
       flx(m,IDN,k,j,i) = wr(IDN,i)*wr(ivx,i);
       flx(m,ivx,k,j,i) = wr(IDN,i)*wr(ivx,i)*wr(ivx,i);
-      flx(m,ivy,k,j,i) = 0.0;
-      flx(m,ivz,k,j,i) = 0.0;
+      flx(m,ivy,k,j,i) = wr(ivy,i)*wr(ivx,i);
+      flx(m,ivz,k,j,i) = wr(ivz,i)*wr(ivx,i);
+      if (eos.is_ideal) {
+        flx(m,IEN,k,j,i) = wr(IEN,i)*wr(ivx,i);
+      }
     }
   });
 

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -93,7 +93,7 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   nscalars = pin->GetOrAddInteger("mhd","nscalars",0);
 
   // Viscosity (only constructed if needed)
-  if (pin->DoesParameterExist("mhd","viscosity")) {
+  if (pin->DoesParameterExist("mhd","isotropic_viscosity")) {
     pvisc = new Viscosity("mhd", ppack, pin);
   } else {
     pvisc = nullptr;
@@ -107,8 +107,7 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   }
 
   // Thermal conduction (only constructed if needed)
-  if (pin->DoesParameterExist("mhd","conductivity") ||
-      pin->DoesParameterExist("mhd","tdep_conductivity")) {
+  if (pin->DoesParameterExist("mhd","isotropic_conduction")) {
     pcond = new Conduction("mhd", ppack, pin);
   } else {
     pcond = nullptr;

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -108,7 +108,13 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
 
   // Thermal conduction (only constructed if needed)
   if (pin->DoesParameterExist("mhd","isotropic_conduction")) {
-    pcond = new Conduction("mhd", ppack, pin);
+    if (peos->eos_data.is_ideal) {
+      pcond = new Conduction("mhd", ppack, pin);
+    } else {
+      std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+                << "Thermal conduction in MHD requires ideal gas EOS" << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
   } else {
     pcond = nullptr;
   }

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -111,7 +111,9 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   }
 
   // Thermal conduction (only constructed if needed)
-  if (pin->DoesParameterExist("mhd","isotropic_conduction")) {
+  if (pin->DoesParameterExist("mhd","alpha_iso") ||
+      pin->DoesParameterExist("mhd","alpha_aniso") ||
+      pin->DoesParameterExist("mhd","alpha_spitzer")) {
     if (peos->eos_data.is_ideal) {
       pcond = new Conduction("mhd", ppack, pin);
     } else {

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -97,7 +97,8 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   nscalars = pin->GetOrAddInteger("mhd","nscalars",0);
 
   // Viscosity (only constructed if needed)
-  if (pin->DoesParameterExist("mhd","isotropic_viscosity")) {
+  if (pin->DoesParameterExist("mhd","nu_iso") ||
+      pin->DoesParameterExist("mhd","nu_aniso")) {
     pvisc = new Viscosity("mhd", ppack, pin);
   } else {
     pvisc = nullptr;

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -105,7 +105,7 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   }
 
   // Resistivity (only constructed if needed)
-  if (pin->DoesParameterExist("mhd","ohmic_resistivity")) {
+  if (pin->DoesParameterExist("mhd","eta_ohm")) {
     presist = new Resistivity(ppack, pin);
   } else {
     presist = nullptr;

--- a/src/mhd/mhd.hpp
+++ b/src/mhd/mhd.hpp
@@ -61,7 +61,6 @@ struct MHDTaskIDs {
   TaskID sendu_shr;
   TaskID recvu_shr;
   TaskID efld;
-  TaskID efldsrc;
   TaskID sende;
   TaskID recve;
   TaskID ct;
@@ -168,7 +167,7 @@ class MHD {
   TaskStatus SendU_Shr(Driver *d, int stage);
   TaskStatus RecvU_Shr(Driver *d, int stage);
   TaskStatus CornerE(Driver *d, int stage);
-  TaskStatus EFieldSrc(Driver *d, int stage);
+  TaskStatus EField(Driver *d, int stage);
   TaskStatus SendE(Driver *d, int stage);
   TaskStatus RecvE(Driver *d, int stage);
   TaskStatus CT(Driver *d, int stage);

--- a/src/mhd/mhd_corner_e.cpp
+++ b/src/mhd/mhd_corner_e.cpp
@@ -413,15 +413,6 @@ TaskStatus MHD::CornerE(Driver *pdriver, int stage) {
                 e3x2_(m,k,j,i-1) + e3x2_(m,k,j,i) + e3x1_(m,k,j-1,i) + e3x1_(m,k,j,i));
     });
   }
-
-  // Add resistive electric field (if needed)
-  if (presist != nullptr) {
-    if (presist->eta_ohm > 0.0) {
-      presist->OhmicEField(b0, efld);
-    }
-    // TODO(@user): Add more resistive effects here
-  }
-
   return TaskStatus::complete;
 }
 } // namespace mhd

--- a/src/mhd/mhd_newdt.cpp
+++ b/src/mhd/mhd_newdt.cpp
@@ -18,6 +18,8 @@
 #include "eos/eos.hpp"
 #include "mhd.hpp"
 #include "diffusion/conduction.hpp"
+#include "diffusion/viscosity.hpp"
+#include "diffusion/resistivity.hpp"
 #include "srcterms/srcterms.hpp"
 
 namespace mhd {
@@ -161,6 +163,12 @@ TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
   // compute timestep for diffusion
   if (pcond != nullptr) {
     pcond->NewTimeStep(w0, peos->eos_data);
+  }
+  if (pvisc != nullptr) {
+    pvisc->NewTimeStep(w0, peos->eos_data);
+  }
+  if (presist != nullptr) {
+    presist->NewTimeStep(w0, peos->eos_data);
   }
   // compute source terms timestep
   if (psrc != nullptr) {

--- a/src/pgen/tests/diffusion.cpp
+++ b/src/pgen/tests/diffusion.cpp
@@ -4,11 +4,11 @@
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
 //! \file diffusion.cpp
-//! \brief problem generator for tests of diffusion modules (viscosity, resistivity,
-//! thermal conduction).  Sets up Gaussian profile in x-direction.
-//! CURRENTLY ONLY VISCOSITY IMPLEMENTED
-//! This file also contains a function to compute L1 errors in solution, called in
-//! Driver::Finalize().
+//! \brief problem generator for simultaneous tests of diffusion modules (viscosity,
+//! resistivity, thermal conduction).  Sets up Gaussian profile of transverse velocity,
+//! magnetic field and temperature in x-direction. Should be run in kinematic mode
+//! Errors in final solution are computed from analytic profile at final time in
+//! DiffusionErrors() function.
 
 // C headers
 
@@ -29,11 +29,12 @@
 #include "eos/eos.hpp"
 #include "hydro/hydro.hpp"
 #include "diffusion/viscosity.hpp"
+#include "diffusion/conduction.hpp"
 
 // Prototype for function to compute errors in solution at end of run
 void DiffusionErrors(ParameterInput *pin, Mesh *pm);
 // Prototype for user-defined BCs
-void GaussianProfile(Mesh *pm);
+void GaussianProfileBCs(Mesh *pm);
 
 // Anonymous namespace used to prevent name collisions outside of this file
 namespace {
@@ -41,29 +42,30 @@ namespace {
 bool set_initial_conditions = true;
 // input parameters passed to user-defined BC function
 struct DiffusionVariables {
-  Real d0, amp, t0, x10;
+  int prob_dir;
+  Real amp, t0, x10;
 };
 
-DiffusionVariables dv;
+DiffusionVariables dvars;
 
 } // end anonymous namespace
 
 //----------------------------------------------------------------------------------------
 //! \fn ProblemGenerator::Diffusion()
-//! \brief Problem Generator for spherical blast problem
+//! \brief Sets initial conditions for diffusion tests
 
 void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   // set diffusion errors function
   pgen_final_func = DiffusionErrors;
   // user-define BC
-  user_bcs_func = GaussianProfile;
+  user_bcs_func = GaussianProfileBCs;
   if (restart) return;
 
   // Read problem parameters
-  dv.d0 = 1.0;
-  dv.amp = pin->GetOrAddReal("problem", "amp", 1.e-6);
-  dv.t0 = pin->GetOrAddReal("problem", "t0", 0.5);
-  dv.x10 = pin->GetOrAddReal("problem", "x10", 0.0);
+  dvars.prob_dir = pin->GetOrAddInteger("problem","direction",1);
+  dvars.amp = pin->GetOrAddReal("problem", "amp", 1.e-6);
+  dvars.t0 = pin->GetOrAddReal("problem", "t0", 0.5);
+  dvars.x10 = pin->GetOrAddReal("problem", "x10", 0.0);
 
   // capture variables for the kernel
   auto &indcs = pmy_mesh_->mb_indcs;
@@ -75,44 +77,48 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   auto &time = pmbp->pmesh->time;
 
   // capture variables for the kernel
-  //auto dv_=dv;
-  auto d0_=dv.d0, amp_=dv.amp, x10_=dv.x10;
+  auto amp_ = dvars.amp, x10_ = dvars.x10;
   // add stopping time when called at end of run
-  Real t1 = dv.t0;
+  Real t1 = dvars.t0;
   if (!(set_initial_conditions)) {t1 += time;}
 
   // Initialize Hydro variables -------------------------------
   if (pmbp->phydro != nullptr) {
-    if (pmbp->phydro->pvisc == nullptr) {
+    EOS_Data &eos = pmbp->phydro->peos->eos_data;
+    if (pmbp->phydro->pvisc == nullptr || pmbp->phydro->pcond == nullptr) {
       std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-              << "Hydro diffusion problem requires viscosity to be defined" << std::endl;
+              << "Diffusion test requires viscosity and conduction to be defined in"
+              << " Hydro input block" << std::endl;
       exit(EXIT_FAILURE);
     }
-    EOS_Data &eos = pmbp->phydro->peos->eos_data;
+    if (!(eos.is_ideal)) {
+      std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+              << "Diffusion test requires ideal EOS in Hydro block" << std::endl;
+      exit(EXIT_FAILURE);
+    }
     Real gm1 = eos.gamma - 1.0;
     Real p0 = 1.0/eos.gamma;
     auto &nu_iso = pmbp->phydro->pvisc->nu_iso;
+    auto &kappa_iso = pmbp->phydro->pcond->kappa_iso;
 
     // compute solution in u1 register. For initial conditions, set u1 -> u0.
     auto &u1 = (set_initial_conditions)? pmbp->phydro->u0 : pmbp->phydro->u1;
 
     // Initialize Gaussian profile of transverse (x2 and x3) velocity in x1-direction
-    par_for("pgen_shock1", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
+    // Initialize Gaussian profile of temperature in x1-direction
+    par_for("pgen_diff1", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
     KOKKOS_LAMBDA(int m,int k, int j, int i) {
       Real &x1min = size.d_view(m).x1min;
       Real &x1max = size.d_view(m).x1max;
       int nx1 = indcs.nx1;
       Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
 
-      u1(m,IDN,k,j,i) = d0_;
+      u1(m,IDN,k,j,i) = 1,0;
       u1(m,IM1,k,j,i) = 0.0;
-      u1(m,IM2,k,j,i) = d0_*amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                        /sqrt(4.*M_PI*nu_iso*t1);
-      u1(m,IM3,k,j,i) = d0_*amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                        /sqrt(4.*M_PI*nu_iso*t1);
-      if (eos.is_ideal) {
-        u1(m,IEN,k,j,i) = p0/gm1 + 0.5*(SQR(u1(m,IM2,k,j,i)) + SQR(u1(m,IM3,k,j,i)))/d0_;
-      }
+      u1(m,IM2,k,j,i) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+      u1(m,IM3,k,j,i) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+      Real press = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+      u1(m,IEN,k,j,i) = press/gm1 + 0.5*(SQR(u1(m,IM2,k,j,i)) + SQR(u1(m,IM3,k,j,i)));
     });
   } // End initialization of Hydro variables
   return;
@@ -129,146 +135,16 @@ void DiffusionErrors(ParameterInput *pin, Mesh *pm) {
   // register u1/b1 when flag is false.
   set_initial_conditions = false;
   pm->pgen->Diffusion(pin, false);
-
-  Real l1_err[8];
-  Real linfty_err=0.0;
-  int nvars=0;
-
-  // capture class variables for kernel
-  auto &indcs = pm->mb_indcs;
-  int &nx1 = indcs.nx1;
-  int &nx2 = indcs.nx2;
-  int &nx3 = indcs.nx3;
-  int &is = indcs.is;
-  int &js = indcs.js;
-  int &ks = indcs.ks;
-  MeshBlockPack *pmbp = pm->pmb_pack;
-  auto &size = pmbp->pmb->mb_size;
-
-  // compute errors for Hydro  -----------------------------------------------------------
-  if (pmbp->phydro != nullptr) {
-    nvars = pmbp->phydro->nhydro;
-
-    EOS_Data &eos = pmbp->phydro->peos->eos_data;
-    auto &u0_ = pmbp->phydro->u0;
-    auto &u1_ = pmbp->phydro->u1;
-
-    const int nmkji = (pmbp->nmb_thispack)*nx3*nx2*nx1;
-    const int nkji = nx3*nx2*nx1;
-    const int nji  = nx2*nx1;
-    array_sum::GlobalSum sum_this_mb;
-    Kokkos::parallel_reduce("LW-err",Kokkos::RangePolicy<>(DevExeSpace(), 0, nmkji),
-    KOKKOS_LAMBDA(const int &idx, array_sum::GlobalSum &mb_sum, Real &max_err) {
-      // compute n,k,j,i indices of thread
-      int m = (idx)/nkji;
-      int k = (idx - m*nkji)/nji;
-      int j = (idx - m*nkji - k*nji)/nx1;
-      int i = (idx - m*nkji - k*nji - j*nx1) + is;
-      k += ks;
-      j += js;
-
-      Real vol = size.d_view(m).dx1*size.d_view(m).dx2*size.d_view(m).dx3;
-
-      // conserved variables:
-      array_sum::GlobalSum evars;
-      evars.the_array[IDN] = vol*fabs(u0_(m,IDN,k,j,i) - u1_(m,IDN,k,j,i));
-      max_err = fmax(max_err, evars.the_array[IDN]);
-      evars.the_array[IM1] = vol*fabs(u0_(m,IM1,k,j,i) - u1_(m,IM1,k,j,i));
-      max_err = fmax(max_err, evars.the_array[IM1]);
-      evars.the_array[IM2] = vol*fabs(u0_(m,IM2,k,j,i) - u1_(m,IM2,k,j,i));
-      max_err = fmax(max_err, evars.the_array[IM2]);
-      evars.the_array[IM3] = vol*fabs(u0_(m,IM3,k,j,i) - u1_(m,IM3,k,j,i));
-      max_err = fmax(max_err, evars.the_array[IM3]);
-      if (eos.is_ideal) {
-        evars.the_array[IEN] = vol*fabs(u0_(m,IEN,k,j,i) - u1_(m,IEN,k,j,i));
-        max_err = fmax(max_err, evars.the_array[IEN]);
-      }
-
-      // fill rest of the_array with zeros, if narray < NREDUCTION_VARIABLES
-      for (int n=nvars; n<NREDUCTION_VARIABLES; ++n) {
-        evars.the_array[n] = 0.0;
-      }
-
-      // sum into parallel reduce
-      mb_sum += evars;
-    }, Kokkos::Sum<array_sum::GlobalSum>(sum_this_mb), Kokkos::Max<Real>(linfty_err));
-
-    // store data into l1_err array
-    for (int n=0; n<nvars; ++n) {
-      l1_err[n] = sum_this_mb.the_array[n];
-    }
-  }
-
-#if MPI_PARALLEL_ENABLED
-  MPI_Allreduce(MPI_IN_PLACE, &l1_err, nvars, MPI_ATHENA_REAL, MPI_SUM, MPI_COMM_WORLD);
-  MPI_Allreduce(MPI_IN_PLACE, &linfty_err, 1, MPI_ATHENA_REAL, MPI_MAX, MPI_COMM_WORLD);
-#endif
-
-  // normalize errors by number of cells
-  Real vol=  (pmbp->pmesh->mesh_size.x1max - pmbp->pmesh->mesh_size.x1min)
-            *(pmbp->pmesh->mesh_size.x2max - pmbp->pmesh->mesh_size.x2min)
-            *(pmbp->pmesh->mesh_size.x3max - pmbp->pmesh->mesh_size.x3min);
-  for (int i=0; i<nvars; ++i) l1_err[i] = l1_err[i]/vol;
-  linfty_err /= vol;
-
-  // compute rms error
-  Real rms_err = 0.0;
-  for (int i=0; i<nvars; ++i) {
-    rms_err += SQR(l1_err[i]);
-  }
-  rms_err = std::sqrt(rms_err);
-
-  // root process opens output file and writes out errors
-  if (global_variable::my_rank == 0) {
-    std::string fname;
-    fname.assign(pin->GetString("job","basename"));
-    fname.append("-errs.dat");
-    FILE *pfile;
-
-    // The file exists -- reopen the file in append mode
-    if ((pfile = std::fopen(fname.c_str(), "r")) != nullptr) {
-      if ((pfile = std::freopen(fname.c_str(), "a", pfile)) == nullptr) {
-        std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-                  << std::endl << "Error output file could not be opened" <<std::endl;
-        std::exit(EXIT_FAILURE);
-      }
-
-    // The file does not exist -- open the file in write mode and add headers
-    } else {
-      if ((pfile = std::fopen(fname.c_str(), "w")) == nullptr) {
-        std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-                  << std::endl << "Error output file could not be opened" <<std::endl;
-        std::exit(EXIT_FAILURE);
-      }
-      std::fprintf(pfile, "# Nx1  Nx2  Nx3   Ncycle  RMS-L1    L-infty       ");
-      std::fprintf(pfile,"d_L1         M1_L1         M2_L1         M3_L1         E_L1");
-      if (pmbp->pmhd != nullptr) {
-        std::fprintf(pfile,"          B1_L1         B2_L1         B3_L1");
-      }
-      std::fprintf(pfile, "\n");
-    }
-
-    // write errors
-    std::fprintf(pfile, "%04d", pmbp->pmesh->mesh_indcs.nx1);
-    std::fprintf(pfile, "  %04d", pmbp->pmesh->mesh_indcs.nx2);
-    std::fprintf(pfile, "  %04d", pmbp->pmesh->mesh_indcs.nx3);
-    std::fprintf(pfile, "  %05d  %e %e", pmbp->pmesh->ncycle, rms_err, linfty_err);
-    for (int i=0; i<nvars; ++i) {
-      std::fprintf(pfile, "  %e", l1_err[i]);
-    }
-    std::fprintf(pfile, "\n");
-    std::fclose(pfile);
-  }
-
+  pm->pgen->OutputErrors(pin, pm);
   return;
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn GaussianProfile
-//  \brief Sets boundary condition on surfaces of computational domain
-// FIXME: Boundaries need to be adjusted for DynGRMHD
+//! \fn GaussianProfileBCs
+//! \brief Sets boundary conditions to time-dependent Gaussian profile on edges of
+//! computational domain
 
-void GaussianProfile(Mesh *pm) {
+void GaussianProfileBCs(Mesh *pm) {
   auto &indcs = pm->mb_indcs;
   int &ng = indcs.ng;
   //int n1 = indcs.nx1 + 2*ng;
@@ -283,53 +159,49 @@ void GaussianProfile(Mesh *pm) {
   Real gm1 = eos.gamma - 1.0;
   Real p0 = 1.0/eos.gamma;
   auto &nu_iso = pm->pmb_pack->phydro->pvisc->nu_iso;
+  auto &kappa_iso = pm->pmb_pack->phydro->pcond->kappa_iso;
   auto &u0 = pm->pmb_pack->phydro->u0;
 
   // capture variables for the kernel
   //auto dv_=dv;
-  auto d0_=dv.d0, amp_=dv.amp, x10_=dv.x10;
-  Real t1 = dv.t0 + pm->time;
+  auto amp_ = dvars.amp, x10_ = dvars.x10;
+  Real t1 = dvars.t0 + pm->time;
 
-  par_for("diffusion_x1", DevExeSpace(),0,(nmb-1),0,(n3-1),0,(n2-1),
-  KOKKOS_LAMBDA(int m, int k, int j) {
-    if (mb_bcs.d_view(m,BoundaryFace::inner_x1) == BoundaryFlag::user) {
+  if (dvars.prob_dir == 1) {
+    par_for("diffusion_x1", DevExeSpace(),0,(nmb-1),0,(n3-1),0,(n2-1),
+    KOKKOS_LAMBDA(int m, int k, int j) {
       for (int i=0; i<ng; ++i) {
+        // Inner X1-boundary
         Real &x1min = size.d_view(m).x1min;
         Real &x1max = size.d_view(m).x1max;
         int nx1 = indcs.nx1;
         Real x1v = CellCenterX(-1-i, nx1, x1min, x1max);
 
-        u0(m,IDN,k,j,is-i-1) = d0_;
+        u0(m,IDN,k,j,is-i-1) = 1.0;
         u0(m,IM1,k,j,is-i-1) = 0.0;
-        u0(m,IM2,k,j,is-i-1) = d0_*amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                          /sqrt(4.*M_PI*nu_iso*t1);
-        u0(m,IM3,k,j,is-i-1) = d0_*amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                          /sqrt(4.*M_PI*nu_iso*t1);
-        if (eos.is_ideal) {
-          u0(m,IEN,k,j,is-i-1) = p0/gm1 +
-                                 0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)))/d0_;
-        }
-      }
-    }
-    if (mb_bcs.d_view(m,BoundaryFace::outer_x1) == BoundaryFlag::user) {
-      for (int i=0; i<ng; ++i) {
-        Real &x1min = size.d_view(m).x1min;
-        Real &x1max = size.d_view(m).x1max;
-        int nx1 = indcs.nx1;
-        Real x1v = CellCenterX(ie-is+1+i, nx1, x1min, x1max);
+        u0(m,IM2,k,j,is-i-1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
+                               /sqrt(4.*M_PI*nu_iso*t1);
+        u0(m,IM3,k,j,is-i-1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
+                               /sqrt(4.*M_PI*nu_iso*t1);
+        Real press = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))
+                     /sqrt(4.*M_PI*kappa_iso*t1);
+        u0(m,IEN,k,j,is-i-1) = press/gm1 +
+                               0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
 
-        u0(m,IDN,k,j,ie+i+1) = d0_;
+        // Outer X1-boundary
+        x1v = CellCenterX(ie-is+1+i, nx1, x1min, x1max);
+
+        u0(m,IDN,k,j,ie+i+1) = 1,0;
         u0(m,IM1,k,j,ie+i+1) = 0.0;
-        u0(m,IM2,k,j,ie+i+1) = d0_*amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                          /sqrt(4.*M_PI*nu_iso*t1);
-        u0(m,IM3,k,j,ie+i+1) = d0_*amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                          /sqrt(4.*M_PI*nu_iso*t1);
-        if (eos.is_ideal) {
-          u0(m,IEN,k,j,ie+i+1) = p0/gm1 +
-                                 0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)))/d0_;
-        }
+        u0(m,IM2,k,j,ie+i+1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
+                               /sqrt(4.*M_PI*nu_iso*t1);
+        u0(m,IM3,k,j,ie+i+1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
+                               /sqrt(4.*M_PI*nu_iso*t1);
+        press = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+        u0(m,IEN,k,j,ie+i+1) = press/gm1 +
+                               0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
       }
-    }
-  });
+    });
+  }
   return;
 }

--- a/src/pgen/tests/diffusion.cpp
+++ b/src/pgen/tests/diffusion.cpp
@@ -4,16 +4,23 @@
 // Licensed under the 3-clause BSD License (the "LICENSE")
 //========================================================================================
 //! \file diffusion.cpp
-//! \brief problem generator for simultaneous tests of diffusion modules (viscosity,
-//! resistivity, thermal conduction).  Sets up Gaussian profile of transverse velocity,
-//! magnetic field and temperature in x-direction. Should be run in kinematic mode
-//! Errors in final solution are computed from analytic profile at final time in
-//! DiffusionErrors() function.
+//! \brief problem generator for tests of the diffusion modules (viscosity, resistivity,
+//! thermal conduction).  Sets up a Gaussian pulse that spreads under pure diffusion.
+//! The pulse can vary along one, two, or three coordinate axes (selected with the
+//! spread_x1/x2/x3 flags), giving an isotropic n-dimensional Gaussian whose amplitude
+//! decays as 1/(1+4*D*t)^(n/2).  For thermal conduction the pulse is in the gas
+//! temperature/pressure; for viscosity the pulse is in a single (transverse) velocity
+//! component selected with vel_comp; for resistivity the pulse is in a single
+//! (transverse) magnetic-field component (also selected with vel_comp: 1->Bx, 2->By,
+//! 3->Bz, stored on the corresponding cell face and uniform along its own axis so that
+//! div(B)=0).  Must be run in kinematic mode.  Errors in the final solution are computed
+//! from the analytic profile at final time in DiffusionErrors().  Resistivity runs use
+//! the <mhd> block; conduction/viscosity use the <hydro> block.
 
 // C headers
 
 // C++ headers
-#include <cmath>      // sqrt()
+#include <cmath>      // sqrt(), pow(), exp()
 #include <cstdio>     // fopen(), fprintf(), freopen()
 #include <cstring>    // strcmp()
 #include <iostream>   // endl
@@ -28,8 +35,10 @@
 #include "mesh/mesh.hpp"
 #include "eos/eos.hpp"
 #include "hydro/hydro.hpp"
+#include "mhd/mhd.hpp"
 #include "diffusion/viscosity.hpp"
 #include "diffusion/conduction.hpp"
+#include "diffusion/resistivity.hpp"
 
 // Prototype for function to compute errors in solution at end of run
 void DiffusionErrors(ParameterInput *pin, Mesh *pm);
@@ -40,14 +49,70 @@ void GaussianProfileBCs(Mesh *pm);
 namespace {
 // global variable to control computation of initial conditions versus errors
 bool set_initial_conditions = true;
-// input parameters passed to user-defined BC function
+// input parameters passed to the initialization kernel and user-defined BC function
 struct DiffusionVariables {
-  int prob_dir;
   bool conduction_test, viscosity_test, resistivity_test;
-  Real amp, x10;
+  bool spread_x1, spread_x2, spread_x3;
+  int vel_comp;                 // 1/2/3 -> velocity (viscosity) or B (resistivity) compt
+  Real amp, x10, x20, x30;      // amplitude and Gaussian centers
 };
 
 DiffusionVariables diffvars;
+
+//----------------------------------------------------------------------------------------
+//! \fn DiffusionGaussian
+//! \brief Device-callable helper returning the scalar amplitude of the isotropic n-D
+//! radial Gaussian pulse at (x1,x2,x3) and time, spreading with diffusivity "coef".
+
+KOKKOS_INLINE_FUNCTION
+Real DiffusionGaussian(const DiffusionVariables dv, const Real coef, const Real time,
+                       const Real x1, const Real x2, const Real x3) {
+  Real ndim = (dv.spread_x1 ? 1.0 : 0.0)
+            + (dv.spread_x2 ? 1.0 : 0.0)
+            + (dv.spread_x3 ? 1.0 : 0.0);
+  Real spread = 1.0 + 4.0*coef*time;
+  Real r2 = 0.0;
+  if (dv.spread_x1) r2 += SQR(x1 - dv.x10);
+  if (dv.spread_x2) r2 += SQR(x2 - dv.x20);
+  if (dv.spread_x3) r2 += SQR(x3 - dv.x30);
+  return (dv.amp/pow(spread, 0.5*ndim))*exp(-r2/spread);
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn DiffusionConsState
+//! \brief Device-callable helper that returns the analytic conserved state of the
+//! Gaussian-pulse diffusion solution at position (x1,x2,x3) and time. "coef" is the
+//! relevant diffusivity (nu_iso for viscosity, alpha_iso for conduction), "gamma" the
+//! adiabatic index.  Results are written into cons[IDN..IEN].
+
+KOKKOS_INLINE_FUNCTION
+void DiffusionConsState(const DiffusionVariables dv, const Real coef, const Real gamma,
+                        const Real time, const Real x1, const Real x2, const Real x3,
+                        Real cons[5]) {
+  Real g = DiffusionGaussian(dv, coef, time, x1, x2, x3);
+
+  Real gm1 = gamma - 1.0;
+  Real rho = 1.0;
+  Real m1 = 0.0, m2 = 0.0, m3 = 0.0;
+  Real p0 = 1.0/gamma;       // background pressure (used by viscosity test)
+  if (dv.conduction_test) {
+    p0 = g;                  // Gaussian temperature/pressure pulse
+  }
+  if (dv.viscosity_test) {
+    if (dv.vel_comp == 1) {
+      m1 = rho*g;
+    } else if (dv.vel_comp == 2) {
+      m2 = rho*g;
+    } else {
+      m3 = rho*g;
+    }
+  }
+  cons[IDN] = rho;
+  cons[IM1] = m1;
+  cons[IM2] = m2;
+  cons[IM3] = m3;
+  cons[IEN] = p0/gm1 + 0.5*(SQR(m1) + SQR(m2) + SQR(m3))/rho;
+}
 
 } // end anonymous namespace
 
@@ -59,27 +124,34 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   std::string evolution_t = pin->GetString("time","evolution");
   if (evolution_t.compare("kinematic") != 0) {
     std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-            << "Difusion tests must be run in kinematic mode" << std::endl;
+            << "Diffusion tests must be run in kinematic mode" << std::endl;
     exit(EXIT_FAILURE);
   }
   // set diffusion errors function
   pgen_final_func = DiffusionErrors;
-  // user-define BC
+  // user-defined BC
   user_bcs_func = GaussianProfileBCs;
   if (restart) return;
 
   // Read problem parameters
-  diffvars.prob_dir = pin->GetOrAddInteger("problem","direction",1);
   diffvars.amp = pin->GetOrAddReal("problem", "amp", 1.e-6);
   diffvars.x10 = pin->GetOrAddReal("problem", "x10", 0.0);
+  diffvars.x20 = pin->GetOrAddReal("problem", "x20", 0.0);
+  diffvars.x30 = pin->GetOrAddReal("problem", "x30", 0.0);
   diffvars.conduction_test = pin->GetBoolean("problem", "conduction_test");
   diffvars.viscosity_test = pin->GetBoolean("problem", "viscosity_test");
   diffvars.resistivity_test = pin->GetBoolean("problem", "resistivity_test");
-  if ((diffvars.conduction_test) &&
-      (diffvars.viscosity_test || diffvars.resistivity_test)) {
+  diffvars.spread_x1 = pin->GetOrAddBoolean("problem", "spread_x1", true);
+  diffvars.spread_x2 = pin->GetOrAddBoolean("problem", "spread_x2", false);
+  diffvars.spread_x3 = pin->GetOrAddBoolean("problem", "spread_x3", false);
+  diffvars.vel_comp = pin->GetOrAddInteger("problem", "vel_comp", 2);
+  int ntests = (diffvars.conduction_test ? 1 : 0)
+             + (diffvars.viscosity_test ? 1 : 0)
+             + (diffvars.resistivity_test ? 1 : 0);
+  if (ntests != 1) {
     std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-            << "Cannot run conduction test at same time as viscosity OR resistivity test"
-            << std::endl;
+            << "Exactly one of conduction_test/viscosity_test/resistivity_test must be "
+            << "set true (got " << ntests << ")" << std::endl;
     exit(EXIT_FAILURE);
   }
 
@@ -90,23 +162,17 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   int &ks = indcs.ks; int &ke = indcs.ke;
   MeshBlockPack *pmbp = pmy_mesh_->pmb_pack;
   auto &size = pmbp->pmb->mb_size;
-  auto &time = pmbp->pmesh->time;
-
-  // capture variables for the kernel
-  bool ctest = diffvars.conduction_test;
-  bool vtest = diffvars.viscosity_test;
-  Real x10_ = diffvars.x10;
-  // compute amplitude when called at end of run
-  Real amp_ = diffvars.amp;
+  Real time = pmbp->pmesh->time;
+  auto dv = diffvars;
 
   // Initialize Hydro variables -------------------------------
   if (pmbp->phydro != nullptr) {
-    if (ctest && pmbp->phydro->pcond == nullptr) {
+    if (dv.conduction_test && pmbp->phydro->pcond == nullptr) {
       std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
               << "Conduction not defined in Hydro input block" << std::endl;
       exit(EXIT_FAILURE);
     }
-    if (vtest && pmbp->phydro->pvisc == nullptr) {
+    if (dv.viscosity_test && pmbp->phydro->pvisc == nullptr) {
       std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
               << "Viscosity not defined in Hydro input block" << std::endl;
       exit(EXIT_FAILURE);
@@ -118,39 +184,119 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
               << "Diffusion test requires ideal EOS in Hydro block" << std::endl;
       exit(EXIT_FAILURE);
     }
-    Real gm1 = eos.gamma - 1.0;
-    auto &nu_iso = pmbp->phydro->pvisc->nu_iso;
-    auto &alpha_iso = pmbp->phydro->pcond->alpha_iso;
+    Real gamma = eos.gamma;
+    // Effective diffusivity of the pulse for the active test.  For viscosity the
+    // transverse momentum diffuses with the kinematic viscosity nu_iso.  For conduction
+    // the heat flux uses T = (gamma-1)*eint/rho = p/rho, giving an energy/pressure pulse
+    // that (with rho=1) diffuses with D = (gamma-1) * alpha_iso.
+    Real coef = 0.0;
+    if (dv.conduction_test) coef = (gamma-1.0)*pmbp->phydro->pcond->alpha_iso;
+    if (dv.viscosity_test) coef = pmbp->phydro->pvisc->nu_iso;
 
     // compute solution in u1 register. For initial conditions, set u1 -> u0.
     auto &u1 = (set_initial_conditions)? pmbp->phydro->u0 : pmbp->phydro->u1;
 
-    // Initialize Gaussian profile of transverse (x2 and x3) velocity in x1-direction
-    // Initialize Gaussian profile of temperature in x1-direction
-    par_for("pgen_diff1", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
+    par_for("pgen_diff", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
     KOKKOS_LAMBDA(int m,int k, int j, int i) {
       Real &x1min = size.d_view(m).x1min;
       Real &x1max = size.d_view(m).x1max;
-      int nx1 = indcs.nx1;
-      Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
+      Real x1v = CellCenterX(i-is, indcs.nx1, x1min, x1max);
 
-      Real vperp = 0.0;
-      if (vtest) {
-        vperp = (amp_/sqrt(1.0 + 4.0*nu_iso*time))*
-                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*nu_iso*time));
-      }
-      Real p0 = 1.0/eos.gamma;
-      if (ctest) {
-        p0 = (amp_/sqrt(1.0 + 4.0*alpha_iso*time))*
-              exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*alpha_iso*time));
-      }
-      u1(m,IDN,k,j,i) = 1,0;
-      u1(m,IM1,k,j,i) = 0.0;
-      u1(m,IM2,k,j,i) = vperp;
-      u1(m,IM3,k,j,i) = vperp;
-      u1(m,IEN,k,j,i) = p0/gm1 + 0.5*(SQR(vperp) + SQR(vperp));
+      Real &x2min = size.d_view(m).x2min;
+      Real &x2max = size.d_view(m).x2max;
+      Real x2v = CellCenterX(j-js, indcs.nx2, x2min, x2max);
+
+      Real &x3min = size.d_view(m).x3min;
+      Real &x3max = size.d_view(m).x3max;
+      Real x3v = CellCenterX(k-ks, indcs.nx3, x3min, x3max);
+
+      Real cons[5];
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u1(m,IDN,k,j,i) = cons[IDN];
+      u1(m,IM1,k,j,i) = cons[IM1];
+      u1(m,IM2,k,j,i) = cons[IM2];
+      u1(m,IM3,k,j,i) = cons[IM3];
+      u1(m,IEN,k,j,i) = cons[IEN];
     });
   } // End initialization of Hydro variables
+
+  // Initialize MHD variables (resistivity test) --------------
+  if (pmbp->pmhd != nullptr) {
+    if (!dv.resistivity_test) {
+      std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+              << "MHD diffusion test only supports the resistivity test" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    if (pmbp->pmhd->presist == nullptr) {
+      std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+              << "Resistivity (mhd/ohmic_resistivity) not defined in MHD input block"
+              << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    EOS_Data &eos = pmbp->pmhd->peos->eos_data;
+    if (!(eos.is_ideal)) {
+      std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+              << "Diffusion test requires ideal EOS in MHD block" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    Real gamma = eos.gamma;
+    Real gm1 = gamma - 1.0;
+    // The transverse magnetic field diffuses with the Ohmic diffusivity eta_ohm.
+    Real coef = pmbp->pmhd->presist->eta_ohm;
+    int bcomp = dv.vel_comp;          // 1->Bx, 2->By, 3->Bz
+    Real p0 = 1.0/gamma;              // uniform background gas pressure
+
+    // face- and cell-centered fields go to b0/b1 depending on whether these are ICs
+    auto &b = (set_initial_conditions)? pmbp->pmhd->b0 : pmbp->pmhd->b1;
+    auto &bcc0 = pmbp->pmhd->bcc0;
+    auto &w0 = pmbp->pmhd->w0;
+
+    // The pulse lives in a single B component that is uniform along its own coordinate
+    // axis (which is never a spread axis), so the staggered face value equals the
+    // Gaussian evaluated at the cell-centered spread coordinates and div(B)=0.
+    par_for("pgen_resist_b", DevExeSpace(),0,(pmbp->nmb_thispack-1),ks,ke,js,je,is,ie,
+    KOKKOS_LAMBDA(int m,int k, int j, int i) {
+      Real &x1min = size.d_view(m).x1min;
+      Real &x1max = size.d_view(m).x1max;
+      Real x1v = CellCenterX(i-is, indcs.nx1, x1min, x1max);
+
+      Real &x2min = size.d_view(m).x2min;
+      Real &x2max = size.d_view(m).x2max;
+      Real x2v = CellCenterX(j-js, indcs.nx2, x2min, x2max);
+
+      Real &x3min = size.d_view(m).x3min;
+      Real &x3max = size.d_view(m).x3max;
+      Real x3v = CellCenterX(k-ks, indcs.nx3, x3min, x3max);
+
+      Real g = DiffusionGaussian(dv, coef, time, x1v, x2v, x3v);
+      b.x1f(m,k,j,i) = (bcomp == 1) ? g : 0.0;
+      b.x2f(m,k,j,i) = (bcomp == 2) ? g : 0.0;
+      b.x3f(m,k,j,i) = (bcomp == 3) ? g : 0.0;
+      if (i == ie) {
+        b.x1f(m,k,j,i+1) = (bcomp == 1) ? g : 0.0;
+      }
+      if (j == je) {
+        b.x2f(m,k,j+1,i) = (bcomp == 2) ? g : 0.0;
+      }
+      if (k == ke) {
+        b.x3f(m,k+1,j,i) = (bcomp == 3) ? g : 0.0;
+      }
+
+      // cell-centered field and primitive state (rho=1, v=0, uniform pressure)
+      bcc0(m,IBX,k,j,i) = (bcomp == 1) ? g : 0.0;
+      bcc0(m,IBY,k,j,i) = (bcomp == 2) ? g : 0.0;
+      bcc0(m,IBZ,k,j,i) = (bcomp == 3) ? g : 0.0;
+      w0(m,IDN,k,j,i) = 1.0;
+      w0(m,IVX,k,j,i) = 0.0;
+      w0(m,IVY,k,j,i) = 0.0;
+      w0(m,IVZ,k,j,i) = 0.0;
+      w0(m,IEN,k,j,i) = p0/gm1;
+    });
+
+    // convert primitives + cell-centered B to conserved variables in u0/u1
+    auto &u = (set_initial_conditions)? pmbp->pmhd->u0 : pmbp->pmhd->u1;
+    pmbp->pmhd->peos->PrimToCons(w0, bcc0, u, is, ie, js, je, ks, ke);
+  } // End initialization of MHD variables
   return;
 }
 
@@ -171,75 +317,145 @@ void DiffusionErrors(ParameterInput *pin, Mesh *pm) {
 
 //----------------------------------------------------------------------------------------
 //! \fn GaussianProfileBCs
-//! \brief Sets boundary conditions to time-dependent Gaussian profile on edges of
-//! computational domain
+//! \brief Sets boundary conditions to the time-dependent analytic Gaussian profile on
+//! all (user) boundary faces of the computational domain.
 
 void GaussianProfileBCs(Mesh *pm) {
   auto &indcs = pm->mb_indcs;
   int &ng = indcs.ng;
-  //int n1 = indcs.nx1 + 2*ng;
+  int n1 = indcs.nx1 + 2*ng;
   int n2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*ng) : 1;
   int n3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*ng) : 1;
   int &is = indcs.is;  int &ie  = indcs.ie;
+  int &js = indcs.js;  int &je  = indcs.je;
+  int &ks = indcs.ks;  int &ke  = indcs.ke;
   auto &mb_bcs = pm->pmb_pack->pmb->mb_bcs;
   int nmb = pm->pmb_pack->nmb_thispack;
   auto &size = pm->pmb_pack->pmb->mb_size;
 
-  EOS_Data &eos = pm->pmb_pack->phydro->peos->eos_data;
-  Real gm1 = eos.gamma - 1.0;
-  auto &nu_iso = pm->pmb_pack->phydro->pvisc->nu_iso;
-  auto &alpha_iso = pm->pmb_pack->phydro->pcond->alpha_iso;
-  auto &u0 = pm->pmb_pack->phydro->u0;
+  // The analytic-profile user BCs are only used by the hydro (conduction/viscosity)
+  // tests.  Resistivity (MHD) runs use outflow BCs, since the field is negligible at the
+  // (wide) domain boundaries, so nothing to do here when hydro is absent.
+  auto *phydro = pm->pmb_pack->phydro;
+  if (phydro == nullptr) return;
+  EOS_Data &eos = phydro->peos->eos_data;
+  Real gamma = eos.gamma;
+  auto &u0 = phydro->u0;
 
   // capture variables for the kernel
-  //auto dv_=dv;
-  auto amp_ = diffvars.amp, x10_ = diffvars.x10;
+  auto dv = diffvars;
   Real time = pm->time;
-  bool ctest = diffvars.conduction_test;
-  bool vtest = diffvars.viscosity_test;
-
-  if (diffvars.prob_dir == 1) {
-    par_for("diffusion_x1", DevExeSpace(),0,(nmb-1),0,(n3-1),0,(n2-1),
-    KOKKOS_LAMBDA(int m, int k, int j) {
-      for (int i=0; i<ng; ++i) {
-        // Inner X1-boundary
-        Real &x1min = size.d_view(m).x1min;
-        Real &x1max = size.d_view(m).x1max;
-        Real x1v = CellCenterX(-1-i, indcs.nx1, x1min, x1max);
-        Real vperp = 0.0;
-        if (vtest) {
-          vperp = (amp_/sqrt(1.0 + 4.0*nu_iso*time))*
-                  exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*nu_iso*time));
-        }
-        Real p0 = 1.0/eos.gamma;
-        if (ctest) {
-          p0 = (amp_/sqrt(1.0 + 4.0*alpha_iso*time))*
-                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*alpha_iso*time));
-        }
-        u0(m,IDN,k,j,is-i-1) = 1,0;
-        u0(m,IM1,k,j,is-i-1) = 0.0;
-        u0(m,IM2,k,j,is-i-1) = vperp;
-        u0(m,IM3,k,j,is-i-1) = vperp;
-        u0(m,IEN,k,j,is-i-1) = p0/gm1 + 0.5*(SQR(vperp) + SQR(vperp));
-
-        // Outer X1-boundary
-        x1v = CellCenterX(ie-is+1+i, indcs.nx1, x1min, x1max);
-        if (vtest) {
-          vperp = (amp_/sqrt(1.0 + 4.0*nu_iso*time))*
-                  exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*nu_iso*time));
-        }
-        p0 = 1.0/eos.gamma;
-        if (ctest) {
-          p0 = (amp_/sqrt(1.0 + 4.0*alpha_iso*time))*
-                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*alpha_iso*time));
-        }
-        u0(m,IDN,k,j,ie+i+1) = 1,0;
-        u0(m,IM1,k,j,ie+i+1) = 0.0;
-        u0(m,IM2,k,j,ie+i+1) = vperp;
-        u0(m,IM3,k,j,ie+i+1) = vperp;
-        u0(m,IEN,k,j,ie+i+1) = p0/gm1 + 0.5*(SQR(vperp) + SQR(vperp));
-      }
-    });
+  Real coef = 0.0;
+  if (dv.conduction_test && phydro->pcond != nullptr) {
+    coef = (gamma-1.0)*phydro->pcond->alpha_iso;
   }
+  if (dv.viscosity_test && phydro->pvisc != nullptr) coef = phydro->pvisc->nu_iso;
+
+  // X1 boundaries
+  par_for("diffbc_x1", DevExeSpace(),0,(nmb-1),0,(n3-1),0,(n2-1),0,(ng-1),
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real &x1min = size.d_view(m).x1min;
+    Real &x1max = size.d_view(m).x1max;
+    Real &x2min = size.d_view(m).x2min;
+    Real &x2max = size.d_view(m).x2max;
+    Real &x3min = size.d_view(m).x3min;
+    Real &x3max = size.d_view(m).x3max;
+    Real x2v = CellCenterX(j-js, indcs.nx2, x2min, x2max);
+    Real x3v = CellCenterX(k-ks, indcs.nx3, x3min, x3max);
+    Real cons[5];
+
+    // inner x1
+    if (mb_bcs.d_view(m,BoundaryFace::inner_x1) == BoundaryFlag::user) {
+      Real x1v = CellCenterX(i-is, indcs.nx1, x1min, x1max);
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u0(m,IDN,k,j,i) = cons[IDN];
+      u0(m,IM1,k,j,i) = cons[IM1];
+      u0(m,IM2,k,j,i) = cons[IM2];
+      u0(m,IM3,k,j,i) = cons[IM3];
+      u0(m,IEN,k,j,i) = cons[IEN];
+    }
+    // outer x1
+    if (mb_bcs.d_view(m,BoundaryFace::outer_x1) == BoundaryFlag::user) {
+      Real x1v = CellCenterX((ie+i+1)-is, indcs.nx1, x1min, x1max);
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u0(m,IDN,k,j,(ie+i+1)) = cons[IDN];
+      u0(m,IM1,k,j,(ie+i+1)) = cons[IM1];
+      u0(m,IM2,k,j,(ie+i+1)) = cons[IM2];
+      u0(m,IM3,k,j,(ie+i+1)) = cons[IM3];
+      u0(m,IEN,k,j,(ie+i+1)) = cons[IEN];
+    }
+  });
+  if (pm->one_d) return;
+
+  // X2 boundaries
+  par_for("diffbc_x2", DevExeSpace(),0,(nmb-1),0,(n3-1),0,(ng-1),0,(n1-1),
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real &x1min = size.d_view(m).x1min;
+    Real &x1max = size.d_view(m).x1max;
+    Real &x2min = size.d_view(m).x2min;
+    Real &x2max = size.d_view(m).x2max;
+    Real &x3min = size.d_view(m).x3min;
+    Real &x3max = size.d_view(m).x3max;
+    Real x1v = CellCenterX(i-is, indcs.nx1, x1min, x1max);
+    Real x3v = CellCenterX(k-ks, indcs.nx3, x3min, x3max);
+    Real cons[5];
+
+    // inner x2
+    if (mb_bcs.d_view(m,BoundaryFace::inner_x2) == BoundaryFlag::user) {
+      Real x2v = CellCenterX(j-js, indcs.nx2, x2min, x2max);
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u0(m,IDN,k,j,i) = cons[IDN];
+      u0(m,IM1,k,j,i) = cons[IM1];
+      u0(m,IM2,k,j,i) = cons[IM2];
+      u0(m,IM3,k,j,i) = cons[IM3];
+      u0(m,IEN,k,j,i) = cons[IEN];
+    }
+    // outer x2
+    if (mb_bcs.d_view(m,BoundaryFace::outer_x2) == BoundaryFlag::user) {
+      Real x2v = CellCenterX((je+j+1)-js, indcs.nx2, x2min, x2max);
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u0(m,IDN,k,(je+j+1),i) = cons[IDN];
+      u0(m,IM1,k,(je+j+1),i) = cons[IM1];
+      u0(m,IM2,k,(je+j+1),i) = cons[IM2];
+      u0(m,IM3,k,(je+j+1),i) = cons[IM3];
+      u0(m,IEN,k,(je+j+1),i) = cons[IEN];
+    }
+  });
+  if (pm->two_d) return;
+
+  // X3 boundaries
+  par_for("diffbc_x3", DevExeSpace(),0,(nmb-1),0,(ng-1),0,(n2-1),0,(n1-1),
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real &x1min = size.d_view(m).x1min;
+    Real &x1max = size.d_view(m).x1max;
+    Real &x2min = size.d_view(m).x2min;
+    Real &x2max = size.d_view(m).x2max;
+    Real &x3min = size.d_view(m).x3min;
+    Real &x3max = size.d_view(m).x3max;
+    Real x1v = CellCenterX(i-is, indcs.nx1, x1min, x1max);
+    Real x2v = CellCenterX(j-js, indcs.nx2, x2min, x2max);
+    Real cons[5];
+
+    // inner x3
+    if (mb_bcs.d_view(m,BoundaryFace::inner_x3) == BoundaryFlag::user) {
+      Real x3v = CellCenterX(k-ks, indcs.nx3, x3min, x3max);
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u0(m,IDN,k,j,i) = cons[IDN];
+      u0(m,IM1,k,j,i) = cons[IM1];
+      u0(m,IM2,k,j,i) = cons[IM2];
+      u0(m,IM3,k,j,i) = cons[IM3];
+      u0(m,IEN,k,j,i) = cons[IEN];
+    }
+    // outer x3
+    if (mb_bcs.d_view(m,BoundaryFace::outer_x3) == BoundaryFlag::user) {
+      Real x3v = CellCenterX((ke+k+1)-ks, indcs.nx3, x3min, x3max);
+      DiffusionConsState(dv, coef, gamma, time, x1v, x2v, x3v, cons);
+      u0(m,IDN,(ke+k+1),j,i) = cons[IDN];
+      u0(m,IM1,(ke+k+1),j,i) = cons[IM1];
+      u0(m,IM2,(ke+k+1),j,i) = cons[IM2];
+      u0(m,IM3,(ke+k+1),j,i) = cons[IM3];
+      u0(m,IEN,(ke+k+1),j,i) = cons[IEN];
+    }
+  });
   return;
 }

--- a/src/pgen/tests/diffusion.cpp
+++ b/src/pgen/tests/diffusion.cpp
@@ -43,10 +43,11 @@ bool set_initial_conditions = true;
 // input parameters passed to user-defined BC function
 struct DiffusionVariables {
   int prob_dir;
+  bool conduction_test, viscosity_test, resistivity_test;
   Real amp, t0, x10;
 };
 
-DiffusionVariables dvars;
+DiffusionVariables diffvars;
 
 } // end anonymous namespace
 
@@ -55,6 +56,12 @@ DiffusionVariables dvars;
 //! \brief Sets initial conditions for diffusion tests
 
 void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
+  std::string evolution_t = pin->GetString("time","evolution");
+  if (evolution_t.compare("kinematic") != 0) {
+    std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+            << "Difusion tests must be run in kinematic mode" << std::endl;
+    exit(EXIT_FAILURE);
+  }
   // set diffusion errors function
   pgen_final_func = DiffusionErrors;
   // user-define BC
@@ -62,10 +69,20 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   if (restart) return;
 
   // Read problem parameters
-  dvars.prob_dir = pin->GetOrAddInteger("problem","direction",1);
-  dvars.amp = pin->GetOrAddReal("problem", "amp", 1.e-6);
-  dvars.t0 = pin->GetOrAddReal("problem", "t0", 0.5);
-  dvars.x10 = pin->GetOrAddReal("problem", "x10", 0.0);
+  diffvars.prob_dir = pin->GetOrAddInteger("problem","direction",1);
+  diffvars.amp = pin->GetOrAddReal("problem", "amp", 1.e-6);
+  diffvars.t0 = pin->GetOrAddReal("problem", "t0", 0.5);
+  diffvars.x10 = pin->GetOrAddReal("problem", "x10", 0.0);
+  diffvars.conduction_test = pin->GetBoolean("problem", "conduction_test");
+  diffvars.viscosity_test = pin->GetBoolean("problem", "viscosity_test");
+  diffvars.resistivity_test = pin->GetBoolean("problem", "resistivity_test");
+  if ((diffvars.conduction_test) &&
+      (diffvars.viscosity_test || diffvars.resistivity_test)) {
+    std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+            << "Cannot run conduction test at same time as viscosity OR resistivity test"
+            << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
   // capture variables for the kernel
   auto &indcs = pmy_mesh_->mb_indcs;
@@ -77,27 +94,34 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   auto &time = pmbp->pmesh->time;
 
   // capture variables for the kernel
-  auto amp_ = dvars.amp, x10_ = dvars.x10;
+  Real amp_ = diffvars.amp;
+  bool ctest = diffvars.conduction_test;
+  bool vtest = diffvars.viscosity_test;
+  Real x10_ = diffvars.x10;
   // add stopping time when called at end of run
-  Real t1 = dvars.t0;
+  Real t1 = diffvars.t0;
   if (!(set_initial_conditions)) {t1 += time;}
 
   // Initialize Hydro variables -------------------------------
   if (pmbp->phydro != nullptr) {
-    EOS_Data &eos = pmbp->phydro->peos->eos_data;
-    if (pmbp->phydro->pvisc == nullptr || pmbp->phydro->pcond == nullptr) {
+    if (ctest && pmbp->phydro->pcond == nullptr) {
       std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-              << "Diffusion test requires viscosity and conduction to be defined in"
-              << " Hydro input block" << std::endl;
+              << "Conduction not defined in Hydro input block" << std::endl;
       exit(EXIT_FAILURE);
     }
+    if (vtest && pmbp->phydro->pvisc == nullptr) {
+      std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
+              << "Viscosity not defined in Hydro input block" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+    EOS_Data &eos = pmbp->phydro->peos->eos_data;
     if (!(eos.is_ideal)) {
       std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
               << "Diffusion test requires ideal EOS in Hydro block" << std::endl;
       exit(EXIT_FAILURE);
     }
     Real gm1 = eos.gamma - 1.0;
-    Real p0 = 1.0/eos.gamma;
     auto &nu_iso = pmbp->phydro->pvisc->nu_iso;
     auto &kappa_iso = pmbp->phydro->pcond->kappa_iso;
 
@@ -113,12 +137,19 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
       int nx1 = indcs.nx1;
       Real x1v = CellCenterX(i-is, nx1, x1min, x1max);
 
+      Real vperp = 0.0;
+      if (vtest) {
+        vperp = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+      }
+      Real p0 = 1.0/eos.gamma;
+      if (ctest) {
+        p0 = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+      }
       u1(m,IDN,k,j,i) = 1,0;
       u1(m,IM1,k,j,i) = 0.0;
-      u1(m,IM2,k,j,i) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
-      u1(m,IM3,k,j,i) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
-      Real press = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
-      u1(m,IEN,k,j,i) = press/gm1 + 0.5*(SQR(u1(m,IM2,k,j,i)) + SQR(u1(m,IM3,k,j,i)));
+      u1(m,IM2,k,j,i) = vperp;
+      u1(m,IM3,k,j,i) = vperp;
+      u1(m,IEN,k,j,i) = p0/gm1 + 0.5*(SQR(u1(m,IM2,k,j,i)) + SQR(u1(m,IM3,k,j,i)));
     });
   } // End initialization of Hydro variables
   return;
@@ -157,49 +188,52 @@ void GaussianProfileBCs(Mesh *pm) {
 
   EOS_Data &eos = pm->pmb_pack->phydro->peos->eos_data;
   Real gm1 = eos.gamma - 1.0;
-  Real p0 = 1.0/eos.gamma;
   auto &nu_iso = pm->pmb_pack->phydro->pvisc->nu_iso;
   auto &kappa_iso = pm->pmb_pack->phydro->pcond->kappa_iso;
   auto &u0 = pm->pmb_pack->phydro->u0;
 
   // capture variables for the kernel
   //auto dv_=dv;
-  auto amp_ = dvars.amp, x10_ = dvars.x10;
-  Real t1 = dvars.t0 + pm->time;
+  auto amp_ = diffvars.amp, x10_ = diffvars.x10;
+  Real t1 = diffvars.t0 + pm->time;
+  bool ctest = diffvars.conduction_test;
+  bool vtest = diffvars.viscosity_test;
 
-  if (dvars.prob_dir == 1) {
+  if (diffvars.prob_dir == 1) {
     par_for("diffusion_x1", DevExeSpace(),0,(nmb-1),0,(n3-1),0,(n2-1),
     KOKKOS_LAMBDA(int m, int k, int j) {
       for (int i=0; i<ng; ++i) {
         // Inner X1-boundary
         Real &x1min = size.d_view(m).x1min;
         Real &x1max = size.d_view(m).x1max;
-        int nx1 = indcs.nx1;
-        Real x1v = CellCenterX(-1-i, nx1, x1min, x1max);
-
-        u0(m,IDN,k,j,is-i-1) = 1.0;
+        Real x1v = CellCenterX(-1-i, indcs.nx1, x1min, x1max);
+        Real vperp = 0.0;
+        if (vtest) {
+          vperp = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+        }
+        Real p0 = 1.0/eos.gamma;
+        if (ctest) {
+          p0 = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+        }
+        u0(m,IDN,k,j,is-i-1) = 1,0;
         u0(m,IM1,k,j,is-i-1) = 0.0;
-        u0(m,IM2,k,j,is-i-1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                               /sqrt(4.*M_PI*nu_iso*t1);
-        u0(m,IM3,k,j,is-i-1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                               /sqrt(4.*M_PI*nu_iso*t1);
-        Real press = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))
-                     /sqrt(4.*M_PI*kappa_iso*t1);
-        u0(m,IEN,k,j,is-i-1) = press/gm1 +
-                               0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
+        u0(m,IM2,k,j,is-i-1) = vperp;
+        u0(m,IM3,k,j,is-i-1) = vperp;
+        u0(m,IEN,k,j,is-i-1) = p0/gm1 + 0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
 
         // Outer X1-boundary
-        x1v = CellCenterX(ie-is+1+i, nx1, x1min, x1max);
-
+        x1v = CellCenterX(ie-is+1+i, indcs.nx1, x1min, x1max);
+        if (vtest) {
+          vperp = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+        }
+        if (ctest) {
+          p0 = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+        }
         u0(m,IDN,k,j,ie+i+1) = 1,0;
         u0(m,IM1,k,j,ie+i+1) = 0.0;
-        u0(m,IM2,k,j,ie+i+1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                               /sqrt(4.*M_PI*nu_iso*t1);
-        u0(m,IM3,k,j,ie+i+1) = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))
-                               /sqrt(4.*M_PI*nu_iso*t1);
-        press = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
-        u0(m,IEN,k,j,ie+i+1) = press/gm1 +
-                               0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
+        u0(m,IM2,k,j,ie+i+1) = vperp;
+        u0(m,IM3,k,j,ie+i+1) = vperp;
+        u0(m,IEN,k,j,ie+i+1) = p0/gm1 + 0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
       }
     });
   }

--- a/src/pgen/tests/diffusion.cpp
+++ b/src/pgen/tests/diffusion.cpp
@@ -229,7 +229,7 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
     }
     if (pmbp->pmhd->presist == nullptr) {
       std::cout <<"### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
-              << "Resistivity (mhd/ohmic_resistivity) not defined in MHD input block"
+              << "Resistivity (mhd/eta_ohm) not defined in MHD input block"
               << std::endl;
       exit(EXIT_FAILURE);
     }

--- a/src/pgen/tests/diffusion.cpp
+++ b/src/pgen/tests/diffusion.cpp
@@ -120,7 +120,7 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
     }
     Real gm1 = eos.gamma - 1.0;
     auto &nu_iso = pmbp->phydro->pvisc->nu_iso;
-    auto &kappa_iso = pmbp->phydro->pcond->kappa_iso;
+    auto &alpha_iso = pmbp->phydro->pcond->alpha_iso;
 
     // compute solution in u1 register. For initial conditions, set u1 -> u0.
     auto &u1 = (set_initial_conditions)? pmbp->phydro->u0 : pmbp->phydro->u1;
@@ -141,8 +141,8 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
       }
       Real p0 = 1.0/eos.gamma;
       if (ctest) {
-        p0 = (amp_/sqrt(1.0 + 4.0*kappa_iso*time))*
-              exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*kappa_iso*time));
+        p0 = (amp_/sqrt(1.0 + 4.0*alpha_iso*time))*
+              exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*alpha_iso*time));
       }
       u1(m,IDN,k,j,i) = 1,0;
       u1(m,IM1,k,j,i) = 0.0;
@@ -188,7 +188,7 @@ void GaussianProfileBCs(Mesh *pm) {
   EOS_Data &eos = pm->pmb_pack->phydro->peos->eos_data;
   Real gm1 = eos.gamma - 1.0;
   auto &nu_iso = pm->pmb_pack->phydro->pvisc->nu_iso;
-  auto &kappa_iso = pm->pmb_pack->phydro->pcond->kappa_iso;
+  auto &alpha_iso = pm->pmb_pack->phydro->pcond->alpha_iso;
   auto &u0 = pm->pmb_pack->phydro->u0;
 
   // capture variables for the kernel
@@ -213,8 +213,8 @@ void GaussianProfileBCs(Mesh *pm) {
         }
         Real p0 = 1.0/eos.gamma;
         if (ctest) {
-          p0 = (amp_/sqrt(1.0 + 4.0*kappa_iso*time))*
-                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*kappa_iso*time));
+          p0 = (amp_/sqrt(1.0 + 4.0*alpha_iso*time))*
+                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*alpha_iso*time));
         }
         u0(m,IDN,k,j,is-i-1) = 1,0;
         u0(m,IM1,k,j,is-i-1) = 0.0;
@@ -230,8 +230,8 @@ void GaussianProfileBCs(Mesh *pm) {
         }
         p0 = 1.0/eos.gamma;
         if (ctest) {
-          p0 = (amp_/sqrt(1.0 + 4.0*kappa_iso*time))*
-                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*kappa_iso*time));
+          p0 = (amp_/sqrt(1.0 + 4.0*alpha_iso*time))*
+                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*alpha_iso*time));
         }
         u0(m,IDN,k,j,ie+i+1) = 1,0;
         u0(m,IM1,k,j,ie+i+1) = 0.0;

--- a/src/pgen/tests/diffusion.cpp
+++ b/src/pgen/tests/diffusion.cpp
@@ -44,7 +44,7 @@ bool set_initial_conditions = true;
 struct DiffusionVariables {
   int prob_dir;
   bool conduction_test, viscosity_test, resistivity_test;
-  Real amp, t0, x10;
+  Real amp, x10;
 };
 
 DiffusionVariables diffvars;
@@ -71,7 +71,6 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   // Read problem parameters
   diffvars.prob_dir = pin->GetOrAddInteger("problem","direction",1);
   diffvars.amp = pin->GetOrAddReal("problem", "amp", 1.e-6);
-  diffvars.t0 = pin->GetOrAddReal("problem", "t0", 0.5);
   diffvars.x10 = pin->GetOrAddReal("problem", "x10", 0.0);
   diffvars.conduction_test = pin->GetBoolean("problem", "conduction_test");
   diffvars.viscosity_test = pin->GetBoolean("problem", "viscosity_test");
@@ -94,13 +93,11 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
   auto &time = pmbp->pmesh->time;
 
   // capture variables for the kernel
-  Real amp_ = diffvars.amp;
   bool ctest = diffvars.conduction_test;
   bool vtest = diffvars.viscosity_test;
   Real x10_ = diffvars.x10;
-  // add stopping time when called at end of run
-  Real t1 = diffvars.t0;
-  if (!(set_initial_conditions)) {t1 += time;}
+  // compute amplitude when called at end of run
+  Real amp_ = diffvars.amp;
 
   // Initialize Hydro variables -------------------------------
   if (pmbp->phydro != nullptr) {
@@ -139,17 +136,19 @@ void ProblemGenerator::Diffusion(ParameterInput *pin, const bool restart) {
 
       Real vperp = 0.0;
       if (vtest) {
-        vperp = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+        vperp = (amp_/sqrt(1.0 + 4.0*nu_iso*time))*
+                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*nu_iso*time));
       }
       Real p0 = 1.0/eos.gamma;
       if (ctest) {
-        p0 = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+        p0 = (amp_/sqrt(1.0 + 4.0*kappa_iso*time))*
+              exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*kappa_iso*time));
       }
       u1(m,IDN,k,j,i) = 1,0;
       u1(m,IM1,k,j,i) = 0.0;
       u1(m,IM2,k,j,i) = vperp;
       u1(m,IM3,k,j,i) = vperp;
-      u1(m,IEN,k,j,i) = p0/gm1 + 0.5*(SQR(u1(m,IM2,k,j,i)) + SQR(u1(m,IM3,k,j,i)));
+      u1(m,IEN,k,j,i) = p0/gm1 + 0.5*(SQR(vperp) + SQR(vperp));
     });
   } // End initialization of Hydro variables
   return;
@@ -195,7 +194,7 @@ void GaussianProfileBCs(Mesh *pm) {
   // capture variables for the kernel
   //auto dv_=dv;
   auto amp_ = diffvars.amp, x10_ = diffvars.x10;
-  Real t1 = diffvars.t0 + pm->time;
+  Real time = pm->time;
   bool ctest = diffvars.conduction_test;
   bool vtest = diffvars.viscosity_test;
 
@@ -209,31 +208,36 @@ void GaussianProfileBCs(Mesh *pm) {
         Real x1v = CellCenterX(-1-i, indcs.nx1, x1min, x1max);
         Real vperp = 0.0;
         if (vtest) {
-          vperp = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+          vperp = (amp_/sqrt(1.0 + 4.0*nu_iso*time))*
+                  exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*nu_iso*time));
         }
         Real p0 = 1.0/eos.gamma;
         if (ctest) {
-          p0 = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+          p0 = (amp_/sqrt(1.0 + 4.0*kappa_iso*time))*
+                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*kappa_iso*time));
         }
         u0(m,IDN,k,j,is-i-1) = 1,0;
         u0(m,IM1,k,j,is-i-1) = 0.0;
         u0(m,IM2,k,j,is-i-1) = vperp;
         u0(m,IM3,k,j,is-i-1) = vperp;
-        u0(m,IEN,k,j,is-i-1) = p0/gm1 + 0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
+        u0(m,IEN,k,j,is-i-1) = p0/gm1 + 0.5*(SQR(vperp) + SQR(vperp));
 
         // Outer X1-boundary
         x1v = CellCenterX(ie-is+1+i, indcs.nx1, x1min, x1max);
         if (vtest) {
-          vperp = amp_*exp(SQR(x1v-x10_)/(-4.0*nu_iso*t1))/sqrt(4.*M_PI*nu_iso*t1);
+          vperp = (amp_/sqrt(1.0 + 4.0*nu_iso*time))*
+                  exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*nu_iso*time));
         }
+        p0 = 1.0/eos.gamma;
         if (ctest) {
-          p0 = amp_*exp(SQR(x1v-x10_)/(-4.0*kappa_iso*t1))/sqrt(4.*M_PI*kappa_iso*t1);
+          p0 = (amp_/sqrt(1.0 + 4.0*kappa_iso*time))*
+                exp(-1.0*SQR(x1v-x10_)/(1.0 + 4.0*kappa_iso*time));
         }
         u0(m,IDN,k,j,ie+i+1) = 1,0;
         u0(m,IM1,k,j,ie+i+1) = 0.0;
         u0(m,IM2,k,j,ie+i+1) = vperp;
         u0(m,IM3,k,j,ie+i+1) = vperp;
-        u0(m,IEN,k,j,ie+i+1) = p0/gm1 + 0.5*(SQR(u0(m,IM2,k,j,i)) + SQR(u0(m,IM3,k,j,i)));
+        u0(m,IEN,k,j,ie+i+1) = p0/gm1 + 0.5*(SQR(vperp) + SQR(vperp));
       }
     });
   }

--- a/src/pgen/tests/gr_bondi.cpp
+++ b/src/pgen/tests/gr_bondi.cpp
@@ -91,12 +91,6 @@ void ProblemGenerator::BondiAccretion(ParameterInput *pin, const bool restart) {
   MeshBlockPack *pmbp = pmy_mesh_->pmb_pack;
 
   if (pmbp->pdyngr == nullptr) {
-    if (!(pmbp->phydro->peos->eos_data.use_e)) {
-      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-                << std::endl
-                << "gr_bondi test requires hydro/use_e=true" << std::endl;
-      exit(EXIT_FAILURE);
-    }
     if (!pmbp->pcoord->is_general_relativistic) {
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
                 << std::endl

--- a/src/srcterms/srcterms_newdt.cpp
+++ b/src/srcterms/srcterms_newdt.cpp
@@ -33,7 +33,6 @@ void SourceTerms::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_d
   dtnew = static_cast<Real>(std::numeric_limits<float>::max());
 
   if (ism_cooling) {
-    Real use_e = eos_data.use_e;
     Real gamma = eos_data.gamma;
     Real gm1 = gamma - 1.0;
     Real heating_rate = hrate;
@@ -58,15 +57,8 @@ void SourceTerms::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_d
       j += js;
 
       // temperature in cgs unit
-      Real temp = 1.0;
-      Real eint = 1.0;
-      if (use_e) {
-        temp = temp_unit*w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
-        eint = w0(m,IEN,k,j,i);
-      } else {
-        temp = temp_unit*w0(m,ITM,k,j,i);
-        eint = w0(m,ITM,k,j,i)*w0(m,IDN,k,j,i)/gm1;
-      }
+      Real temp = temp_unit*w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
+      Real &eint = w0(m,IEN,k,j,i);
 
       Real lambda_cooling = ISMCoolFn(temp)/cooling_unit;
       Real gamma_heating = heating_rate/heating_unit;
@@ -80,7 +72,6 @@ void SourceTerms::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_d
   }
 
   if (rel_cooling) {
-    Real use_e = eos_data.use_e;
     Real gamma = eos_data.gamma;
     Real gm1 = gamma - 1.0;
     Real cooling_rate = crate_rel;
@@ -99,22 +90,13 @@ void SourceTerms::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_d
       j += js;
 
       // temperature in cgs unit
-      Real temp = 1.0;
-      Real eint = 1.0;
-      if (use_e) {
-        temp = w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
-        eint = w0(m,IEN,k,j,i);
-      } else {
-        temp = w0(m,ITM,k,j,i);
-        eint = w0(m,ITM,k,j,i)*w0(m,IDN,k,j,i)/gm1;
-      }
+      Real temp = w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
+      Real &eint = w0(m,IEN,k,j,i);
 
       auto &ux = w0(m, IVX, k, j, i);
       auto &uy = w0(m, IVY, k, j, i);
       auto &uz = w0(m, IVZ, k, j, i);
-
-      auto ut = 1. + ux * ux + uy * uy + uz * uz;
-      ut = sqrt(ut);
+      Real ut = sqrt(1.0 + ux * ux + uy * uy + uz * uz);
 
       // The following should be approximately correct
       // add a tiny number

--- a/tst/inputs/diffusion.athinput
+++ b/tst/inputs/diffusion.athinput
@@ -1,0 +1,73 @@
+# AthenaK input file for Gaussian-pulse diffusion tests (conduction/viscosity).
+# Mesh sizes, diffusivities (hydro/nu_iso or hydro/alpha_iso), the conduction/viscosity
+# test flags, the spread_x1/x2/x3 axes, vel_comp, tlim and job/basename are overridden
+# per test on the command line (see tst/test_suite/diffusion/).
+
+<comment>
+problem   = Gaussian-pulse diffusion
+
+<job>
+basename  = diffusion   # problem ID: basename of output filenames
+
+<mesh>
+nghost    = 3          # Number of ghost cells
+nx1       = 64         # Number of zones in X1-direction
+x1min     = -6.0       # minimum value of X1
+x1max     = 6.0        # maximum value of X1
+ix1_bc    = user       # inner-X1 boundary flag
+ox1_bc    = user       # outer-X1 boundary flag
+
+nx2       = 1          # Number of zones in X2-direction
+x2min     = -6.0       # minimum value of X2
+x2max     = 6.0        # maximum value of X2
+ix2_bc    = user       # inner-X2 boundary flag
+ox2_bc    = user       # outer-X2 boundary flag
+
+nx3       = 1          # Number of zones in X3-direction
+x3min     = -6.0       # minimum value of X3
+x3max     = 6.0        # maximum value of X3
+ix3_bc    = user       # inner-X3 boundary flag
+ox3_bc    = user       # outer-X3 boundary flag
+
+<meshblock>
+nx1       = 64         # Number of cells in each MeshBlock, X1-dir
+nx2       = 1          # Number of cells in each MeshBlock, X2-dir
+nx3       = 1          # Number of cells in each MeshBlock, X3-dir
+
+<time>
+evolution  = kinematic # dynamic/kinematic/static (diffusion tests require kinematic)
+integrator = rk2       # time integration algorithm
+cfl_number = 0.4       # The Courant, Friedrichs, & Lewy (CFL) Number
+nlim       = -1        # cycle limit (no limit if <0)
+tlim       = 1.0       # time limit
+ndiag      = 1         # cycles between diagostic output
+
+<hydro>
+eos         = ideal    # EOS type
+reconstruct = wenoz    # spatial reconstruction method
+rsolver     = advect   # Riemann-solver to be used
+gamma       = 1.66666666667   # gamma = C_p/C_v
+nu_iso      = 0.0      # isotropic kinematic viscosity (set by viscosity tests)
+alpha_iso   = 0.0      # isotropic thermal diffusivity (set by conduction tests)
+
+<units>
+# Default (length=mass=time=mu=1) code units. Present so the thermal-conduction module
+# (which references the units class) has a valid units object.
+length_cgs = 1.0
+mass_cgs   = 1.0
+time_cgs   = 1.0
+mu         = 1.0
+
+<problem>
+pgen_name        = diffusion  # problem generator name
+amp              = 1.0e-6     # amplitude of Gaussian pulse
+x10              = 0.0        # center of Gaussian in x1
+x20              = 0.0        # center of Gaussian in x2
+x30              = 0.0        # center of Gaussian in x3
+conduction_test  = false     # set true to diffuse a temperature pulse
+viscosity_test   = false     # set true to diffuse a velocity pulse
+resistivity_test = false     # (not yet implemented)
+spread_x1        = true       # Gaussian varies along x1
+spread_x2        = false      # Gaussian varies along x2
+spread_x3        = false      # Gaussian varies along x3
+vel_comp         = 2          # velocity component carrying the viscous pulse (1/2/3)

--- a/tst/inputs/diffusion_mhd.athinput
+++ b/tst/inputs/diffusion_mhd.athinput
@@ -48,7 +48,6 @@ eos               = ideal    # EOS type
 reconstruct       = wenoz    # spatial reconstruction method
 rsolver           = advect   # Riemann-solver (kinematic MHD uses advect)
 gamma             = 1.66666666667   # gamma = C_p/C_v
-ohmic_resistivity = constant # constant Ohmic resistivity
 eta_ohm           = 0.25     # Ohmic resistivity (set by resistivity tests)
 
 <units>

--- a/tst/inputs/diffusion_mhd.athinput
+++ b/tst/inputs/diffusion_mhd.athinput
@@ -1,0 +1,73 @@
+# AthenaK input file for Gaussian-pulse resistivity (Ohmic diffusion) tests.
+# Mesh sizes, eta_ohm, the spread_x1/x2/x3 axes, vel_comp (selects the diffusing B
+# component: 1->Bx, 2->By, 3->Bz), tlim and job/basename are overridden per test on the
+# command line (see tst/test_suite/diffusion/).  Boundaries use outflow BCs: the pulse is
+# negligible at the (wide) domain edges.
+
+<comment>
+problem   = Gaussian-pulse Ohmic diffusion
+
+<job>
+basename  = diffusion_resist   # problem ID: basename of output filenames
+
+<mesh>
+nghost    = 3          # Number of ghost cells
+nx1       = 64         # Number of zones in X1-direction
+x1min     = -6.0       # minimum value of X1
+x1max     = 6.0        # maximum value of X1
+ix1_bc    = outflow    # inner-X1 boundary flag
+ox1_bc    = outflow    # outer-X1 boundary flag
+
+nx2       = 1          # Number of zones in X2-direction
+x2min     = -6.0       # minimum value of X2
+x2max     = 6.0        # maximum value of X2
+ix2_bc    = outflow    # inner-X2 boundary flag
+ox2_bc    = outflow    # outer-X2 boundary flag
+
+nx3       = 1          # Number of zones in X3-direction
+x3min     = -6.0       # minimum value of X3
+x3max     = 6.0        # maximum value of X3
+ix3_bc    = outflow    # inner-X3 boundary flag
+ox3_bc    = outflow    # outer-X3 boundary flag
+
+<meshblock>
+nx1       = 64         # Number of cells in each MeshBlock, X1-dir
+nx2       = 1          # Number of cells in each MeshBlock, X2-dir
+nx3       = 1          # Number of cells in each MeshBlock, X3-dir
+
+<time>
+evolution  = kinematic # dynamic/kinematic/static (diffusion tests require kinematic)
+integrator = rk2       # time integration algorithm
+cfl_number = 0.4       # The Courant, Friedrichs, & Lewy (CFL) Number
+nlim       = -1        # cycle limit (no limit if <0)
+tlim       = 1.0       # time limit
+ndiag      = 1         # cycles between diagostic output
+
+<mhd>
+eos               = ideal    # EOS type
+reconstruct       = wenoz    # spatial reconstruction method
+rsolver           = advect   # Riemann-solver (kinematic MHD uses advect)
+gamma             = 1.66666666667   # gamma = C_p/C_v
+ohmic_resistivity = constant # constant Ohmic resistivity
+eta_ohm           = 0.25     # Ohmic resistivity (set by resistivity tests)
+
+<units>
+# Default (length=mass=time=mu=1) code units.
+length_cgs = 1.0
+mass_cgs   = 1.0
+time_cgs   = 1.0
+mu         = 1.0
+
+<problem>
+pgen_name        = diffusion  # problem generator name
+amp              = 1.0e-6     # amplitude of Gaussian pulse
+x10              = 0.0        # center of Gaussian in x1
+x20              = 0.0        # center of Gaussian in x2
+x30              = 0.0        # center of Gaussian in x3
+conduction_test  = false     # set true to diffuse a temperature pulse
+viscosity_test   = false     # set true to diffuse a velocity pulse
+resistivity_test = true      # set true to diffuse a magnetic-field pulse
+spread_x1        = true       # Gaussian varies along x1
+spread_x2        = false      # Gaussian varies along x2
+spread_x3        = false      # Gaussian varies along x3
+vel_comp         = 2          # B component carrying the pulse (1->Bx, 2->By, 3->Bz)

--- a/tst/test_suite/diffusion/test_diffusion_conduct_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_conduct_cpu.py
@@ -48,6 +48,10 @@ def arguments(iv, rv, fv, wv, res, soe, name):
     ]
 
 
+"""
+Uses test_error_convergence() function in testutils.py, written for linear wave
+convergence problems. Runs 1d/2d tests using _mode as wave flag.
+"""
 def test_run():
     """Run the 1D and 2D thermal-conduction convergence tests."""
     testutils.test_error_convergence(
@@ -61,6 +65,4 @@ def test_run():
         "diff",
         "none",
         "hydro",
-        left_wave="1d",
-        right_wave="2d",
     )

--- a/tst/test_suite/diffusion/test_diffusion_conduct_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_conduct_cpu.py
@@ -49,9 +49,11 @@ def arguments(iv, rv, fv, wv, res, soe, name):
 
 
 """
-Uses test_error_convergence() function in testutils.py, written for linear wave
+Following uses test_error_convergence() function in testutils.py, written for linear wave
 convergence problems. Runs 1d/2d tests using _mode as wave flag.
 """
+
+
 def test_run():
     """Run the 1D and 2D thermal-conduction convergence tests."""
     testutils.test_error_convergence(

--- a/tst/test_suite/diffusion/test_diffusion_conduct_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_conduct_gpu.py
@@ -40,9 +40,11 @@ def arguments(iv, rv, fv, wv, res, soe, name):
 
 
 """
-Uses test_error_convergence() function in testutils.py, written for linear wave
+Following uses test_error_convergence() function in testutils.py, written for linear wave
 convergence problems. Runs tests using _mode as wave flag.
 """
+
+
 def test_run():
     """Run the 3D thermal-conduction convergence test."""
     testutils.test_error_convergence(

--- a/tst/test_suite/diffusion/test_diffusion_conduct_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_conduct_gpu.py
@@ -39,6 +39,10 @@ def arguments(iv, rv, fv, wv, res, soe, name):
     ]
 
 
+"""
+Uses test_error_convergence() function in testutils.py, written for linear wave
+convergence problems. Runs tests using _mode as wave flag.
+"""
 def test_run():
     """Run the 3D thermal-conduction convergence test."""
     testutils.test_error_convergence(
@@ -52,6 +56,4 @@ def test_run():
         "diff",
         "none",
         "hydro",
-        left_wave="heat",
-        right_wave="heat",
     )

--- a/tst/test_suite/diffusion/test_diffusion_heat_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_heat_cpu.py
@@ -1,0 +1,66 @@
+"""
+Thermal-conduction convergence tests in 1D and 2D (CPU).
+Diffuses an isotropic Gaussian temperature pulse with the gaussian-pulse diffusion pgen
+and checks that the L1 error converges at (close to) 2nd order between two resolutions, in
+the same style as the linear-wave tests.  The "1d"/"2d" modes select the number of axes
+along which the pulse spreads.
+"""
+
+# Modules
+import test_suite.testutils as testutils
+
+# Threshold (max high-res RMS-L1 error) and max error ratio (err_hi/err_lo), keyed by
+# (soe, integrator, label, mode).
+errors = {
+    ("hydro", "rk2", "diff", "1d"): (6.0e-10, 0.30),
+    ("hydro", "rk2", "diff", "2d"): (1.5e-10, 0.30),
+}
+
+_mode = ["1d", "2d"]
+_res = [32, 64]
+
+# number of axes the Gaussian spreads along, per mode
+_ndim = {"1d": 1, "2d": 2}
+
+
+def arguments(iv, rv, fv, wv, res, soe, name):
+    """Assemble arguments for run command"""
+    ndim = _ndim[wv]
+    nx2 = res if ndim >= 2 else 1
+    mbx2 = res // 2 if ndim >= 2 else 1
+    return [
+        f"job/basename={name}",
+        "time/tlim=1.0",
+        "time/integrator=" + iv,
+        "mesh/nx1=" + repr(res),
+        "mesh/nx2=" + repr(nx2),
+        "mesh/nx3=1",
+        "meshblock/nx1=" + repr(res // 2),
+        "meshblock/nx2=" + repr(mbx2),
+        "meshblock/nx3=1",
+        "problem/conduction_test=true",
+        "problem/viscosity_test=false",
+        "problem/spread_x1=true",
+        "problem/spread_x2=" + ("true" if ndim >= 2 else "false"),
+        "problem/spread_x3=false",
+        "hydro/alpha_iso=0.5",
+        "problem/amp=1.0e-6",
+    ]
+
+
+def test_run():
+    """Run the 1D and 2D thermal-conduction convergence tests."""
+    testutils.test_error_convergence(
+        "inputs/diffusion.athinput",
+        "diffusion_heat",
+        arguments,
+        errors,
+        _mode,
+        _res,
+        "rk2",
+        "diff",
+        "none",
+        "hydro",
+        left_wave="1d",
+        right_wave="2d",
+    )

--- a/tst/test_suite/diffusion/test_diffusion_heat_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_heat_gpu.py
@@ -1,0 +1,57 @@
+"""
+Thermal-conduction convergence test in 3D (GPU).
+Diffuses an isotropic 3D Gaussian temperature pulse (spreading along x1, x2 and x3) and
+checks that the L1 error converges at (close to) 2nd order between two resolutions.
+"""
+
+# Modules
+import test_suite.testutils as testutils
+
+# Threshold (max high-res RMS-L1 error) and max error ratio (err_hi/err_lo), keyed by
+# (soe, integrator, label, mode).
+errors = {
+    ("hydro", "rk2", "diff", "heat"): (3.0e-11, 0.30),
+}
+
+_mode = ["heat"]
+_res = [32, 64]
+
+
+def arguments(iv, rv, fv, wv, res, soe, name):
+    """Assemble arguments for run command"""
+    return [
+        f"job/basename={name}",
+        "time/tlim=1.0",
+        "time/integrator=" + iv,
+        "mesh/nx1=" + repr(res),
+        "mesh/nx2=" + repr(res),
+        "mesh/nx3=" + repr(res),
+        "meshblock/nx1=" + repr(res // 2),
+        "meshblock/nx2=" + repr(res // 2),
+        "meshblock/nx3=" + repr(res // 2),
+        "problem/conduction_test=true",
+        "problem/viscosity_test=false",
+        "problem/spread_x1=true",
+        "problem/spread_x2=true",
+        "problem/spread_x3=true",
+        "hydro/alpha_iso=0.5",
+        "problem/amp=1.0e-6",
+    ]
+
+
+def test_run():
+    """Run the 3D thermal-conduction convergence test."""
+    testutils.test_error_convergence(
+        "inputs/diffusion.athinput",
+        "diffusion_heat3d",
+        arguments,
+        errors,
+        _mode,
+        _res,
+        "rk2",
+        "diff",
+        "none",
+        "hydro",
+        left_wave="heat",
+        right_wave="heat",
+    )

--- a/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
@@ -44,6 +44,10 @@ def arguments(iv, rv, fv, wv, res, soe, name):
     ]
 
 
+"""
+Uses test_error_convergence() function in testutils.py, written for linear wave
+convergence problems. Runs By/Bz tests using _mode as wave flag.
+"""
 def test_run():
     """Run the 1D resistive-diffusion convergence test for By and Bz."""
     testutils.test_error_convergence(
@@ -57,6 +61,4 @@ def test_run():
         "diff",
         "none",
         "mhd",
-        left_wave="By",
-        right_wave="Bz",
     )

--- a/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
@@ -1,0 +1,62 @@
+"""
+Resistive (Ohmic) diffusion convergence test in 1D (CPU).
+Diffuses a 1D Gaussian pulse in a single transverse magnetic-field component (By and Bz,
+in turn) along x1, and checks 2nd-order convergence of the L1 error between two
+resolutions.  This is the magnetic analogue of the 1D viscosity test.
+"""
+
+# Modules
+import test_suite.testutils as testutils
+
+# Threshold (max high-res RMS-L1 error) and max error ratio (err_hi/err_lo), keyed by
+# (soe, integrator, label, mode).  "By"/"Bz" select the diffusing field component.
+errors = {
+    ("mhd", "rk2", "diff", "By"): (1.5e-10, 0.30),
+    ("mhd", "rk2", "diff", "Bz"): (1.5e-10, 0.30),
+}
+
+_mode = ["By", "Bz"]
+_res = [64, 128]
+
+# magnetic-field component (1->Bx, 2->By, 3->Bz) carrying the pulse for each mode
+_b_comp = {"By": 2, "Bz": 3}
+
+
+def arguments(iv, rv, fv, wv, res, soe, name):
+    """Assemble arguments for run command"""
+    return [
+        f"job/basename={name}",
+        "time/tlim=1.0",
+        "time/integrator=" + iv,
+        "mesh/nx1=" + repr(res),
+        "mesh/nx2=1",
+        "mesh/nx3=1",
+        "meshblock/nx1=" + repr(res // 2),
+        "meshblock/nx2=1",
+        "meshblock/nx3=1",
+        "problem/resistivity_test=true",
+        "problem/spread_x1=true",
+        "problem/spread_x2=false",
+        "problem/spread_x3=false",
+        "problem/vel_comp=" + repr(_b_comp[wv]),
+        "mhd/eta_ohm=0.25",
+        "problem/amp=1.0e-6",
+    ]
+
+
+def test_run():
+    """Run the 1D resistive-diffusion convergence test for By and Bz."""
+    testutils.test_error_convergence(
+        "inputs/diffusion_mhd.athinput",
+        "diffusion_resist1d",
+        arguments,
+        errors,
+        _mode,
+        _res,
+        "rk2",
+        "diff",
+        "none",
+        "mhd",
+        left_wave="By",
+        right_wave="Bz",
+    )

--- a/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
@@ -45,9 +45,11 @@ def arguments(iv, rv, fv, wv, res, soe, name):
 
 
 """
-Uses test_error_convergence() function in testutils.py, written for linear wave
+Following uses test_error_convergence() function in testutils.py, written for linear wave
 convergence problems. Runs By/Bz tests using _mode as wave flag.
 """
+
+
 def test_run():
     """Run the 1D resistive-diffusion convergence test for By and Bz."""
     testutils.test_error_convergence(

--- a/tst/test_suite/diffusion/test_diffusion_resist_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_gpu.py
@@ -74,6 +74,4 @@ def test_run():
         "diff",
         "none",
         "mhd",
-        left_wave="xy",
-        right_wave="zx",
     )

--- a/tst/test_suite/diffusion/test_diffusion_resist_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_gpu.py
@@ -1,0 +1,79 @@
+"""
+Resistive (Ohmic) diffusion convergence test on 2D planes embedded in 3D (GPU).
+For each of the xy, yz and zx planes the mesh is extended in the two in-plane directions
+and only 4 cells wide in the perpendicular direction.  The diffusing magnetic-field
+component is the one parallel to that perpendicular direction (Bz for xy, Bx for yz, By
+for zx), which spreads isotropically within the plane and remains divergence-free (it is
+uniform along its own axis).  This is the magnetic analogue of the viscosity plane test.
+Checks 2nd-order convergence of the L1 error between two in-plane resolutions.
+"""
+
+# Modules
+import test_suite.testutils as testutils
+
+# Threshold (max high-res RMS-L1 error) and max error ratio (err_hi/err_lo), keyed by
+# (soe, integrator, label, mode).
+errors = {
+    ("mhd", "rk2", "diff", "xy"): (3.0e-11, 0.30),
+    ("mhd", "rk2", "diff", "yz"): (3.0e-11, 0.30),
+    ("mhd", "rk2", "diff", "zx"): (3.0e-11, 0.30),
+}
+
+_mode = ["xy", "yz", "zx"]
+_res = [64, 128]
+
+# Per-plane setup: spread axes, diffusing B component (1->Bx, 2->By, 3->Bz), and the thin
+# (perpendicular) direction (1->x1, 2->x2, 3->x3).
+_plane = {
+    "xy": {"spread": (True, True, False), "b_comp": 3, "thin": 3},
+    "yz": {"spread": (False, True, True), "b_comp": 1, "thin": 1},
+    "zx": {"spread": (True, False, True), "b_comp": 2, "thin": 2},
+}
+_NTHIN = 4  # cells in the perpendicular direction
+
+
+def arguments(iv, rv, fv, wv, res, soe, name):
+    """Assemble arguments for run command"""
+    p = _plane[wv]
+    sx1, sx2, sx3 = p["spread"]
+    # mesh/meshblock sizes: in-plane = res (tiled by 2), perpendicular = _NTHIN
+    nx = {1: res, 2: res, 3: res}
+    mbx = {1: res // 2, 2: res // 2, 3: res // 2}
+    nx[p["thin"]] = _NTHIN
+    mbx[p["thin"]] = _NTHIN
+    return [
+        f"job/basename={name}",
+        "time/tlim=1.0",
+        "time/integrator=" + iv,
+        "mesh/nx1=" + repr(nx[1]),
+        "mesh/nx2=" + repr(nx[2]),
+        "mesh/nx3=" + repr(nx[3]),
+        "meshblock/nx1=" + repr(mbx[1]),
+        "meshblock/nx2=" + repr(mbx[2]),
+        "meshblock/nx3=" + repr(mbx[3]),
+        "problem/resistivity_test=true",
+        "problem/spread_x1=" + ("true" if sx1 else "false"),
+        "problem/spread_x2=" + ("true" if sx2 else "false"),
+        "problem/spread_x3=" + ("true" if sx3 else "false"),
+        "problem/vel_comp=" + repr(p["b_comp"]),
+        "mhd/eta_ohm=0.25",
+        "problem/amp=1.0e-6",
+    ]
+
+
+def test_run():
+    """Run the resistive-diffusion plane tests for xy, yz and zx."""
+    testutils.test_error_convergence(
+        "inputs/diffusion_mhd.athinput",
+        "diffusion_resist_planes",
+        arguments,
+        errors,
+        _mode,
+        _res,
+        "rk2",
+        "diff",
+        "none",
+        "mhd",
+        left_wave="xy",
+        right_wave="zx",
+    )

--- a/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
@@ -1,0 +1,62 @@
+"""
+Viscous-diffusion convergence test in 1D (CPU).
+Diffuses a 1D Gaussian pulse in a single transverse velocity component (vy and vz, in
+turn) along x1, and checks 2nd-order convergence of the L1 error between two resolutions.
+"""
+
+# Modules
+import test_suite.testutils as testutils
+
+# Threshold (max high-res RMS-L1 error) and max error ratio (err_hi/err_lo), keyed by
+# (soe, integrator, label, mode).  "vy"/"vz" select the diffusing velocity component.
+errors = {
+    ("hydro", "rk2", "diff", "vy"): (1.5e-10, 0.30),
+    ("hydro", "rk2", "diff", "vz"): (1.5e-10, 0.30),
+}
+
+_mode = ["vy", "vz"]
+_res = [64, 128]
+
+# velocity component (1/2/3) carrying the pulse for each mode
+_vel_comp = {"vy": 2, "vz": 3}
+
+
+def arguments(iv, rv, fv, wv, res, soe, name):
+    """Assemble arguments for run command"""
+    return [
+        f"job/basename={name}",
+        "time/tlim=1.0",
+        "time/integrator=" + iv,
+        "mesh/nx1=" + repr(res),
+        "mesh/nx2=1",
+        "mesh/nx3=1",
+        "meshblock/nx1=" + repr(res // 2),
+        "meshblock/nx2=1",
+        "meshblock/nx3=1",
+        "problem/viscosity_test=true",
+        "problem/conduction_test=false",
+        "problem/spread_x1=true",
+        "problem/spread_x2=false",
+        "problem/spread_x3=false",
+        "problem/vel_comp=" + repr(_vel_comp[wv]),
+        "hydro/nu_iso=0.25",
+        "problem/amp=1.0e-6",
+    ]
+
+
+def test_run():
+    """Run the 1D viscous-diffusion convergence test for vy and vz."""
+    testutils.test_error_convergence(
+        "inputs/diffusion.athinput",
+        "diffusion_visc1d",
+        arguments,
+        errors,
+        _mode,
+        _res,
+        "rk2",
+        "diff",
+        "none",
+        "hydro",
+        left_wave="vy",
+        right_wave="vz",
+    )

--- a/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
@@ -45,9 +45,11 @@ def arguments(iv, rv, fv, wv, res, soe, name):
 
 
 """
-Uses test_error_convergence() function in testutils.py, written for linear wave
+Following uses test_error_convergence() function in testutils.py, written for linear wave
 convergence problems. Runs vy/vz tests using _mode as wave flag.
 """
+
+
 def test_run():
     """Run the 1D viscous-diffusion convergence test for vy and vz."""
     testutils.test_error_convergence(

--- a/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
@@ -44,6 +44,10 @@ def arguments(iv, rv, fv, wv, res, soe, name):
     ]
 
 
+"""
+Uses test_error_convergence() function in testutils.py, written for linear wave
+convergence problems. Runs vy/vz tests using _mode as wave flag.
+"""
 def test_run():
     """Run the 1D viscous-diffusion convergence test for vy and vz."""
     testutils.test_error_convergence(
@@ -57,6 +61,4 @@ def test_run():
         "diff",
         "none",
         "hydro",
-        left_wave="vy",
-        right_wave="vz",
     )

--- a/tst/test_suite/diffusion/test_diffusion_visc_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_visc_gpu.py
@@ -1,0 +1,79 @@
+"""
+Viscous-diffusion convergence test on 2D planes embedded in 3D (GPU).
+For each of the xy, yz and zx planes the mesh is extended in the two in-plane directions
+and only 4 cells wide in the perpendicular direction.  The diffusing velocity component
+is the one parallel to that perpendicular direction (vz for xy, vx for yz, vy for zx),
+which spreads isotropically within the plane.  Checks 2nd-order convergence of the L1
+error between two in-plane resolutions.
+"""
+
+# Modules
+import test_suite.testutils as testutils
+
+# Threshold (max high-res RMS-L1 error) and max error ratio (err_hi/err_lo), keyed by
+# (soe, integrator, label, mode).
+errors = {
+    ("hydro", "rk2", "diff", "xy"): (3.0e-11, 0.30),
+    ("hydro", "rk2", "diff", "yz"): (3.0e-11, 0.30),
+    ("hydro", "rk2", "diff", "zx"): (3.0e-11, 0.30),
+}
+
+_mode = ["xy", "yz", "zx"]
+_res = [64, 128]
+
+# Per-plane setup: spread axes, diffusing velocity component, and the thin (perpendicular)
+# direction (1->x1, 2->x2, 3->x3).
+_plane = {
+    "xy": {"spread": (True, True, False), "vel_comp": 3, "thin": 3},
+    "yz": {"spread": (False, True, True), "vel_comp": 1, "thin": 1},
+    "zx": {"spread": (True, False, True), "vel_comp": 2, "thin": 2},
+}
+_NTHIN = 4  # cells in the perpendicular direction
+
+
+def arguments(iv, rv, fv, wv, res, soe, name):
+    """Assemble arguments for run command"""
+    p = _plane[wv]
+    sx1, sx2, sx3 = p["spread"]
+    # mesh/meshblock sizes: in-plane = res (tiled by 2), perpendicular = _NTHIN
+    nx = {1: res, 2: res, 3: res}
+    mbx = {1: res // 2, 2: res // 2, 3: res // 2}
+    nx[p["thin"]] = _NTHIN
+    mbx[p["thin"]] = _NTHIN
+    return [
+        f"job/basename={name}",
+        "time/tlim=1.0",
+        "time/integrator=" + iv,
+        "mesh/nx1=" + repr(nx[1]),
+        "mesh/nx2=" + repr(nx[2]),
+        "mesh/nx3=" + repr(nx[3]),
+        "meshblock/nx1=" + repr(mbx[1]),
+        "meshblock/nx2=" + repr(mbx[2]),
+        "meshblock/nx3=" + repr(mbx[3]),
+        "problem/viscosity_test=true",
+        "problem/conduction_test=false",
+        "problem/spread_x1=" + ("true" if sx1 else "false"),
+        "problem/spread_x2=" + ("true" if sx2 else "false"),
+        "problem/spread_x3=" + ("true" if sx3 else "false"),
+        "problem/vel_comp=" + repr(p["vel_comp"]),
+        "hydro/nu_iso=0.25",
+        "problem/amp=1.0e-6",
+    ]
+
+
+def test_run():
+    """Run the viscous-diffusion plane tests for xy, yz and zx."""
+    testutils.test_error_convergence(
+        "inputs/diffusion.athinput",
+        "diffusion_visc_planes",
+        arguments,
+        errors,
+        _mode,
+        _res,
+        "rk2",
+        "diff",
+        "none",
+        "hydro",
+        left_wave="xy",
+        right_wave="zx",
+    )

--- a/tst/test_suite/diffusion/test_diffusion_visc_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_visc_gpu.py
@@ -74,6 +74,4 @@ def test_run():
         "diff",
         "none",
         "hydro",
-        left_wave="xy",
-        right_wave="zx",
     )

--- a/tst/test_suite/testutils.py
+++ b/tst/test_suite/testutils.py
@@ -259,6 +259,8 @@ def test_error_convergence(
     mpi=False,
 ):
     RUN = mpi_run if mpi else run
+    l1_rms_l = 0.0
+    l1_rms_r = 0.0
     for wv in _wave:
         try:
             for res in _res:


### PR DESCRIPTION
Updates diffusion physics (thermal conduction, viscosity, resistivity) modules and adds regression tests.  Removes ITM parameter from primitive variables since temperature is in fact never used.

Temperature-dependent (Spitzer) thermal conductivity, and anisotropic thermal conduction and viscosity modules are not yet working, but hooks are included to add them in the future.