### PR TITLE
Add Newtonian dual-energy support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(
         geodesic-grid/gauss_legendre.cpp
 
         hydro/hydro.cpp
+        hydro/hydro_dual_energy.cpp
         hydro/hydro_fluxes.cpp
         hydro/hydro_fofc.cpp
         hydro/hydro_newdt.cpp
@@ -82,6 +83,7 @@ add_executable(
         mhd/mhd.cpp
         mhd/mhd_corner_e.cpp
         mhd/mhd_ct.cpp
+        mhd/mhd_dual_energy.cpp
         mhd/mhd_fluxes.cpp
         mhd/mhd_fofc.cpp
         mhd/mhd_newdt.cpp

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -106,7 +106,9 @@ MeshBoundaryValues::~MeshBoundaryValues() {
 //! NOTE2: work here cannot be done in MeshBoundaryValues constructor since it calls pure
 //! virtual functions that only get instantiated when the derived classes are constructed
 
-void MeshBoundaryValues::InitializeBuffers(const int nvar) {
+void MeshBoundaryValues::InitializeBuffers(const int nvar, const int nflx) {
+  const int nflx_alloc = (nflx >= 0) ? nflx : nvar;
+
   // allocate memory for inflow BCs (but only if domain not strictly periodic)
   if (!(pmy_pack->pmesh->strictly_periodic)) {
     Kokkos::realloc(u_in, nvar, 6);
@@ -132,8 +134,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
         int indx = NeighborIndex(n,0,0,fy,fz);
         InitSendIndices(sendbuf[indx],n, 0, 0, fy, fz);
         InitRecvIndices(recvbuf[indx],n, 0, 0, fy, fz);
-        sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-        recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+        sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+        recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
         indx++;
       }
     }
@@ -148,8 +150,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           int indx = NeighborIndex(0,m,0,fx,fz);
           InitSendIndices(sendbuf[indx],0, m, 0, fx, fz);
           InitRecvIndices(recvbuf[indx],0, m, 0, fx, fz);
-          sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+          sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+          recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
           indx++;
         }
       }
@@ -162,8 +164,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           int indx = NeighborIndex(n,m,0,fz,0);
           InitSendIndices(sendbuf[indx],n, m, 0, fz, 0);
           InitRecvIndices(recvbuf[indx],n, m, 0, fz, 0);
-          sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+          sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+          recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
           indx++;
         }
       }
@@ -179,8 +181,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           int indx = NeighborIndex(0,0,l,fx,fy);
           InitSendIndices(sendbuf[indx],0, 0, l, fx, fy);
           InitRecvIndices(recvbuf[indx],0, 0, l, fx, fy);
-          sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+          sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+          recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
           indx++;
         }
       }
@@ -193,8 +195,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           int indx = NeighborIndex(n,0,l,fy,0);
           InitSendIndices(sendbuf[indx],n, 0, l, fy, 0);
           InitRecvIndices(recvbuf[indx],n, 0, l, fy, 0);
-          sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+          sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+          recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
           indx++;
         }
       }
@@ -207,8 +209,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           int indx = NeighborIndex(0,m,l,fx,0);
           InitSendIndices(sendbuf[indx],0, m, l, fx, 0);
           InitRecvIndices(recvbuf[indx],0, m, l, fx, 0);
-          sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+          sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+          recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
           indx++;
         }
       }
@@ -221,8 +223,8 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           int indx = NeighborIndex(n,m,l,0,0);
           InitSendIndices(sendbuf[indx],n, m, l, 0, 0);
           InitRecvIndices(recvbuf[indx],n, m, l, 0, 0);
-          sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
+          sendbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
+          recvbuf[indx].AllocateBuffers(nmb, nvar, nflx_alloc, is_z4c_);
         }
       }
     }

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -85,7 +85,7 @@ struct MeshBoundaryBuffer {
 
   // function to allocate memory for buffers for variables and their fluxes
   // Must only be called after BufferIndcs above are initialized
-  void AllocateBuffers(int nmb, int nvars, bool is_z4c) {
+  void AllocateBuffers(int nmb, int nvars, int nflx, bool is_z4c) {
     // With Z4c, buffers may contain BOTH same and coarse data
     if (is_z4c) {
       int nmax = std::max(isame_z4c_ndat, std::max(icoar_ndat, ifine_ndat) );
@@ -95,7 +95,7 @@ struct MeshBoundaryBuffer {
       Kokkos::realloc(vars, nmb, (nvars*nmax));
     }
     int nmax = std::max(iflxs_ndat, iflxc_ndat);
-    Kokkos::realloc(flux, nmb, (nvars*nmax));
+    Kokkos::realloc(flux, nmb, (nflx*nmax));
   }
 };
 
@@ -127,7 +127,7 @@ class MeshBoundaryValues {
   //functions
   virtual void InitSendIndices(MeshBoundaryBuffer &buf,int x,int y,int z,int a,int b)=0;
   virtual void InitRecvIndices(MeshBoundaryBuffer &buf,int x,int y,int z,int a,int b)=0;
-  void InitializeBuffers(const int nvar);
+  void InitializeBuffers(const int nvar, const int nflx=-1);
 
   TaskStatus InitRecv(const int nvar);
   virtual TaskStatus InitFluxRecv(const int nvar)=0;
@@ -167,8 +167,10 @@ class MeshBoundaryValuesCC : public MeshBoundaryValues {
   TaskStatus PackAndSendCC(DvceArray5D<Real> &a, DvceArray5D<Real> &ca);
   TaskStatus RecvAndUnpackCC(DvceArray5D<Real> &a, DvceArray5D<Real> &ca);
   // functions to communicate fluxes of CC data
-  TaskStatus PackAndSendFluxCC(DvceFaceFld5D<Real> &flx);
-  TaskStatus RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx);
+  TaskStatus PackAndSendFluxCC(DvceFaceFld5D<Real> &flx,
+                               DvceFaceFld5D<Real> *extra_flx = nullptr);
+  TaskStatus RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx,
+                                 DvceFaceFld5D<Real> *extra_flx = nullptr);
 
   // functions to prolongate conserved and primitive CC variables
   void FillCoarseInBndryCC(DvceArray5D<Real> &a, DvceArray5D<Real> &ca,

--- a/src/bvals/flux_correct_cc.cpp
+++ b/src/bvals/flux_correct_cc.cpp
@@ -26,11 +26,18 @@
 //! MeshBlocks. Buffer data are then sent (via MPI) or copied directly for periodic or
 //! block boundaries.
 
-TaskStatus MeshBoundaryValuesCC::PackAndSendFluxCC(DvceFaceFld5D<Real> &flx) {
+TaskStatus MeshBoundaryValuesCC::PackAndSendFluxCC(DvceFaceFld5D<Real> &flx,
+                                                   DvceFaceFld5D<Real> *extra_flx) {
   // create local references for variables in kernel
   int nmb = pmy_pack->nmb_thispack;
   int nnghbr = pmy_pack->pmb->nnghbr;
-  int nvar = flx.x1f.extent_int(1);  // TODO(@user): 2nd idx from L of in arr must be NVAR
+  const int nvar_base = flx.x1f.extent_int(1);
+  const bool use_extra = (extra_flx != nullptr);
+  const int nvar_extra = use_extra ? extra_flx->x1f.extent_int(1) : 0;
+  int nvar = nvar_base + nvar_extra;
+  auto extra_x1f = use_extra ? extra_flx->x1f : flx.x1f;
+  auto extra_x2f = use_extra ? extra_flx->x2f : flx.x2f;
+  auto extra_x3f = use_extra ? extra_flx->x3f : flx.x3f;
 
   auto &cis = pmy_pack->pmesh->mb_indcs.cis;
   auto &cjs = pmy_pack->pmesh->mb_indcs.cjs;
@@ -85,12 +92,26 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendFluxCC(DvceFaceFld5D<Real> &flx) {
           int fk = 2*k - cks;
           Real rflx;
           if (one_d) {
-            rflx = flx.x1f(m,v,0,0,fi);
+            rflx = (v < nvar_base) ? flx.x1f(m,v,0,0,fi) :
+                extra_x1f(m,v - nvar_base,0,0,fi);
           } else if (two_d) {
-            rflx = 0.5*(flx.x1f(m,v,0,fj,fi) + flx.x1f(m,v,0,fj+1,fi));
+            if (v < nvar_base) {
+              rflx = 0.5*(flx.x1f(m,v,0,fj,fi) + flx.x1f(m,v,0,fj+1,fi));
+            } else {
+              const int ve = v - nvar_base;
+              rflx = 0.5*(extra_x1f(m,ve,0,fj,fi) + extra_x1f(m,ve,0,fj+1,fi));
+            }
           } else {
-            rflx = 0.25*(flx.x1f(m,v,fk  ,fj,fi) + flx.x1f(m,v,fk  ,fj+1,fi) +
-                         flx.x1f(m,v,fk+1,fj,fi) + flx.x1f(m,v,fk+1,fj+1,fi));
+            if (v < nvar_base) {
+              rflx = 0.25*(flx.x1f(m,v,fk  ,fj,fi) + flx.x1f(m,v,fk  ,fj+1,fi) +
+                           flx.x1f(m,v,fk+1,fj,fi) + flx.x1f(m,v,fk+1,fj+1,fi));
+            } else {
+              const int ve = v - nvar_base;
+              rflx = 0.25*(extra_x1f(m,ve,fk  ,fj,fi) +
+                           extra_x1f(m,ve,fk  ,fj+1,fi) +
+                           extra_x1f(m,ve,fk+1,fj,fi) +
+                           extra_x1f(m,ve,fk+1,fj+1,fi));
+            }
           }
           // copy directly into recv buffer if MeshBlocks on same rank
           if (nghbr.d_view(m,n).rank == my_rank) {
@@ -113,10 +134,23 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendFluxCC(DvceFaceFld5D<Real> &flx) {
           int fk = 2*k - cks;
           Real rflx;
           if (two_d) {
-            rflx = 0.5*(flx.x2f(m,v,0,fj,fi) + flx.x2f(m,v,0,fj,fi+1));
+            if (v < nvar_base) {
+              rflx = 0.5*(flx.x2f(m,v,0,fj,fi) + flx.x2f(m,v,0,fj,fi+1));
+            } else {
+              const int ve = v - nvar_base;
+              rflx = 0.5*(extra_x2f(m,ve,0,fj,fi) + extra_x2f(m,ve,0,fj,fi+1));
+            }
           } else {
-            rflx = 0.25*(flx.x2f(m,v,fk  ,fj,fi) + flx.x2f(m,v,fk  ,fj,fi+1) +
-                         flx.x2f(m,v,fk+1,fj,fi) + flx.x2f(m,v,fk+1,fj,fi+1));
+            if (v < nvar_base) {
+              rflx = 0.25*(flx.x2f(m,v,fk  ,fj,fi) + flx.x2f(m,v,fk  ,fj,fi+1) +
+                           flx.x2f(m,v,fk+1,fj,fi) + flx.x2f(m,v,fk+1,fj,fi+1));
+            } else {
+              const int ve = v - nvar_base;
+              rflx = 0.25*(extra_x2f(m,ve,fk  ,fj,fi) +
+                           extra_x2f(m,ve,fk  ,fj,fi+1) +
+                           extra_x2f(m,ve,fk+1,fj,fi) +
+                           extra_x2f(m,ve,fk+1,fj,fi+1));
+            }
           }
           // copy directly into recv buffer if MeshBlocks on same rank
           if (nghbr.d_view(m,n).rank == my_rank) {
@@ -137,8 +171,17 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendFluxCC(DvceFaceFld5D<Real> &flx) {
           j += jl;
           int fi = 2*i - cis;
           int fj = 2*j - cjs;
-          Real rflx = 0.25*(flx.x3f(m,v,fk,fj  ,fi) + flx.x3f(m,v,fk,fj  ,fi+1) +
-                            flx.x3f(m,v,fk,fj+1,fi) + flx.x3f(m,v,fk,fj+1,fi+1));
+          Real rflx;
+          if (v < nvar_base) {
+            rflx = 0.25*(flx.x3f(m,v,fk,fj  ,fi) + flx.x3f(m,v,fk,fj  ,fi+1) +
+                         flx.x3f(m,v,fk,fj+1,fi) + flx.x3f(m,v,fk,fj+1,fi+1));
+          } else {
+            const int ve = v - nvar_base;
+            rflx = 0.25*(extra_x3f(m,ve,fk,fj  ,fi) +
+                         extra_x3f(m,ve,fk,fj  ,fi+1) +
+                         extra_x3f(m,ve,fk,fj+1,fi) +
+                         extra_x3f(m,ve,fk,fj+1,fi+1));
+          }
           // copy directly into recv buffer if MeshBlocks on same rank
           if (nghbr.d_view(m,n).rank == my_rank) {
             rbuf[dn].flux(dm, (i-il + ni*(j-jl + nj*v)) ) = rflx;
@@ -196,7 +239,8 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendFluxCC(DvceFaceFld5D<Real> &flx) {
 //! \fn void RecvBuffers()
 //! \brief Unpack boundary buffers for flux correction of CC variables.
 
-TaskStatus MeshBoundaryValuesCC::RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx) {
+TaskStatus MeshBoundaryValuesCC::RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx,
+                                                     DvceFaceFld5D<Real> *extra_flx) {
   // create local references for variables in kernel
   int nmb = pmy_pack->nmb_thispack;
   int nnghbr = pmy_pack->pmb->nnghbr;
@@ -238,7 +282,13 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx) {
 
   //----- STEP 2: buffers have all completed, so unpack
 
-  int nvar = flx.x1f.extent_int(1); // TODO(@user): 2nd idx from L of in arr must be NVAR
+  const int nvar_base = flx.x1f.extent_int(1);
+  const bool use_extra = (extra_flx != nullptr);
+  const int nvar_extra = use_extra ? extra_flx->x1f.extent_int(1) : 0;
+  int nvar = nvar_base + nvar_extra;
+  auto extra_x1f = use_extra ? extra_flx->x1f : flx.x1f;
+  auto extra_x2f = use_extra ? extra_flx->x2f : flx.x2f;
+  auto extra_x3f = use_extra ? extra_flx->x3f : flx.x3f;
 
   // Outer loop over (# of MeshBlocks)*(# of neighbors)*(# of variables)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (nmb*nnghbr*nvar), Kokkos::AUTO);
@@ -269,7 +319,12 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx) {
           int k = idx / nj;
           int j = (idx - k * nj) + jl;
           k += kl;
-          flx.x1f(m,v,k,j,il) = rbuf[n].flux(m,(j-jl + nj*(k-kl + nk*v)));
+          const Real rval = rbuf[n].flux(m,(j-jl + nj*(k-kl + nk*v)));
+          if (v < nvar_base) {
+            flx.x1f(m,v,k,j,il) = rval;
+          } else {
+            extra_x1f(m,v - nvar_base,k,j,il) = rval;
+          }
         });
       // x2faces
       } else if (n<16) {
@@ -277,7 +332,12 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx) {
           int k = idx / ni;
           int i = (idx - k * ni) + il;
           k += kl;
-          flx.x2f(m,v,k,jl,i) = rbuf[n].flux(m,(i-il + ni*(k-kl + nk*v)));
+          const Real rval = rbuf[n].flux(m,(i-il + ni*(k-kl + nk*v)));
+          if (v < nvar_base) {
+            flx.x2f(m,v,k,jl,i) = rval;
+          } else {
+            extra_x2f(m,v - nvar_base,k,jl,i) = rval;
+          }
         });
       // x3faces
       } else if ((n>=24) && (n<32)) {
@@ -285,7 +345,12 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackFluxCC(DvceFaceFld5D<Real> &flx) {
           int j = idx / ni;
           int i = (idx - j * ni) + il;
           j += jl;
-          flx.x3f(m,v,kl,j,i) = rbuf[n].flux(m,(i-il + ni*(j-jl + nj*v)));
+          const Real rval = rbuf[n].flux(m,(i-il + ni*(j-jl + nj*v)));
+          if (v < nvar_base) {
+            flx.x3f(m,v,kl,j,i) = rval;
+          } else {
+            extra_x3f(m,v - nvar_base,kl,j,i) = rval;
+          }
         });
       }
     }  // end if-neighbor-exists block

--- a/src/bvals/prolong_prims.cpp
+++ b/src/bvals/prolong_prims.cpp
@@ -25,6 +25,23 @@
 #include "coordinates/cartesian_ks.hpp"
 #include "coordinates/cell_locations.hpp"
 
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+Real BoundaryInternalEnergyFloor(const EOS_Data &eos, const Real dens) {
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+} // namespace
+
 //----------------------------------------------------------------------------------------
 //! \fn void ConsToPrimCoarseBndry()
 //! \brief Converts Hydro conserved variables in coarse level boundary buffers into
@@ -52,6 +69,9 @@ void MeshBoundaryValuesCC::ConsToPrimCoarseBndry(const DvceArray5D<Real> &cons,
   auto &eos = pmy_pack->phydro->peos->eos_data;
   int &nhyd  = pmy_pack->phydro->nhydro;
   int &nscal = pmy_pack->phydro->nscalars;
+  bool use_dual = pmy_pack->phydro->use_dual_energy;
+  int dual_idx = pmy_pack->phydro->dual_energy_idx;
+  Real dual_eta1 = pmy_pack->phydro->dual_energy_eta1;
 
   // Outer loop over (# of MeshBlocks)*(# of buffers)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (nmb*nnghbr), Kokkos::AUTO);
@@ -154,8 +174,26 @@ void MeshBoundaryValuesCC::ConsToPrimCoarseBndry(const DvceArray5D<Real> &cons,
             w.vy *= factor;
             w.vz *= factor;
           }
-        } else {
+        } else if (!use_dual) {
           SingleC2P_IdealHyd(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+        } else {
+          if (u.d < eos.dfloor) {
+            u.d = eos.dfloor;
+          }
+          w.d = u.d;
+          const Real di = 1.0/u.d;
+          w.vx = di*u.mx;
+          w.vy = di*u.my;
+          w.vz = di*u.mz;
+          const Real e_k = 0.5*di*(SQR(u.mx) + SQR(u.my) + SQR(u.mz));
+          const Real eint_cons = u.e - e_k;
+          Real eint_aux = cons(m, dual_idx, k, j, i);
+          eint_aux = fmax(eint_aux, BoundaryInternalEnergyFloor(eos, w.d));
+          const bool use_cons_e =
+              (eint_cons > 0.0) &&
+              ((dual_eta1 <= 0.0) || (eint_cons > dual_eta1*fmax(u.e, 1.0e-18)));
+          w.e = use_cons_e ? eint_cons : eint_aux;
+          w.e = fmax(w.e, BoundaryInternalEnergyFloor(eos, w.d));
         }
 
         // No need to correct conserved state in coarse boundary arrays if floors used
@@ -173,6 +211,10 @@ void MeshBoundaryValuesCC::ConsToPrimCoarseBndry(const DvceArray5D<Real> &cons,
             cons(m,n,k,j,i) = 0.0;
           }
           prim(m,n,k,j,i) = cons(m,n,k,j,i)/u.d;
+        }
+        if (use_dual) {
+          prim(m,dual_idx,k,j,i) = fmax(cons(m,dual_idx,k,j,i),
+                                        BoundaryInternalEnergyFloor(eos, w.d));
         }
       });
     }
@@ -204,9 +246,12 @@ void MeshBoundaryValuesCC::PrimToConsFineBndry(const DvceArray5D<Real> &prim,
   auto &spin = pmy_pack->pcoord->coord_data.bh_spin;
   bool &is_sr = pmy_pack->pcoord->is_special_relativistic;
   bool &is_gr = pmy_pack->pcoord->is_general_relativistic;
-  Real &gamma = pmy_pack->phydro->peos->eos_data.gamma;
+  auto &eos = pmy_pack->phydro->peos->eos_data;
+  Real &gamma = eos.gamma;
   int &nhyd  = pmy_pack->phydro->nhydro;
   int &nscal = pmy_pack->phydro->nscalars;
+  bool use_dual = pmy_pack->phydro->use_dual_energy;
+  int dual_idx = pmy_pack->phydro->dual_energy_idx;
 
   // Outer loop over (# of MeshBlocks)*(# of buffers)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (nmb*nnghbr), Kokkos::AUTO);
@@ -286,6 +331,10 @@ void MeshBoundaryValuesCC::PrimToConsFineBndry(const DvceArray5D<Real> &prim,
         for (int n=nhyd; n<(nhyd+nscal); ++n) {
           cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
         }
+        if (use_dual) {
+          cons(m,dual_idx,k,j,i) = fmax(prim(m,dual_idx,k,j,i),
+                                        BoundaryInternalEnergyFloor(eos, u.d));
+        }
       });
     }
     tmember.team_barrier();
@@ -320,6 +369,9 @@ void MeshBoundaryValuesCC::ConsToPrimCoarseBndry(const DvceArray5D<Real> &cons,
   auto &eos = pmy_pack->pmhd->peos->eos_data;
   int &nmhd  = pmy_pack->pmhd->nmhd;
   int &nscal = pmy_pack->pmhd->nscalars;
+  bool use_dual = pmy_pack->pmhd->use_dual_energy;
+  int dual_idx = pmy_pack->pmhd->dual_energy_idx;
+  Real dual_eta1 = pmy_pack->pmhd->dual_energy_eta1;
 
   // Outer loop over (# of MeshBlocks)*(# of buffers)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (nmb*nnghbr), Kokkos::AUTO);
@@ -428,8 +480,29 @@ void MeshBoundaryValuesCC::ConsToPrimCoarseBndry(const DvceArray5D<Real> &cons,
             w.vy *= factor;
             w.vz *= factor;
           }
-        } else {
+        } else if (!use_dual) {
           SingleC2P_IdealMHD(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+        } else {
+          const Real b2 = SQR(u.bx) + SQR(u.by) + SQR(u.bz);
+          const Real dfloor = fmax(eos.dfloor, b2/eos.sigma_max);
+          if (u.d < dfloor) {
+            u.d = dfloor;
+          }
+          w.d = u.d;
+          const Real di = 1.0/u.d;
+          w.vx = di*u.mx;
+          w.vy = di*u.my;
+          w.vz = di*u.mz;
+          const Real e_k = 0.5*di*(SQR(u.mx) + SQR(u.my) + SQR(u.mz));
+          const Real e_m = 0.5*b2;
+          const Real eint_cons = u.e - e_k - e_m;
+          Real eint_aux = cons(m, dual_idx, k, j, i);
+          eint_aux = fmax(eint_aux, BoundaryInternalEnergyFloor(eos, w.d));
+          const bool use_cons_e =
+              (eint_cons > 0.0) &&
+              ((dual_eta1 <= 0.0) || (eint_cons > dual_eta1*fmax(u.e, 1.0e-18)));
+          w.e = use_cons_e ? eint_cons : eint_aux;
+          w.e = fmax(w.e, BoundaryInternalEnergyFloor(eos, w.d));
         }
 
         // No need to correct conserved state in coarse boundary arrays if floors used
@@ -448,6 +521,10 @@ void MeshBoundaryValuesCC::ConsToPrimCoarseBndry(const DvceArray5D<Real> &cons,
             cons(m,n,k,j,i) = 0.0;
           }
           prim(m,n,k,j,i) = cons(m,n,k,j,i)/u.d;
+        }
+        if (use_dual) {
+          prim(m,dual_idx,k,j,i) = fmax(cons(m,dual_idx,k,j,i),
+                                        BoundaryInternalEnergyFloor(eos, w.d));
         }
       });
     }
@@ -479,9 +556,12 @@ void MeshBoundaryValuesCC::PrimToConsFineBndry(const DvceArray5D<Real> &prim,
   auto &spin = pmy_pack->pcoord->coord_data.bh_spin;
   bool &is_sr = pmy_pack->pcoord->is_special_relativistic;
   bool &is_gr = pmy_pack->pcoord->is_general_relativistic;
-  Real &gamma = pmy_pack->pmhd->peos->eos_data.gamma;
+  auto &eos = pmy_pack->pmhd->peos->eos_data;
+  Real &gamma = eos.gamma;
   int &nmhd  = pmy_pack->pmhd->nmhd;
   int &nscal = pmy_pack->pmhd->nscalars;
+  bool use_dual = pmy_pack->pmhd->use_dual_energy;
+  int dual_idx = pmy_pack->pmhd->dual_energy_idx;
 
   // Outer loop over (# of MeshBlocks)*(# of buffers)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (nmb*nnghbr), Kokkos::AUTO);
@@ -564,6 +644,10 @@ void MeshBoundaryValuesCC::PrimToConsFineBndry(const DvceArray5D<Real> &prim,
         // convert scalars (if any)
         for (int n=nmhd; n<(nmhd+nscal); ++n) {
           cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
+        }
+        if (use_dual) {
+          cons(m,dual_idx,k,j,i) = fmax(prim(m,dual_idx,k,j,i),
+                                        BoundaryInternalEnergyFloor(eos, u.d));
         }
       });
     }

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -580,6 +580,10 @@ void Driver::InitBoundaryValuesAndPrimitives(Mesh *pm) {
   // includes communications for shearing box boundaries
   hydro::Hydro *phydro = pm->pmb_pack->phydro;
   if (phydro != nullptr) {
+    if (phydro->use_dual_energy && phydro->dual_energy_needs_init) {
+      phydro->InitializeDualEnergyFieldFromTotal();
+      phydro->dual_energy_needs_init = false;
+    }
     // following functions return a TaskStatus, but it is ignored so cast to (void)
     (void) phydro->RestrictU(this, 0);
     (void) phydro->InitRecv(this, -1);  // stage < 0 suppresses InitFluxRecv
@@ -601,6 +605,10 @@ void Driver::InitBoundaryValuesAndPrimitives(Mesh *pm) {
   mhd::MHD *pmhd = pm->pmb_pack->pmhd;
   dyngr::DynGRMHD *pdyngr = pm->pmb_pack->pdyngr;
   if (pmhd != nullptr) {
+    if (pmhd->use_dual_energy && pmhd->dual_energy_needs_init) {
+      pmhd->InitializeDualEnergyFieldFromTotal();
+      pmhd->dual_energy_needs_init = false;
+    }
     (void) pmhd->RestrictU(this, 0);
     (void) pmhd->RestrictB(this, 0);
     (void) pmhd->InitRecv(this, -1);  // stage < 0 suppresses InitFluxRecv

--- a/src/eos/ideal_hyd.cpp
+++ b/src/eos/ideal_hyd.cpp
@@ -213,8 +213,9 @@ void IdealHydro::PrimToCons(const DvceArray5D<Real> &prim, DvceArray5D<Real> &co
       cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
     }
     if (use_dual) {
-      cons(m,dual_idx,k,j,i) = fmax(prim(m,dual_idx,k,j,i),
-                                    HydroInternalEnergyFloor(eos, u.d));
+      const Real eint_aux = fmax(w.e, HydroInternalEnergyFloor(eos, u.d));
+      cons(m,dual_idx,k,j,i) = eint_aux;
+      prim(m,dual_idx,k,j,i) = eint_aux;
     }
   });
 

--- a/src/eos/ideal_hyd.cpp
+++ b/src/eos/ideal_hyd.cpp
@@ -11,6 +11,23 @@
 #include "eos/eos.hpp"
 #include "eos/ideal_c2p_hyd.hpp"
 
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+Real HydroInternalEnergyFloor(const EOS_Data &eos, const Real dens) {
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+} // namespace
+
 //----------------------------------------------------------------------------------------
 // ctor: also calls EOS base class constructor
 
@@ -34,6 +51,9 @@ void IdealHydro::ConsToPrim(DvceArray5D<Real> &cons, DvceArray5D<Real> &prim,
                             const int kl, const int ku) {
   int &nhyd  = pmy_pack->phydro->nhydro;
   int &nscal = pmy_pack->phydro->nscalars;
+  int dual_idx = pmy_pack->phydro->dual_energy_idx;
+  bool use_dual = pmy_pack->phydro->use_dual_energy;
+  const Real dual_eta1 = pmy_pack->phydro->dual_energy_eta1;
   int &nmb = pmy_pack->nmb_thispack;
   auto &eos = eos_data;
   auto &fofc_ = pmy_pack->phydro->fofc;
@@ -65,7 +85,39 @@ void IdealHydro::ConsToPrim(DvceArray5D<Real> &cons, DvceArray5D<Real> &prim,
     // (inline function in ideal_c2p_hyd.hpp file)
     HydPrim1D w;
     bool dfloor_used=false, efloor_used=false, tfloor_used=false;
-    SingleC2P_IdealHyd(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+    Real eint_aux_out = 0.0;
+    if (!use_dual) {
+      SingleC2P_IdealHyd(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+    } else {
+      if (u.d < eos.dfloor) {
+        u.d = eos.dfloor;
+        dfloor_used = true;
+      }
+      w.d = u.d;
+      const Real di = 1.0/u.d;
+      w.vx = di*u.mx;
+      w.vy = di*u.my;
+      w.vz = di*u.mz;
+      const Real e_k = 0.5*di*(SQR(u.mx) + SQR(u.my) + SQR(u.mz));
+      const Real eint_cons = u.e - e_k;
+      Real eint_aux = cons(m, dual_idx, k, j, i);
+
+      const Real eint_floor = HydroInternalEnergyFloor(eos, w.d);
+      if (eint_aux < eint_floor) {
+        eint_aux = eint_floor;
+        efloor_used = true;
+      }
+      const bool use_cons_e =
+          (eint_cons > 0.0) &&
+          ((dual_eta1 <= 0.0) || (eint_cons > dual_eta1*fmax(u.e, 1.0e-18)));
+      w.e = use_cons_e ? eint_cons : eint_aux;
+      if (w.e < eint_floor) {
+        w.e = eint_floor;
+        efloor_used = true;
+      }
+      u.e = w.e + e_k;
+      eint_aux_out = eint_aux;
+    }
 
     // set FOFC flag and quit loop if this function called only to check floors
     if (only_testfloors) {
@@ -101,6 +153,10 @@ void IdealHydro::ConsToPrim(DvceArray5D<Real> &cons, DvceArray5D<Real> &prim,
         }
         prim(m,n,k,j,i) = cons(m,n,k,j,i)/u.d;
       }
+      if (use_dual) {
+        cons(m,dual_idx,k,j,i) = eint_aux_out;
+        prim(m,dual_idx,k,j,i) = eint_aux_out;
+      }
     }
   }, Kokkos::Sum<int>(nfloord_), Kokkos::Sum<int>(nfloore_), Kokkos::Sum<int>(nfloort_));
 
@@ -126,7 +182,10 @@ void IdealHydro::PrimToCons(const DvceArray5D<Real> &prim, DvceArray5D<Real> &co
                             const int kl, const int ku) {
   int &nhyd  = pmy_pack->phydro->nhydro;
   int &nscal = pmy_pack->phydro->nscalars;
+  int dual_idx = pmy_pack->phydro->dual_energy_idx;
+  bool use_dual = pmy_pack->phydro->use_dual_energy;
   int &nmb = pmy_pack->nmb_thispack;
+  auto &eos = eos_data;
 
   par_for("hyd_p2c", DevExeSpace(), 0, (nmb-1), kl, ku, jl, ju, il, iu,
   KOKKOS_LAMBDA(int m, int k, int j, int i) {
@@ -152,6 +211,10 @@ void IdealHydro::PrimToCons(const DvceArray5D<Real> &prim, DvceArray5D<Real> &co
     // convert scalars (if any)
     for (int n=nhyd; n<(nhyd+nscal); ++n) {
       cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
+    }
+    if (use_dual) {
+      cons(m,dual_idx,k,j,i) = fmax(prim(m,dual_idx,k,j,i),
+                                    HydroInternalEnergyFloor(eos, u.d));
     }
   });
 

--- a/src/eos/ideal_mhd.cpp
+++ b/src/eos/ideal_mhd.cpp
@@ -11,6 +11,23 @@
 #include "eos.hpp"
 #include "eos/ideal_c2p_mhd.hpp"
 
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+Real MHDInternalEnergyFloor(const EOS_Data &eos, const Real dens) {
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+} // namespace
+
 //----------------------------------------------------------------------------------------
 // ctor: also calls EOS base class constructor
 
@@ -36,6 +53,9 @@ void IdealMHD::ConsToPrim(DvceArray5D<Real> &cons, const DvceFaceFld4D<Real> &b,
                           const int kl, const int ku) {
   int &nmhd  = pmy_pack->pmhd->nmhd;
   int &nscal = pmy_pack->pmhd->nscalars;
+  int dual_idx = pmy_pack->pmhd->dual_energy_idx;
+  bool use_dual = pmy_pack->pmhd->use_dual_energy;
+  const Real dual_eta1 = pmy_pack->pmhd->dual_energy_eta1;
   int &nmb = pmy_pack->nmb_thispack;
   auto &eos = eos_data;
   auto &fofc_ = pmy_pack->pmhd->fofc;
@@ -80,7 +100,42 @@ void IdealMHD::ConsToPrim(DvceArray5D<Real> &cons, const DvceFaceFld4D<Real> &b,
     // (inline function in ideal_c2p_mhd.hpp file)
     HydPrim1D w;
     bool dfloor_used=false, efloor_used=false, tfloor_used=false;
-    SingleC2P_IdealMHD(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+    Real eint_aux_out = 0.0;
+    if (!use_dual) {
+      SingleC2P_IdealMHD(u, eos, w, dfloor_used, efloor_used, tfloor_used);
+    } else {
+      const Real b2 = SQR(u.bx) + SQR(u.by) + SQR(u.bz);
+      const Real dfloor = fmax(eos.dfloor, b2/eos.sigma_max);
+      if (u.d < dfloor) {
+        u.d = dfloor;
+        dfloor_used = true;
+      }
+      w.d = u.d;
+      const Real di = 1.0/u.d;
+      w.vx = di*u.mx;
+      w.vy = di*u.my;
+      w.vz = di*u.mz;
+      const Real e_k = 0.5*di*(SQR(u.mx) + SQR(u.my) + SQR(u.mz));
+      const Real e_m = 0.5*b2;
+      const Real eint_cons = u.e - e_k - e_m;
+      Real eint_aux = cons(m, dual_idx, k, j, i);
+
+      const Real eint_floor = MHDInternalEnergyFloor(eos, w.d);
+      if (eint_aux < eint_floor) {
+        eint_aux = eint_floor;
+        efloor_used = true;
+      }
+      const bool use_cons_e =
+          (eint_cons > 0.0) &&
+          ((dual_eta1 <= 0.0) || (eint_cons > dual_eta1*fmax(u.e, 1.0e-18)));
+      w.e = use_cons_e ? eint_cons : eint_aux;
+      if (w.e < eint_floor) {
+        w.e = eint_floor;
+        efloor_used = true;
+      }
+      u.e = w.e + e_k + e_m;
+      eint_aux_out = eint_aux;
+    }
 
     // set FOFC flag and quit loop if this function called only to check floors
     if (only_testfloors) {
@@ -120,6 +175,10 @@ void IdealMHD::ConsToPrim(DvceArray5D<Real> &cons, const DvceFaceFld4D<Real> &b,
         }
         prim(m,n,k,j,i) = cons(m,n,k,j,i)/u.d;
       }
+      if (use_dual) {
+        cons(m,dual_idx,k,j,i) = eint_aux_out;
+        prim(m,dual_idx,k,j,i) = eint_aux_out;
+      }
     }
   }, Kokkos::Sum<int>(nfloord_), Kokkos::Sum<int>(nfloore_), Kokkos::Sum<int>(nfloort_));
 
@@ -145,7 +204,10 @@ void IdealMHD::PrimToCons(const DvceArray5D<Real> &prim, const DvceArray5D<Real>
                           const int jl, const int ju, const int kl, const int ku) {
   int &nmhd  = pmy_pack->pmhd->nmhd;
   int &nscal = pmy_pack->pmhd->nscalars;
+  int dual_idx = pmy_pack->pmhd->dual_energy_idx;
+  bool use_dual = pmy_pack->pmhd->use_dual_energy;
   int &nmb = pmy_pack->nmb_thispack;
+  auto &eos = eos_data;
 
   par_for("mhd_p2c", DevExeSpace(), 0, (nmb-1), kl, ku, jl, ju, il, iu,
   KOKKOS_LAMBDA(int m, int k, int j, int i) {
@@ -176,6 +238,10 @@ void IdealMHD::PrimToCons(const DvceArray5D<Real> &prim, const DvceArray5D<Real>
     // convert scalars (if any), always stored at end of cons and prim arrays.
     for (int n=nmhd; n<(nmhd+nscal); ++n) {
       cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
+    }
+    if (use_dual) {
+      cons(m,dual_idx,k,j,i) = fmax(prim(m,dual_idx,k,j,i),
+                                    MHDInternalEnergyFloor(eos, u.d));
     }
   });
 

--- a/src/eos/ideal_mhd.cpp
+++ b/src/eos/ideal_mhd.cpp
@@ -240,8 +240,9 @@ void IdealMHD::PrimToCons(const DvceArray5D<Real> &prim, const DvceArray5D<Real>
       cons(m,n,k,j,i) = u.d*prim(m,n,k,j,i);
     }
     if (use_dual) {
-      cons(m,dual_idx,k,j,i) = fmax(prim(m,dual_idx,k,j,i),
-                                    MHDInternalEnergyFloor(eos, u.d));
+      const Real eint_aux = fmax(w.e, MHDInternalEnergyFloor(eos, u.d));
+      cons(m,dual_idx,k,j,i) = eint_aux;
+      prim(m,dual_idx,k,j,i) = eint_aux;
     }
   });
 

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -34,6 +34,8 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
     coarse_w0("cprim",1,1,1,1,1),
     u1("cons1",1,1,1,1,1),
     uflx("uflx",1,1,1,1,1),
+    dual_vf("dual_vf",1,1,1,1,1),
+    dual_etot_max("dual_etot_max",1,1,1,1),
     utest("utest",1,1,1,1,1),
     fofc("fofc",1,1,1,1) {
   // Total number of MeshBlocks on this rank to be used in array dimensioning
@@ -71,6 +73,28 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
 
   // (2) Initialize scalars, diffusion, source terms
   nscalars = pin->GetOrAddInteger("hydro","nscalars",0);
+  use_dual_energy = pin->GetOrAddBoolean("hydro", "dual_energy", false);
+  if (use_dual_energy) {
+    if (!peos->eos_data.is_ideal || nhydro != 5) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<hydro>/dual_energy requires a non-isothermal ideal gas EOS"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+    if (pmy_pack->pcoord->is_special_relativistic ||
+        pmy_pack->pcoord->is_general_relativistic) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<hydro>/dual_energy is implemented only for Newtonian hydro"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+    naux = 1;
+    dual_energy_idx = nhydro + nscalars;
+    dual_energy_needs_init = true;
+    dual_energy_eta1 = pin->GetOrAddReal("hydro", "dual_energy_eta1", 1.0e-3);
+    dual_energy_eta2 = pin->GetOrAddReal("hydro", "dual_energy_eta2", 1.0e-4);
+  }
+  nvars = nhydro + nscalars + naux;
 
   // Viscosity (if requested in input file)
   if (pin->DoesParameterExist("hydro","viscosity")) {
@@ -92,9 +116,26 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
     psrc = new SourceTerms("hydro_srcterms", ppack, pin);
   }
 
+  if (use_dual_energy) {
+    if (pvisc != nullptr || pcond != nullptr || psrc != nullptr ||
+        pin->DoesBlockExist("shearing_box")) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<hydro>/dual_energy is not implemented with "
+                << "viscosity, thermal conduction, hydro source terms, or shearing box"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
   // (3) read time-evolution option [already error checked in driver constructor]
   // Then initialize memory and algorithms for reconstruction and Riemann solvers
   std::string evolution_t = pin->GetString("time","evolution");
+  if (use_dual_energy && evolution_t.compare("dynamic") != 0) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "<hydro>/dual_energy only supports dynamic evolution"
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
 
   // allocate memory for conserved and primitive variables
   // With AMR, maximum size of Views are limited by total device memory through an input
@@ -104,8 +145,11 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
     int ncells1 = indcs.nx1 + 2*(indcs.ng);
     int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
     int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
-    Kokkos::realloc(u0, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
-    Kokkos::realloc(w0, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+    Kokkos::realloc(u0, nmb, nvars, ncells3, ncells2, ncells1);
+    Kokkos::realloc(w0, nmb, nvars, ncells3, ncells2, ncells1);
+    if (use_dual_energy) {
+      Kokkos::realloc(dual_etot_max, nmb, ncells3, ncells2, ncells1);
+    }
   }
 
   // allocate memory for conserved variables on coarse mesh
@@ -114,18 +158,18 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
     int n_ccells1 = indcs.cnx1 + 2*(indcs.ng);
     int n_ccells2 = (indcs.cnx2 > 1)? (indcs.cnx2 + 2*(indcs.ng)) : 1;
     int n_ccells3 = (indcs.cnx3 > 1)? (indcs.cnx3 + 2*(indcs.ng)) : 1;
-    Kokkos::realloc(coarse_u0, nmb, (nhydro+nscalars), n_ccells3, n_ccells2, n_ccells1);
-    Kokkos::realloc(coarse_w0, nmb, (nhydro+nscalars), n_ccells3, n_ccells2, n_ccells1);
+    Kokkos::realloc(coarse_u0, nmb, nvars, n_ccells3, n_ccells2, n_ccells1);
+    Kokkos::realloc(coarse_w0, nmb, nvars, n_ccells3, n_ccells2, n_ccells1);
   }
 
   // allocate boundary buffers for conserved (cell-centered) variables
   pbval_u = new MeshBoundaryValuesCC(ppack, pin, false);
-  pbval_u->InitializeBuffers((nhydro+nscalars));
+  pbval_u->InitializeBuffers(nvars, nvars + (use_dual_energy ? 1 : 0));
 
   // Orbital advection and shearing box BCs (if requested in input file)
   if (pin->DoesBlockExist("shearing_box")) {
-    porb_u = new OrbitalAdvectionCC(ppack, pin, (nhydro+nscalars));
-    psbox_u = new ShearingBoxCC(ppack, pin, (nhydro+nscalars));
+    porb_u = new OrbitalAdvectionCC(ppack, pin, nvars);
+    psbox_u = new ShearingBoxCC(ppack, pin, nvars);
   } else {
     porb_u = nullptr;
     psbox_u = nullptr;
@@ -135,6 +179,12 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   if (evolution_t.compare("stationary") != 0) {
     // determine if FOFC is enabled
     use_fofc = pin->GetOrAddBoolean("hydro","fofc",false);
+    if (use_dual_energy && use_fofc) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<hydro>/dual_energy is not implemented with FOFC"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
 
     // select reconstruction method (default PLM)
     std::string xorder = pin->GetOrAddString("hydro","reconstruct","plm");
@@ -275,10 +325,15 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
       int ncells1 = indcs.nx1 + 2*(indcs.ng);
       int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
       int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
-      Kokkos::realloc(u1,       nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
-      Kokkos::realloc(uflx.x1f, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
-      Kokkos::realloc(uflx.x2f, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
-      Kokkos::realloc(uflx.x3f, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+      Kokkos::realloc(u1,       nmb, nvars, ncells3, ncells2, ncells1);
+      Kokkos::realloc(uflx.x1f, nmb, nvars, ncells3, ncells2, ncells1);
+      Kokkos::realloc(uflx.x2f, nmb, nvars, ncells3, ncells2, ncells1);
+      Kokkos::realloc(uflx.x3f, nmb, nvars, ncells3, ncells2, ncells1);
+      if (use_dual_energy) {
+        Kokkos::realloc(dual_vf.x1f, nmb, 1, ncells3, ncells2, ncells1+1);
+        Kokkos::realloc(dual_vf.x2f, nmb, 1, ncells3, ncells2+1, ncells1);
+        Kokkos::realloc(dual_vf.x3f, nmb, 1, ncells3+1, ncells2, ncells1);
+      }
 
       // allocate array of flags used with FOFC
       if (use_fofc) {

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -90,7 +90,6 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
     }
     naux = 1;
     dual_energy_idx = nhydro + nscalars;
-    dual_energy_needs_init = true;
     dual_energy_eta1 = pin->GetOrAddReal("hydro", "dual_energy_eta1", 1.0e-3);
     dual_energy_eta2 = pin->GetOrAddReal("hydro", "dual_energy_eta2", 1.0e-4);
   }

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -43,6 +43,7 @@ struct HydroTaskIDs {
   TaskID sendf;
   TaskID recvf;
   TaskID rkupdt;
+  TaskID duale;
   TaskID srctrms;
   TaskID sendu_oa;
   TaskID recvu_oa;
@@ -76,6 +77,13 @@ class Hydro {
 
   int nhydro;             // number of hydro variables (5/4 for ideal/isothermal EOS)
   int nscalars;           // number of passive scalars
+  int naux = 0;            // number of hidden auxiliary hydro variables
+  int nvars = 0;           // total hydro-carried variables = nhydro+nscalars+naux
+  int dual_energy_idx = -1;
+  bool use_dual_energy = false;
+  bool dual_energy_needs_init = false;
+  Real dual_energy_eta1 = 1.0e-3;
+  Real dual_energy_eta2 = 1.0e-4;
   DvceArray5D<Real> u0;   // conserved variables
   DvceArray5D<Real> w0;   // primitive variables
 
@@ -97,6 +105,8 @@ class Hydro {
   // following only used for time-evolving flow
   DvceArray5D<Real> u1;       // conserved variables at intermediate step
   DvceFaceFld5D<Real> uflx;   // fluxes of conserved quantities on cell faces
+  DvceFaceFld5D<Real> dual_vf;  // mass-flux velocity for dual-energy compression
+  DvceArray4D<Real> dual_etot_max;  // local total-energy scale for dual-energy sync
   Real dtnew;
 
   // following used for FOFC
@@ -117,6 +127,7 @@ class Hydro {
   TaskStatus SendFlux(Driver *d, int stage);
   TaskStatus RecvFlux(Driver *d, int stage);
   TaskStatus RKUpdate(Driver *d, int stage);
+  TaskStatus DualEnergyStep(Driver *d, int stage);
   TaskStatus HydroSrcTerms(Driver *d, int stage);
   TaskStatus SendU_OA(Driver *d, int stage);
   TaskStatus RecvU_OA(Driver *d, int stage);
@@ -136,6 +147,14 @@ class Hydro {
   // CalculateFluxes function templated over Riemann Solvers
   template <Hydro_RSolver T>
   void CalculateFluxes(Driver *d, int stage);
+
+  // dual-energy formalism
+  void InitializeDualEnergyFieldFromTotal();
+  void ApplyDualEnergyFormalism(const Real dt);
+  void SynchronizeDualEnergyFieldFromTotal();
+  void SynchronizeRestrictedDualEnergyField();
+  void RepairRefinedDualEnergyState(DualArray1D<int> &n2o, DualArray1D<int> &rflag,
+                                    const int new_gids, const int new_nmb_local);
 
   // first-order flux correction
   void FOFC(Driver *d, int stage);

--- a/src/hydro/hydro_dual_energy.cpp
+++ b/src/hydro/hydro_dual_energy.cpp
@@ -1,0 +1,226 @@
+//========================================================================================
+// AthenaK astrophysical fluid dynamics and numerical relativity code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the AthenaK collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file hydro_dual_energy.cpp
+//! \brief Dual-energy formalism for Newtonian ideal-gas hydro.
+
+#include <cmath>
+
+#include "athena.hpp"
+#include "driver/driver.hpp"
+#include "mesh/mesh.hpp"
+#include "eos/eos.hpp"
+#include "hydro.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+Real HydroInternalEnergyFloor(const EOS_Data &eos, const Real dens) {
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool DualEnergySyncEligible(const Real eint_cons, const Real local_etot_max,
+                            const Real eta2) {
+  if (eint_cons <= 0.0) return false;
+  if (eta2 <= 0.0) return true;
+  return (eint_cons > eta2*fmax(local_etot_max, 1.0e-18));
+}
+
+} // namespace
+
+namespace hydro {
+
+TaskStatus Hydro::DualEnergyStep(Driver *pdrive, int stage) {
+  if (use_dual_energy) {
+    const Real beta_dt = (pdrive->beta[stage-1])*(pmy_pack->pmesh->dt);
+    ApplyDualEnergyFormalism(beta_dt);
+  }
+  return TaskStatus::complete;
+}
+
+void Hydro::InitializeDualEnergyFieldFromTotal() {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("hyd_dual_energy_init", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real e_k = 0.5*(SQR(u0_(m, IM1, k, j, i)) + SQR(u0_(m, IM2, k, j, i)) +
+                          SQR(u0_(m, IM3, k, j, i)))/dens;
+    const Real eint_floor = HydroInternalEnergyFloor(eos, dens);
+    const Real eint = fmax(u0_(m, IEN, k, j, i) - e_k, eint_floor);
+    u0_(m, de_idx, k, j, i) = eint;
+    w0_(m, de_idx, k, j, i) = eint;
+  });
+}
+
+void Hydro::ApplyDualEnergyFormalism(const Real dt) {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  const bool multi_d = pmy_pack->pmesh->multi_d;
+  const bool three_d = pmy_pack->pmesh->three_d;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto vf1_ = dual_vf.x1f;
+  auto vf2_ = dual_vf.x2f;
+  auto vf3_ = dual_vf.x3f;
+  auto &mbsize = pmy_pack->pmb->mb_size;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("hyd_dual_energy_compress", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    Real divv = (vf1_(m, 0, k, j, i+1) - vf1_(m, 0, k, j, i))/mbsize.d_view(m).dx1;
+    if (multi_d) {
+      divv += (vf2_(m, 0, k, j+1, i) - vf2_(m, 0, k, j, i))/mbsize.d_view(m).dx2;
+    }
+    if (three_d) {
+      divv += (vf3_(m, 0, k+1, j, i) - vf3_(m, 0, k, j, i))/mbsize.d_view(m).dx3;
+    }
+
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real eint_floor = HydroInternalEnergyFloor(eos, dens);
+    Real eint = fmax(u0_(m, de_idx, k, j, i), eint_floor);
+    eint *= exp(-(eos.gamma - 1.0)*divv*dt);
+    eint = fmax(eint, eint_floor);
+    u0_(m, de_idx, k, j, i) = eint;
+    w0_(m, de_idx, k, j, i) = eint;
+  });
+}
+
+void Hydro::SynchronizeDualEnergyFieldFromTotal() {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int ng = indcs.ng;
+  const bool multi_d = pmy_pack->pmesh->multi_d;
+  const bool three_d = pmy_pack->pmesh->three_d;
+  const int gis = is - ng;
+  const int gie = ie + ng;
+  const int gjs = multi_d ? (js - ng) : js;
+  const int gje = multi_d ? (je + ng) : je;
+  const int gks = three_d ? (ks - ng) : ks;
+  const int gke = three_d ? (ke + ng) : ke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto etot_max_ = dual_etot_max;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+  const Real eta2 = dual_energy_eta2;
+
+  if (eta2 > 0.0) {
+    par_for("hyd_dual_energy_etot_max", DevExeSpace(), 0, nmb1, gks, gke, gjs, gje, gis, gie,
+    KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+      Real emax = 0.0;
+      const int kmin = three_d ? ((k - 1 > gks) ? (k - 1) : gks) : k;
+      const int kmax = three_d ? ((k + 1 < gke) ? (k + 1) : gke) : k;
+      const int jmin = multi_d ? ((j - 1 > gjs) ? (j - 1) : gjs) : j;
+      const int jmax = multi_d ? ((j + 1 < gje) ? (j + 1) : gje) : j;
+      const int imin = (i - 1 > gis) ? (i - 1) : gis;
+      const int imax = (i + 1 < gie) ? (i + 1) : gie;
+      for (int kk = kmin; kk <= kmax; ++kk) {
+        for (int jj = jmin; jj <= jmax; ++jj) {
+          for (int ii = imin; ii <= imax; ++ii) {
+            emax = fmax(emax, u0_(m, IEN, kk, jj, ii));
+          }
+        }
+      }
+      etot_max_(m, k, j, i) = emax;
+    });
+  }
+
+  par_for("hyd_dual_energy_sync", DevExeSpace(), 0, nmb1, gks, gke, gjs, gje, gis, gie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real e_k = 0.5*(SQR(u0_(m, IM1, k, j, i)) + SQR(u0_(m, IM2, k, j, i)) +
+                          SQR(u0_(m, IM3, k, j, i)))/dens;
+    const Real eint_cons = u0_(m, IEN, k, j, i) - e_k;
+    const Real local_etot_max = (eta2 > 0.0) ? etot_max_(m, k, j, i) : 0.0;
+    Real eint_aux = u0_(m, de_idx, k, j, i);
+    if (DualEnergySyncEligible(eint_cons, local_etot_max, eta2)) {
+      eint_aux = eint_cons;
+    }
+    eint_aux = fmax(eint_aux, HydroInternalEnergyFloor(eos, dens));
+    u0_(m, de_idx, k, j, i) = eint_aux;
+    w0_(m, de_idx, k, j, i) = eint_aux;
+  });
+}
+
+void Hydro::SynchronizeRestrictedDualEnergyField() {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.cis, ie = indcs.cie;
+  const int js = indcs.cjs, je = indcs.cje;
+  const int ks = indcs.cks, ke = indcs.cke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  auto cu = coarse_u0;
+  auto cw = coarse_w0;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("hyd_dual_energy_sync_restricted", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    const Real dens = fmax(cu(m, IDN, k, j, i), eos.dfloor);
+    const Real eint_aux = fmax(cu(m, de_idx, k, j, i),
+                               HydroInternalEnergyFloor(eos, dens));
+    cu(m, de_idx, k, j, i) = eint_aux;
+    cw(m, de_idx, k, j, i) = eint_aux;
+  });
+}
+
+void Hydro::RepairRefinedDualEnergyState(DualArray1D<int> &n2o, DualArray1D<int> &rflag,
+                                         const int new_gids, const int new_nmb_local) {
+  if (!use_dual_energy || new_nmb_local <= 0) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int nmb1 = new_nmb_local - 1;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("hyd_dual_energy_repair_refined", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    if (rflag.d_view(n2o.d_view(m + new_gids)) <= 0) return;
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real eint_aux = fmax(u0_(m, de_idx, k, j, i),
+                               HydroInternalEnergyFloor(eos, dens));
+    u0_(m, de_idx, k, j, i) = eint_aux;
+    w0_(m, de_idx, k, j, i) = eint_aux;
+  });
+}
+
+} // namespace hydro

--- a/src/hydro/hydro_fluxes.cpp
+++ b/src/hydro/hydro_fluxes.cpp
@@ -22,6 +22,7 @@
 #include "hydro/rsolvers/hlle_hyd.hpp"
 #include "hydro/rsolvers/hllc_hyd.hpp"
 #include "hydro/rsolvers/roe_hyd.hpp"
+#include "hydro/rsolvers/dual_eint_hyd.hpp"
 #include "hydro/rsolvers/llf_srhyd.hpp"
 #include "hydro/rsolvers/hlle_srhyd.hpp"
 #include "hydro/rsolvers/hllc_srhyd.hpp"
@@ -43,7 +44,10 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
   int ncells1 = indcs_.nx1 + 2*(indcs_.ng);
 
   int &nhyd_  = nhydro;
-  int nvars = nhydro + nscalars;
+  int nvars = this->nvars;
+  int nuser_vars = nhydro + nscalars;
+  const bool use_dual_energy_ = use_dual_energy;
+  const int dual_idx_ = dual_energy_idx;
   int nmb1 = pmy_pack->nmb_thispack - 1;
   const auto recon_method_ = recon_method;
   bool extrema = false;
@@ -62,6 +66,7 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
   size_t scr_size = ScrArray2D<Real>::shmem_size(nvars, ncells1) * 2;
   int scr_level = 0;
   auto &flx1_ = uflx.x1f;
+  auto &vf1_ = dual_vf.x1f;
 
   // set the loop limits for 1D/2D/3D problems
   int il = is, iu = ie+1, jl = js, ju = je, kl = ks, ku = ke;
@@ -97,6 +102,9 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
       default:
         break;
     }
+    if (use_dual_energy_) {
+      FloorDualEnergyFaceStates(member, eos_, dual_idx_, il, iu, wl, wr);
+    }
     // Sync all threads in the team so that scratch memory is consistent
     member.team_barrier();
 
@@ -107,6 +115,9 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
     auto size = size_;
     auto coord = coord_;
     auto flx1 = flx1_;
+    auto vf1 = vf1_;
+    const bool dual_enabled = use_dual_energy_;
+    const int dual_idx = dual_idx_;
     if constexpr (rsolver_method_ == Hydro_RSolver::advect) {
       Advect(member, eos, indcs, size, coord, m, k, j, il, iu, IVX, wl, wr, flx1);
     } else if constexpr (rsolver_method_ == Hydro_RSolver::llf) {
@@ -129,10 +140,14 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
       HLLE_GR(member, eos, indcs, size, coord, m, k, j, il, iu, IVX, wl, wr, flx1);
     }
     member.team_barrier();
+    if (dual_enabled) {
+      UpwindDualEnergyFlux(member, eos, dual_idx, m, k, j, il, iu, wl, wr, flx1, vf1);
+      member.team_barrier();
+    }
 
     // calculate fluxes of scalars (if any)
-    if (nvars > nhyd_) {
-      for (int n=nhyd_; n<nvars; ++n) {
+    if (nuser_vars > nhyd_) {
+      for (int n=nhyd_; n<nuser_vars; ++n) {
         par_for_inner(member, is, ie+1, [&](const int i) {
           if (flx1_(m,IDN,k,j,i) >= 0.0) {
             flx1_(m,n,k,j,i) = flx1_(m,IDN,k,j,i)*wl(n,i);
@@ -150,6 +165,7 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
   if (pmy_pack->pmesh->multi_d) {
     scr_size = ScrArray2D<Real>::shmem_size(nvars, ncells1) * 3;
     auto &flx2_ = uflx.x2f;
+    auto &vf2_ = dual_vf.x2f;
 
     // set the loop limits for 1D/2D/3D problems
     il = is, iu = ie, jl = js-1, ju = je+1, kl = ks, ku = ke;
@@ -196,6 +212,9 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
           default:
             break;
         }
+        if (use_dual_energy_) {
+          FloorDualEnergyFaceStates(member, eos_, dual_idx_, il, iu, wl_jp1, wr);
+        }
         member.team_barrier();
 
         // compute fluxes over [js,je+1].  RS returns flux in input wr array
@@ -206,6 +225,9 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
           auto size = size_;
           auto coord = coord_;
           auto flx2 = flx2_;
+          auto vf2 = vf2_;
+          const bool dual_enabled = use_dual_energy_;
+          const int dual_idx = dual_idx_;
           if constexpr (rsolver_method_ == Hydro_RSolver::advect) {
             Advect(member, eos, indcs, size, coord, m, k, j, il, iu, IVY, wl, wr, flx2);
           } else if constexpr (rsolver_method_ == Hydro_RSolver::llf) {
@@ -228,11 +250,16 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
             HLLE_GR(member, eos, indcs, size, coord, m, k, j, il, iu, IVY, wl, wr, flx2);
           }
           member.team_barrier();
+          if (dual_enabled) {
+            UpwindDualEnergyFlux(member, eos, dual_idx, m, k, j, il, iu,
+                                 wl, wr, flx2, vf2);
+            member.team_barrier();
+          }
         }
 
         // calculate fluxes of scalars (if any)
-        if (nvars > nhyd_) {
-          for (int n=nhyd_; n<nvars; ++n) {
+        if (nuser_vars > nhyd_) {
+          for (int n=nhyd_; n<nuser_vars; ++n) {
             par_for_inner(member, is, ie, [&](const int i) {
               if (flx2_(m,IDN,k,j,i) >= 0.0) {
                 flx2_(m,n,k,j,i) = flx2_(m,IDN,k,j,i)*wl(n,i);
@@ -252,6 +279,7 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
   if (pmy_pack->pmesh->three_d) {
     scr_size = ScrArray2D<Real>::shmem_size(nvars, ncells1) * 3;
     auto &flx3_ = uflx.x3f;
+    auto &vf3_ = dual_vf.x3f;
 
     // set the loop limits
     il = is, iu = ie, jl = js, ju = je, kl = ks-1, ku = ke+1;
@@ -291,6 +319,9 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
           default:
             break;
         }
+        if (use_dual_energy_) {
+          FloorDualEnergyFaceStates(member, eos_, dual_idx_, il, iu, wl_kp1, wr);
+        }
         member.team_barrier();
 
         // compute fluxes over [ks,ke+1].  RS returns flux in input wr array
@@ -301,6 +332,9 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
           auto size = size_;
           auto coord = coord_;
           auto flx3 = flx3_;
+          auto vf3 = vf3_;
+          const bool dual_enabled = use_dual_energy_;
+          const int dual_idx = dual_idx_;
           if constexpr (rsolver_method_ == Hydro_RSolver::advect) {
             Advect(member, eos, indcs, size, coord, m, k, j, il, iu, IVZ, wl, wr, flx3);
           } else if constexpr (rsolver_method_ == Hydro_RSolver::llf) {
@@ -323,11 +357,16 @@ void Hydro::CalculateFluxes(Driver *pdriver, int stage) {
             HLLE_GR(member, eos, indcs, size, coord, m, k, j, il, iu, IVZ, wl, wr, flx3);
           }
           member.team_barrier();
+          if (dual_enabled) {
+            UpwindDualEnergyFlux(member, eos, dual_idx, m, k, j, il, iu,
+                                 wl, wr, flx3, vf3);
+            member.team_barrier();
+          }
         }
 
         // calculate fluxes of scalars (if any)
-        if (nvars > nhyd_) {
-          for (int n=nhyd_; n<nvars; ++n) {
+        if (nuser_vars > nhyd_) {
+          for (int n=nhyd_; n<nuser_vars; ++n) {
             par_for_inner(member, is, ie, [&](const int i) {
               if (flx3_(m,IDN,k,j,i) >= 0.0) {
                 flx3_(m,n,k,j,i) = flx3_(m,IDN,k,j,i)*wl(n,i);

--- a/src/hydro/hydro_tasks.cpp
+++ b/src/hydro/hydro_tasks.cpp
@@ -57,7 +57,8 @@ void Hydro::AssembleHydroTasks(std::map<std::string, std::shared_ptr<TaskList>> 
   id.sendf     = tl["stagen"]->AddTask(&Hydro::SendFlux, this, id.flux);
   id.recvf     = tl["stagen"]->AddTask(&Hydro::RecvFlux, this, id.sendf);
   id.rkupdt    = tl["stagen"]->AddTask(&Hydro::RKUpdate, this, id.recvf);
-  id.srctrms   = tl["stagen"]->AddTask(&Hydro::HydroSrcTerms, this, id.rkupdt);
+  id.duale     = tl["stagen"]->AddTask(&Hydro::DualEnergyStep, this, id.rkupdt);
+  id.srctrms   = tl["stagen"]->AddTask(&Hydro::HydroSrcTerms, this, id.duale);
   id.sendu_oa  = tl["stagen"]->AddTask(&Hydro::SendU_OA, this, id.srctrms);
   id.recvu_oa  = tl["stagen"]->AddTask(&Hydro::RecvU_OA, this, id.sendu_oa);
   id.restu     = tl["stagen"]->AddTask(&Hydro::RestrictU, this, id.recvu_oa);
@@ -86,13 +87,13 @@ void Hydro::AssembleHydroTasks(std::map<std::string, std::shared_ptr<TaskList>> 
 
 TaskStatus Hydro::InitRecv(Driver *pdrive, int stage) {
   // post receives for U
-  TaskStatus tstat = pbval_u->InitRecv(nhydro+nscalars);
+  TaskStatus tstat = pbval_u->InitRecv(nvars);
   if (tstat != TaskStatus::complete) return tstat;
 
   // with SMR/AMR post receives for fluxes of U
   // do not post receives for fluxes when stage < 0 (i.e. ICs)
   if (pmy_pack->pmesh->multilevel && (stage >= 0)) {
-    tstat = pbval_u->InitFluxRecv(nhydro+nscalars);
+    tstat = pbval_u->InitFluxRecv(nvars + (use_dual_energy ? 1 : 0));
   }
   if (tstat != TaskStatus::complete) return tstat;
 
@@ -138,7 +139,7 @@ TaskStatus Hydro::CopyCons(Driver *pdrive, int stage) {
       int js = indcs.js, je = indcs.je;
       int ks = indcs.ks, ke = indcs.ke;
       int nmb1 = pmy_pack->nmb_thispack - 1;
-      int nvar = nhydro + nscalars;
+      int nvar = nvars;
       auto &u0 = pmy_pack->phydro->u0;
       auto &u1 = pmy_pack->phydro->u1;
       Real &delta = pdrive->delta[stage-1];
@@ -209,7 +210,7 @@ TaskStatus Hydro::SendFlux(Driver *pdrive, int stage) {
   TaskStatus tstat = TaskStatus::complete;
   // Only execute BoundaryVaLUES function with SMR/SMR
   if (pmy_pack->pmesh->multilevel) {
-    tstat = pbval_u->PackAndSendFluxCC(uflx);
+    tstat = pbval_u->PackAndSendFluxCC(uflx, use_dual_energy ? &dual_vf : nullptr);
   }
   return tstat;
 }
@@ -223,7 +224,7 @@ TaskStatus Hydro::RecvFlux(Driver *pdrive, int stage) {
   TaskStatus tstat = TaskStatus::complete;
   // Only execute BoundaryValues function with SMR/SMR
   if (pmy_pack->pmesh->multilevel) {
-    tstat = pbval_u->RecvAndUnpackFluxCC(uflx);
+    tstat = pbval_u->RecvAndUnpackFluxCC(uflx, use_dual_energy ? &dual_vf : nullptr);
   }
   return tstat;
 }
@@ -297,6 +298,7 @@ TaskStatus Hydro::RestrictU(Driver *pdrive, int stage) {
   // Only execute Mesh function with SMR/SMR
   if (pmy_pack->pmesh->multilevel) {
     pmy_pack->pmesh->pmr->RestrictCC(u0, coarse_u0);
+    SynchronizeRestrictedDualEnergyField();
   }
   return TaskStatus::complete;
 }
@@ -397,6 +399,7 @@ TaskStatus Hydro::ConToPrim(Driver *pdrive, int stage) {
   int n1m1 = indcs.nx1 + 2*ng - 1;
   int n2m1 = (indcs.nx2 > 1)? (indcs.nx2 + 2*ng - 1) : 0;
   int n3m1 = (indcs.nx3 > 1)? (indcs.nx3 + 2*ng - 1) : 0;
+  SynchronizeDualEnergyFieldFromTotal();
   peos->ConsToPrim(u0, w0, false, 0, n1m1, 0, n2m1, 0, n3m1);
   return TaskStatus::complete;
 }

--- a/src/hydro/hydro_update.cpp
+++ b/src/hydro/hydro_update.cpp
@@ -33,7 +33,7 @@ TaskStatus Hydro::RKUpdate(Driver *pdriver, int stage) {
   Real &gam1 = pdriver->gam1[stage-1];
   Real beta_dt = (pdriver->beta[stage-1])*(pmy_pack->pmesh->dt);
   int nmb1 = pmy_pack->nmb_thispack - 1;
-  int nvar = nhydro + nscalars;
+  int nvar = nvars;
   auto u0_ = u0;
   auto u1_ = u1;
   auto flx1 = uflx.x1f;

--- a/src/hydro/rsolvers/dual_eint_hyd.hpp
+++ b/src/hydro/rsolvers/dual_eint_hyd.hpp
@@ -1,0 +1,64 @@
+#ifndef HYDRO_RSOLVERS_DUAL_EINT_HYD_HPP_
+#define HYDRO_RSOLVERS_DUAL_EINT_HYD_HPP_
+//========================================================================================
+// AthenaK astrophysical fluid dynamics and numerical relativity code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the AthenaK collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file dual_eint_hyd.hpp
+//! \brief auxiliary internal-energy flux helper for Newtonian hydro
+
+namespace hydro {
+
+KOKKOS_INLINE_FUNCTION
+Real DualEnergyInternalEnergyFloor(const EOS_Data &eos, const Real dens_in) {
+  const Real dens = fmax(dens_in, eos.dfloor);
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+KOKKOS_INLINE_FUNCTION
+void FloorDualEnergyFaceStates(TeamMember_t const &member, const EOS_Data &eos,
+                               const int dual_idx, const int il, const int iu,
+                               ScrArray2D<Real> &wl, ScrArray2D<Real> &wr) {
+  par_for_inner(member, il, iu, [&](const int i) {
+    wl(dual_idx, i) = fmax(wl(dual_idx, i),
+                           DualEnergyInternalEnergyFloor(eos, wl(IDN, i)));
+    wr(dual_idx, i) = fmax(wr(dual_idx, i),
+                           DualEnergyInternalEnergyFloor(eos, wr(IDN, i)));
+  });
+}
+
+KOKKOS_INLINE_FUNCTION
+void UpwindDualEnergyFlux(TeamMember_t const &member, const EOS_Data &eos,
+                          const int dual_idx, const int m, const int k, const int j,
+                          const int il, const int iu, const ScrArray2D<Real> &wl,
+                          const ScrArray2D<Real> &wr, DvceArray5D<Real> flx,
+                          DvceArray5D<Real> vf) {
+  par_for_inner(member, il, iu, [&](const int i) {
+    const Real mass_flux = flx(m, IDN, k, j, i);
+    if (mass_flux > 0.0) {
+      const Real dens = fmax(wl(IDN, i), eos.dfloor);
+      flx(m, dual_idx, k, j, i) = mass_flux*(wl(dual_idx, i)/dens);
+      vf(m, 0, k, j, i) = mass_flux/dens;
+    } else if (mass_flux < 0.0) {
+      const Real dens = fmax(wr(IDN, i), eos.dfloor);
+      flx(m, dual_idx, k, j, i) = mass_flux*(wr(dual_idx, i)/dens);
+      vf(m, 0, k, j, i) = mass_flux/dens;
+    } else {
+      flx(m, dual_idx, k, j, i) = 0.0;
+      vf(m, 0, k, j, i) = 0.0;
+    }
+  });
+}
+
+} // namespace hydro
+
+#endif // HYDRO_RSOLVERS_DUAL_EINT_HYD_HPP_

--- a/src/mesh/load_balance.cpp
+++ b/src/mesh/load_balance.cpp
@@ -137,12 +137,10 @@ void MeshRefinement::InitRecvAMR(int nleaf) {
   // count number of cell- and face-centered variables communicated depending on physics
   int ncc_tosend=0, nfc_tosend=0;
   if (pmy_mesh->pmb_pack->phydro != nullptr) {
-    ncc_tosend += (pmy_mesh->pmb_pack->phydro->nhydro +
-                   pmy_mesh->pmb_pack->phydro->nscalars);
+    ncc_tosend += pmy_mesh->pmb_pack->phydro->nvars;
   }
   if (pmy_mesh->pmb_pack->pmhd != nullptr) {
-    ncc_tosend += (pmy_mesh->pmb_pack->pmhd->nmhd +
-                   pmy_mesh->pmb_pack->pmhd->nscalars);
+    ncc_tosend += pmy_mesh->pmb_pack->pmhd->nvars;
     nfc_tosend += 1;
   }
   if (pmy_mesh->pmb_pack->prad != nullptr) {
@@ -392,12 +390,10 @@ void MeshRefinement::PackAndSendAMR(int nleaf) {
   // count number of cell- and face-centered variables communicated depending on physics
   int ncc_tosend=0, nfc_tosend=0;
   if (pmy_mesh->pmb_pack->phydro != nullptr) {
-    ncc_tosend += (pmy_mesh->pmb_pack->phydro->nhydro +
-                   pmy_mesh->pmb_pack->phydro->nscalars);
+    ncc_tosend += pmy_mesh->pmb_pack->phydro->nvars;
   }
   if (pmy_mesh->pmb_pack->pmhd != nullptr) {
-    ncc_tosend += (pmy_mesh->pmb_pack->pmhd->nmhd +
-                   pmy_mesh->pmb_pack->pmhd->nscalars);
+    ncc_tosend += pmy_mesh->pmb_pack->pmhd->nvars;
     nfc_tosend += 1;
   }
   if (pmy_mesh->pmb_pack->prad != nullptr) {
@@ -534,11 +530,11 @@ void MeshRefinement::PackAndSendAMR(int nleaf) {
   int ncc_sent = 0, nfc_sent = 0;
   if (phydro != nullptr) {
     PackAMRBuffersCC(phydro->u0, phydro->coarse_u0, ncc_sent, nfc_sent);
-    ncc_sent += phydro->nhydro + phydro->nscalars;
+    ncc_sent += phydro->nvars;
   }
   if (pmhd != nullptr) {
     PackAMRBuffersCC(pmhd->u0, pmhd->coarse_u0, ncc_sent, nfc_sent);
-    ncc_sent += pmhd->nmhd + pmhd->nscalars;
+    ncc_sent += pmhd->nvars;
     PackAMRBuffersFC(pmhd->b0, pmhd->coarse_b0, ncc_sent, nfc_sent);
     nfc_sent += 1;
   }
@@ -824,11 +820,11 @@ void MeshRefinement::ClearRecvAndUnpackAMR() {
 
   if (phydro != nullptr) {
     UnpackAMRBuffersCC(phydro->u0, phydro->coarse_u0, ncc_recv, nfc_recv);
-    ncc_recv += phydro->nhydro + phydro->nscalars;
+    ncc_recv += phydro->nvars;
   }
   if (pmhd != nullptr) {
     UnpackAMRBuffersCC(pmhd->u0, pmhd->coarse_u0, ncc_recv, nfc_recv);
-    ncc_recv += pmhd->nmhd + pmhd->nscalars;
+    ncc_recv += pmhd->nvars;
     UnpackAMRBuffersFC(pmhd->b0, pmhd->coarse_b0, ncc_recv, nfc_recv);
     nfc_recv += 1;
   }

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -561,10 +561,20 @@ void MeshRefinement::RedistAndRefineMeshBlocks(ParameterInput *pin, int nnew, in
   if (nnew > 0) {
     if (phydro != nullptr) {
       RefineCC(new_to_old, phydro->u0, phydro->coarse_u0);
+      if (phydro->use_dual_energy) {
+        phydro->RepairRefinedDualEnergyState(new_to_old, refine_flag,
+                                             new_gids_eachrank[global_variable::my_rank],
+                                             new_nmb_eachrank[global_variable::my_rank]);
+      }
     }
     if (pmhd != nullptr) {
       RefineCC(new_to_old, pmhd->u0, pmhd->coarse_u0);
       RefineFC(new_to_old, pmhd->b0, pmhd->coarse_b0);
+      if (pmhd->use_dual_energy) {
+        pmhd->RepairRefinedDualEnergyState(new_to_old, refine_flag,
+                                           new_gids_eachrank[global_variable::my_rank],
+                                           new_nmb_eachrank[global_variable::my_rank]);
+      }
     }
     if (prad != nullptr) {
       RefineCC(new_to_old, prad->i0, prad->coarse_i0);

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -39,6 +39,8 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     u1("cons1",1,1,1,1,1),
     b1("B_fc1",1,1,1,1),
     uflx("uflx",1,1,1,1,1),
+    dual_vf("dual_vf",1,1,1,1,1),
+    dual_etot_max("dual_etot_max",1,1,1,1),
     efld("efld",1,1,1,1),
     wsaved("wsaved",1,1,1,1,1),
     bccsaved("bccsaved",1,1,1,1,1),
@@ -95,6 +97,29 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
 
   // (2) Initialize scalars, diffusion, source terms
   nscalars = pin->GetOrAddInteger("mhd","nscalars",0);
+  use_dual_energy = pin->GetOrAddBoolean("mhd", "dual_energy", false);
+  if (use_dual_energy) {
+    if (!peos->eos_data.is_ideal || nmhd != 5) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<mhd>/dual_energy requires a non-isothermal ideal gas EOS"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+    if (pmy_pack->pcoord->is_special_relativistic ||
+        pmy_pack->pcoord->is_general_relativistic ||
+        pmy_pack->pcoord->is_dynamical_relativistic) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<mhd>/dual_energy is implemented only for Newtonian MHD"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+    naux = 1;
+    dual_energy_idx = nmhd + nscalars;
+    dual_energy_needs_init = true;
+    dual_energy_eta1 = pin->GetOrAddReal("mhd", "dual_energy_eta1", 1.0e-3);
+    dual_energy_eta2 = pin->GetOrAddReal("mhd", "dual_energy_eta2", 1.0e-4);
+  }
+  nvars = nmhd + nscalars + naux;
 
   // Viscosity (only constructed if needed)
   if (pin->DoesParameterExist("mhd","viscosity")) {
@@ -123,9 +148,26 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     psrc = new SourceTerms("mhd_srcterms", ppack, pin);
   }
 
+  if (use_dual_energy) {
+    if (pvisc != nullptr || presist != nullptr || pcond != nullptr || psrc != nullptr ||
+        pin->DoesBlockExist("shearing_box")) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<mhd>/dual_energy is not implemented with viscosity, "
+                << "resistivity, thermal conduction, MHD source terms, or shearing box"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
   // (3) read time-evolution option [already error checked in driver constructor]
   // Then initialize memory and algorithms for reconstruction and Riemann solvers
   std::string evolution_t = pin->GetString("time","evolution");
+  if (use_dual_energy && evolution_t.compare("dynamic") != 0) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "<mhd>/dual_energy only supports dynamic evolution"
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
 
   // allocate memory for conserved and primitive variables
   // With AMR, maximum size of Views are limited by total device memory through an input
@@ -135,8 +177,11 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     int ncells1 = indcs.nx1 + 2*(indcs.ng);
     int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
     int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
-    Kokkos::realloc(u0,   nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
-    Kokkos::realloc(w0,   nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+    Kokkos::realloc(u0,   nmb, nvars, ncells3, ncells2, ncells1);
+    Kokkos::realloc(w0,   nmb, nvars, ncells3, ncells2, ncells1);
+    if (use_dual_energy) {
+      Kokkos::realloc(dual_etot_max, nmb, ncells3, ncells2, ncells1);
+    }
 
     // allocate memory for face-centered and cell-centered magnetic fields
     Kokkos::realloc(bcc0,   nmb, 3, ncells3, ncells2, ncells1);
@@ -151,8 +196,8 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     int n_ccells1 = indcs.cnx1 + 2*(indcs.ng);
     int n_ccells2 = (indcs.cnx2 > 1)? (indcs.cnx2 + 2*(indcs.ng)) : 1;
     int n_ccells3 = (indcs.cnx3 > 1)? (indcs.cnx3 + 2*(indcs.ng)) : 1;
-    Kokkos::realloc(coarse_u0, nmb, (nmhd+nscalars), n_ccells3, n_ccells2, n_ccells1);
-    Kokkos::realloc(coarse_w0, nmb, (nmhd+nscalars), n_ccells3, n_ccells2, n_ccells1);
+    Kokkos::realloc(coarse_u0, nmb, nvars, n_ccells3, n_ccells2, n_ccells1);
+    Kokkos::realloc(coarse_w0, nmb, nvars, n_ccells3, n_ccells2, n_ccells1);
     Kokkos::realloc(coarse_b0.x1f, nmb, n_ccells3, n_ccells2, n_ccells1+1);
     Kokkos::realloc(coarse_b0.x2f, nmb, n_ccells3, n_ccells2+1, n_ccells1);
     Kokkos::realloc(coarse_b0.x3f, nmb, n_ccells3+1, n_ccells2, n_ccells1);
@@ -160,15 +205,15 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
 
   // allocate boundary buffers for conserved (cell-centered) and face-centered variables
   pbval_u = new MeshBoundaryValuesCC(ppack, pin, false);
-  pbval_u->InitializeBuffers((nmhd+nscalars));
+  pbval_u->InitializeBuffers(nvars, nvars + (use_dual_energy ? 1 : 0));
   pbval_b = new MeshBoundaryValuesFC(ppack, pin);
   pbval_b->InitializeBuffers(3);
 
   // Orbital advection and shearing box BCs (if requested in input file)
   if (pin->DoesBlockExist("shearing_box")) {
-    porb_u = new OrbitalAdvectionCC(ppack, pin, (nmhd+nscalars));
+    porb_u = new OrbitalAdvectionCC(ppack, pin, nvars);
     porb_b = new OrbitalAdvectionFC(ppack, pin);
-    psbox_u = new ShearingBoxCC(ppack, pin, (nmhd+nscalars));
+    psbox_u = new ShearingBoxCC(ppack, pin, nvars);
     psbox_b = new ShearingBoxFC(ppack, pin);
   } else {
     porb_u = nullptr;
@@ -181,6 +226,12 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   if (evolution_t.compare("stationary") != 0) {
     // determine if FOFC is enabled
     use_fofc = pin->GetOrAddBoolean("mhd","fofc",false);
+    if (use_dual_energy && use_fofc) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "<mhd>/dual_energy is not implemented with FOFC"
+                << std::endl;
+      std::exit(EXIT_FAILURE);
+    }
 
     // select reconstruction method (default PLM)
     std::string xorder = pin->GetOrAddString("mhd","reconstruct","plm");
@@ -311,15 +362,20 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
       int ncells1 = indcs.nx1 + 2*(indcs.ng);
       int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
       int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
-      Kokkos::realloc(u1,     nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+      Kokkos::realloc(u1,     nmb, nvars, ncells3, ncells2, ncells1);
       Kokkos::realloc(b1.x1f, nmb, ncells3, ncells2, ncells1+1);
       Kokkos::realloc(b1.x2f, nmb, ncells3, ncells2+1, ncells1);
       Kokkos::realloc(b1.x3f, nmb, ncells3+1, ncells2, ncells1);
 
       // allocate fluxes, electric fields
-      Kokkos::realloc(uflx.x1f, nmb, (nmhd+nscalars), ncells3, ncells2, ncells1+1);
-      Kokkos::realloc(uflx.x2f, nmb, (nmhd+nscalars), ncells3, ncells2+1, ncells1);
-      Kokkos::realloc(uflx.x3f, nmb, (nmhd+nscalars), ncells3+1, ncells2, ncells1);
+      Kokkos::realloc(uflx.x1f, nmb, nvars, ncells3, ncells2, ncells1+1);
+      Kokkos::realloc(uflx.x2f, nmb, nvars, ncells3, ncells2+1, ncells1);
+      Kokkos::realloc(uflx.x3f, nmb, nvars, ncells3+1, ncells2, ncells1);
+      if (use_dual_energy) {
+        Kokkos::realloc(dual_vf.x1f, nmb, 1, ncells3, ncells2, ncells1+1);
+        Kokkos::realloc(dual_vf.x2f, nmb, 1, ncells3, ncells2+1, ncells1);
+        Kokkos::realloc(dual_vf.x3f, nmb, 1, ncells3+1, ncells2, ncells1);
+      }
       Kokkos::realloc(efld.x1e, nmb, ncells3+1, ncells2+1, ncells1);
       Kokkos::realloc(efld.x2e, nmb, ncells3+1, ncells2, ncells1+1);
       Kokkos::realloc(efld.x3e, nmb, ncells3, ncells2+1, ncells1+1);
@@ -379,7 +435,7 @@ void MHD::SetSaveWBcc() {
   int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
 
   // allocated saved arrays for time derivatives
-  Kokkos::realloc(wsaved,   nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+  Kokkos::realloc(wsaved,   nmb, nvars, ncells3, ncells2, ncells1);
   Kokkos::realloc(bccsaved, nmb, 3,               ncells3, ncells2, ncells1);
 
   wbcc_saved = true;

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -115,7 +115,6 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     }
     naux = 1;
     dual_energy_idx = nmhd + nscalars;
-    dual_energy_needs_init = true;
     dual_energy_eta1 = pin->GetOrAddReal("mhd", "dual_energy_eta1", 1.0e-3);
     dual_energy_eta2 = pin->GetOrAddReal("mhd", "dual_energy_eta2", 1.0e-4);
   }

--- a/src/mhd/mhd.hpp
+++ b/src/mhd/mhd.hpp
@@ -52,6 +52,7 @@ struct MHDTaskIDs {
   TaskID sendf;
   TaskID recvf;
   TaskID rkupdt;
+  TaskID duale;
   TaskID srctrms;
   TaskID sendu_oa;
   TaskID recvu_oa;
@@ -97,6 +98,13 @@ class MHD {
 
   int nmhd;                // number of mhd variables (5/4 for ideal/isothermal EOS)
   int nscalars;            // number of passive scalars
+  int naux = 0;             // number of hidden auxiliary MHD variables
+  int nvars = 0;            // total MHD-carried variables = nmhd+nscalars+naux
+  int dual_energy_idx = -1;
+  bool use_dual_energy = false;
+  bool dual_energy_needs_init = false;
+  Real dual_energy_eta1 = 1.0e-3;
+  Real dual_energy_eta2 = 1.0e-4;
   DvceArray5D<Real> u0;    // conserved variables
   DvceArray5D<Real> w0;    // primitive variables
   DvceFaceFld4D<Real> b0;  // face-centered magnetic fields
@@ -127,6 +135,8 @@ class MHD {
   DvceArray5D<Real> u1;       // conserved variables, second register
   DvceFaceFld4D<Real> b1;     // face-centered magnetic fields, second register
   DvceFaceFld5D<Real> uflx;   // fluxes of conserved quantities on cell faces
+  DvceFaceFld5D<Real> dual_vf;  // mass-flux velocity for dual-energy compression
+  DvceArray4D<Real> dual_etot_max;  // local total-energy scale for dual-energy sync
   DvceEdgeFld4D<Real> efld;   // edge-centered electric fields (fluxes of B)
   // temporary variables used to store face-centered electric fields returned by RS
   DvceArray4D<Real> e3x1, e2x1;
@@ -160,6 +170,7 @@ class MHD {
   TaskStatus SendFlux(Driver *d, int stage);
   TaskStatus RecvFlux(Driver *d, int stage);
   TaskStatus RKUpdate(Driver *d, int stage);
+  TaskStatus DualEnergyStep(Driver *d, int stage);
   TaskStatus MHDSrcTerms(Driver *d, int stage);
   TaskStatus SendU_OA(Driver *d, int stage);
   TaskStatus RecvU_OA(Driver *d, int stage);
@@ -191,6 +202,14 @@ class MHD {
   // CalculateFluxes function templated over Riemann Solvers
   template <MHD_RSolver T>
   void CalculateFluxes(Driver *d, int stage);
+
+  // dual-energy formalism
+  void InitializeDualEnergyFieldFromTotal();
+  void ApplyDualEnergyFormalism(const Real dt);
+  void SynchronizeDualEnergyFieldFromTotal();
+  void SynchronizeRestrictedDualEnergyField();
+  void RepairRefinedDualEnergyState(DualArray1D<int> &n2o, DualArray1D<int> &rflag,
+                                    const int new_gids, const int new_nmb_local);
 
   // first-order flux correction
   void FOFC(Driver *d, int stage);

--- a/src/mhd/mhd_dual_energy.cpp
+++ b/src/mhd/mhd_dual_energy.cpp
@@ -1,0 +1,236 @@
+//========================================================================================
+// AthenaK astrophysical fluid dynamics and numerical relativity code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the AthenaK collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file mhd_dual_energy.cpp
+//! \brief Dual-energy formalism for Newtonian ideal-gas MHD.
+
+#include <cmath>
+
+#include "athena.hpp"
+#include "driver/driver.hpp"
+#include "mesh/mesh.hpp"
+#include "eos/eos.hpp"
+#include "mhd.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+Real MHDInternalEnergyFloor(const EOS_Data &eos, const Real dens) {
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool DualEnergySyncEligible(const Real eint_cons, const Real local_etot_max,
+                            const Real eta2) {
+  if (eint_cons <= 0.0) return false;
+  if (eta2 <= 0.0) return true;
+  return (eint_cons > eta2*fmax(local_etot_max, 1.0e-18));
+}
+
+} // namespace
+
+namespace mhd {
+
+TaskStatus MHD::DualEnergyStep(Driver *pdrive, int stage) {
+  if (use_dual_energy) {
+    const Real beta_dt = (pdrive->beta[stage-1])*(pmy_pack->pmesh->dt);
+    ApplyDualEnergyFormalism(beta_dt);
+  }
+  return TaskStatus::complete;
+}
+
+void MHD::InitializeDualEnergyFieldFromTotal() {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto b0_ = b0;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("mhd_dual_energy_init", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real e_k = 0.5*(SQR(u0_(m, IM1, k, j, i)) + SQR(u0_(m, IM2, k, j, i)) +
+                          SQR(u0_(m, IM3, k, j, i)))/dens;
+    const Real bx = 0.5*(b0_.x1f(m, k, j, i) + b0_.x1f(m, k, j, i+1));
+    const Real by = 0.5*(b0_.x2f(m, k, j, i) + b0_.x2f(m, k, j+1, i));
+    const Real bz = 0.5*(b0_.x3f(m, k, j, i) + b0_.x3f(m, k+1, j, i));
+    const Real e_m = 0.5*(SQR(bx) + SQR(by) + SQR(bz));
+    const Real eint_floor = MHDInternalEnergyFloor(eos, dens);
+    const Real eint = fmax(u0_(m, IEN, k, j, i) - e_k - e_m, eint_floor);
+    u0_(m, de_idx, k, j, i) = eint;
+    w0_(m, de_idx, k, j, i) = eint;
+  });
+}
+
+void MHD::ApplyDualEnergyFormalism(const Real dt) {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  const bool multi_d = pmy_pack->pmesh->multi_d;
+  const bool three_d = pmy_pack->pmesh->three_d;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto vf1_ = dual_vf.x1f;
+  auto vf2_ = dual_vf.x2f;
+  auto vf3_ = dual_vf.x3f;
+  auto &mbsize = pmy_pack->pmb->mb_size;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("mhd_dual_energy_compress", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    Real divv = (vf1_(m, 0, k, j, i+1) - vf1_(m, 0, k, j, i))/mbsize.d_view(m).dx1;
+    if (multi_d) {
+      divv += (vf2_(m, 0, k, j+1, i) - vf2_(m, 0, k, j, i))/mbsize.d_view(m).dx2;
+    }
+    if (three_d) {
+      divv += (vf3_(m, 0, k+1, j, i) - vf3_(m, 0, k, j, i))/mbsize.d_view(m).dx3;
+    }
+
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real eint_floor = MHDInternalEnergyFloor(eos, dens);
+    Real eint = fmax(u0_(m, de_idx, k, j, i), eint_floor);
+    eint *= exp(-(eos.gamma - 1.0)*divv*dt);
+    eint = fmax(eint, eint_floor);
+    u0_(m, de_idx, k, j, i) = eint;
+    w0_(m, de_idx, k, j, i) = eint;
+  });
+}
+
+void MHD::SynchronizeDualEnergyFieldFromTotal() {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int ng = indcs.ng;
+  const bool multi_d = pmy_pack->pmesh->multi_d;
+  const bool three_d = pmy_pack->pmesh->three_d;
+  const int gis = is - ng;
+  const int gie = ie + ng;
+  const int gjs = multi_d ? (js - ng) : js;
+  const int gje = multi_d ? (je + ng) : je;
+  const int gks = three_d ? (ks - ng) : ks;
+  const int gke = three_d ? (ke + ng) : ke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto b0_ = b0;
+  auto etot_max_ = dual_etot_max;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+  const Real eta2 = dual_energy_eta2;
+
+  if (eta2 > 0.0) {
+    par_for("mhd_dual_energy_etot_max", DevExeSpace(), 0, nmb1, gks, gke, gjs, gje, gis, gie,
+    KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+      Real emax = 0.0;
+      const int kmin = three_d ? ((k - 1 > gks) ? (k - 1) : gks) : k;
+      const int kmax = three_d ? ((k + 1 < gke) ? (k + 1) : gke) : k;
+      const int jmin = multi_d ? ((j - 1 > gjs) ? (j - 1) : gjs) : j;
+      const int jmax = multi_d ? ((j + 1 < gje) ? (j + 1) : gje) : j;
+      const int imin = (i - 1 > gis) ? (i - 1) : gis;
+      const int imax = (i + 1 < gie) ? (i + 1) : gie;
+      for (int kk = kmin; kk <= kmax; ++kk) {
+        for (int jj = jmin; jj <= jmax; ++jj) {
+          for (int ii = imin; ii <= imax; ++ii) {
+            emax = fmax(emax, u0_(m, IEN, kk, jj, ii));
+          }
+        }
+      }
+      etot_max_(m, k, j, i) = emax;
+    });
+  }
+
+  par_for("mhd_dual_energy_sync", DevExeSpace(), 0, nmb1, gks, gke, gjs, gje, gis, gie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real e_k = 0.5*(SQR(u0_(m, IM1, k, j, i)) + SQR(u0_(m, IM2, k, j, i)) +
+                          SQR(u0_(m, IM3, k, j, i)))/dens;
+    const Real bx = 0.5*(b0_.x1f(m, k, j, i) + b0_.x1f(m, k, j, i+1));
+    const Real by = 0.5*(b0_.x2f(m, k, j, i) + b0_.x2f(m, k, j+1, i));
+    const Real bz = 0.5*(b0_.x3f(m, k, j, i) + b0_.x3f(m, k+1, j, i));
+    const Real e_m = 0.5*(SQR(bx) + SQR(by) + SQR(bz));
+    const Real eint_cons = u0_(m, IEN, k, j, i) - e_k - e_m;
+    const Real local_etot_max = (eta2 > 0.0) ? etot_max_(m, k, j, i) : 0.0;
+    Real eint_aux = u0_(m, de_idx, k, j, i);
+    if (DualEnergySyncEligible(eint_cons, local_etot_max, eta2)) {
+      eint_aux = eint_cons;
+    }
+    eint_aux = fmax(eint_aux, MHDInternalEnergyFloor(eos, dens));
+    u0_(m, de_idx, k, j, i) = eint_aux;
+    w0_(m, de_idx, k, j, i) = eint_aux;
+  });
+}
+
+void MHD::SynchronizeRestrictedDualEnergyField() {
+  if (!use_dual_energy) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.cis, ie = indcs.cie;
+  const int js = indcs.cjs, je = indcs.cje;
+  const int ks = indcs.cks, ke = indcs.cke;
+  const int nmb1 = pmy_pack->nmb_thispack - 1;
+  auto cu = coarse_u0;
+  auto cw = coarse_w0;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("mhd_dual_energy_sync_restricted", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    const Real dens = fmax(cu(m, IDN, k, j, i), eos.dfloor);
+    const Real eint_aux = fmax(cu(m, de_idx, k, j, i),
+                               MHDInternalEnergyFloor(eos, dens));
+    cu(m, de_idx, k, j, i) = eint_aux;
+    cw(m, de_idx, k, j, i) = eint_aux;
+  });
+}
+
+void MHD::RepairRefinedDualEnergyState(DualArray1D<int> &n2o, DualArray1D<int> &rflag,
+                                       const int new_gids, const int new_nmb_local) {
+  if (!use_dual_energy || new_nmb_local <= 0) return;
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  const int is = indcs.is, ie = indcs.ie;
+  const int js = indcs.js, je = indcs.je;
+  const int ks = indcs.ks, ke = indcs.ke;
+  const int nmb1 = new_nmb_local - 1;
+  auto u0_ = u0;
+  auto w0_ = w0;
+  auto &eos = peos->eos_data;
+  const int de_idx = dual_energy_idx;
+
+  par_for("mhd_dual_energy_repair_refined", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie,
+  KOKKOS_LAMBDA(const int m, const int k, const int j, const int i) {
+    if (rflag.d_view(n2o.d_view(m + new_gids)) <= 0) return;
+    const Real dens = fmax(u0_(m, IDN, k, j, i), eos.dfloor);
+    const Real eint_aux = fmax(u0_(m, de_idx, k, j, i),
+                               MHDInternalEnergyFloor(eos, dens));
+    u0_(m, de_idx, k, j, i) = eint_aux;
+    w0_(m, de_idx, k, j, i) = eint_aux;
+  });
+}
+
+} // namespace mhd

--- a/src/mhd/mhd_fluxes.cpp
+++ b/src/mhd/mhd_fluxes.cpp
@@ -23,6 +23,7 @@
 #include "mhd/rsolvers/llf_mhd.hpp"
 #include "mhd/rsolvers/hlle_mhd.hpp"
 #include "mhd/rsolvers/hlld_mhd.hpp"
+#include "mhd/rsolvers/dual_eint_mhd.hpp"
 #include "mhd/rsolvers/llf_srmhd.hpp"
 #include "mhd/rsolvers/hlle_srmhd.hpp"
 #include "mhd/rsolvers/llf_grmhd.hpp"
@@ -45,7 +46,10 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
   int ncells1 = indcs_.nx1 + 2*(indcs_.ng);
 
   int &nmhd_ = nmhd;
-  int nvars = nmhd + nscalars;
+  int nvars = this->nvars;
+  int nuser_vars = nmhd + nscalars;
+  const bool use_dual_energy_ = use_dual_energy;
+  const int dual_idx_ = dual_energy_idx;
   int nmb1 = pmy_pack->nmb_thispack - 1;
   const auto recon_method_ = recon_method;
   bool extrema = false;
@@ -66,6 +70,7 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
                      ScrArray2D<Real>::shmem_size(3, ncells1)) * 2;
   int scr_level = 0;
   auto &flx1_ = uflx.x1f;
+  auto &vf1_ = dual_vf.x1f;
   auto &e31_ = e3x1;
   auto &e21_ = e2x1;
   auto &bx_ = b0.x1f;
@@ -111,6 +116,9 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
       default:
         break;
     }
+    if (use_dual_energy_) {
+      FloorDualEnergyFaceStates(member, eos_, dual_idx_, il, iu, wl, wr);
+    }
     // Sync all threads in the team so that scratch memory is consistent
     member.team_barrier();
 
@@ -124,8 +132,11 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
     auto coord = coord_;
     auto bx = bx_;
     auto flx1 = flx1_;
+    auto vf1 = vf1_;
     auto e31 = e31_;
     auto e21 = e21_;
+    const bool dual_enabled = use_dual_energy_;
+    const int dual_idx = dual_idx_;
     if constexpr (rsolver_method_ == MHD_RSolver::advect) {
       Advect(member,eos,indcs,size,coord,m,k,j,il,iu,IVX,wl,wr,bl,br,bx,flx1,e31,e21);
     } else if constexpr (rsolver_method_ == MHD_RSolver::llf) {
@@ -144,10 +155,14 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
       HLLE_GR(member,eos,indcs,size,coord,m,k,j,il,iu,IVX,wl,wr,bl,br,bx,flx1,e31,e21);
     }
     member.team_barrier();
+    if (dual_enabled) {
+      UpwindDualEnergyFlux(member, eos, dual_idx, m, k, j, il, iu, wl, wr, flx1, vf1);
+      member.team_barrier();
+    }
 
     // calculate fluxes of scalars (if any)
-    if (nvars > nmhd_) {
-      for (int n=nmhd_; n<nvars; ++n) {
+    if (nuser_vars > nmhd_) {
+      for (int n=nmhd_; n<nuser_vars; ++n) {
         par_for_inner(member, is, ie+1, [&](const int i) {
           if (flx1_(m,IDN,k,j,i) >= 0.0) {
             flx1_(m,n,k,j,i) = flx1_(m,IDN,k,j,i)*wl(n,i);
@@ -166,6 +181,7 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
     scr_size = (ScrArray2D<Real>::shmem_size(nvars, ncells1) +
                 ScrArray2D<Real>::shmem_size(3, ncells1)) * 3;
     auto &flx2_ = uflx.x2f;
+    auto &vf2_ = dual_vf.x2f;
     auto &by_ = b0.x2f;
     auto &e12_ = e1x2;
     auto &e32_ = e3x2;
@@ -225,6 +241,9 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
           default:
             break;
         }
+        if (use_dual_energy_) {
+          FloorDualEnergyFaceStates(member, eos_, dual_idx_, is-1, ie+1, wl_jp1, wr);
+        }
         member.team_barrier();
 
         // compute fluxes over [js,je+1].  MHD RS also computes electric fields, where
@@ -238,8 +257,11 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
           auto coord = coord_;
           auto by = by_;
           auto flx2 = flx2_;
+          auto vf2 = vf2_;
           auto e12 = e12_;
           auto e32 = e32_;
+          const bool dual_enabled = use_dual_energy_;
+          const int dual_idx = dual_idx_;
           if constexpr (rsolver_method_ == MHD_RSolver::advect) {
             Advect(member,eos,indcs,size,coord,
                     m,k,j,is-1,ie+1,IVY,wl,wr,bl,br,by,flx2,e12,e32);
@@ -266,11 +288,16 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
                     m,k,j,is-1,ie+1,IVY,wl,wr,bl,br,by,flx2,e12,e32);
           }
           member.team_barrier();
+          if (dual_enabled) {
+            UpwindDualEnergyFlux(member, eos, dual_idx, m, k, j, is-1, ie+1,
+                                 wl, wr, flx2, vf2);
+            member.team_barrier();
+          }
         }
 
         // calculate fluxes of scalars (if any)
-        if (nvars > nmhd_) {
-          for (int n=nmhd_; n<nvars; ++n) {
+        if (nuser_vars > nmhd_) {
+          for (int n=nmhd_; n<nuser_vars; ++n) {
             par_for_inner(member, is, ie, [&](const int i) {
               if (flx2_(m,IDN,k,j,i) >= 0.0) {
                 flx2_(m,n,k,j,i) = flx2_(m,IDN,k,j,i)*wl(n,i);
@@ -291,6 +318,7 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
     scr_size = (ScrArray2D<Real>::shmem_size(nvars, ncells1) +
                 ScrArray2D<Real>::shmem_size(3, ncells1)) * 3;
     auto &flx3_ = uflx.x3f;
+    auto &vf3_ = dual_vf.x3f;
     auto &bz_ = b0.x3f;
     auto &e23_ = e2x3;
     auto &e13_ = e1x3;
@@ -345,6 +373,9 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
           default:
             break;
         }
+        if (use_dual_energy_) {
+          FloorDualEnergyFaceStates(member, eos_, dual_idx_, is-1, ie+1, wl_kp1, wr);
+        }
         member.team_barrier();
 
         // compute fluxes over [ks,ke+1].  MHD RS also computes electric fields, where
@@ -358,8 +389,11 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
           auto coord = coord_;
           auto bz = bz_;
           auto flx3 = flx3_;
+          auto vf3 = vf3_;
           auto e23 = e23_;
           auto e13 = e13_;
+          const bool dual_enabled = use_dual_energy_;
+          const int dual_idx = dual_idx_;
           if constexpr (rsolver_method_ == MHD_RSolver::advect) {
             Advect(member,eos,indcs,size,coord,
                     m,k,j,is-1,ie+1,IVZ,wl,wr,bl,br,bz,flx3,e23,e13);
@@ -386,11 +420,16 @@ void MHD::CalculateFluxes(Driver *pdriver, int stage) {
                     m,k,j,is-1,ie+1,IVZ,wl,wr,bl,br,bz,flx3,e23,e13);
           }
           member.team_barrier();
+          if (dual_enabled) {
+            UpwindDualEnergyFlux(member, eos, dual_idx, m, k, j, is-1, ie+1,
+                                 wl, wr, flx3, vf3);
+            member.team_barrier();
+          }
         }
 
         // calculate fluxes of scalars (if any)
-        if (nvars > nmhd_) {
-          for (int n=nmhd_; n<nvars; ++n) {
+        if (nuser_vars > nmhd_) {
+          for (int n=nmhd_; n<nuser_vars; ++n) {
             par_for_inner(member, is, ie, [&](const int i) {
               if (flx3_(m,IDN,k,j,i) >= 0.0) {
                 flx3_(m,n,k,j,i) = flx3_(m,IDN,k,j,i)*wl(n,i);

--- a/src/mhd/mhd_tasks.cpp
+++ b/src/mhd/mhd_tasks.cpp
@@ -50,7 +50,8 @@ void MHD::AssembleMHDTasks(std::map<std::string, std::shared_ptr<TaskList>> tl) 
   id.sendf     = tl["stagen"]->AddTask(&MHD::SendFlux, this, id.flux);
   id.recvf     = tl["stagen"]->AddTask(&MHD::RecvFlux, this, id.sendf);
   id.rkupdt    = tl["stagen"]->AddTask(&MHD::RKUpdate, this, id.recvf);
-  id.srctrms   = tl["stagen"]->AddTask(&MHD::MHDSrcTerms, this, id.rkupdt);
+  id.duale     = tl["stagen"]->AddTask(&MHD::DualEnergyStep, this, id.rkupdt);
+  id.srctrms   = tl["stagen"]->AddTask(&MHD::MHDSrcTerms, this, id.duale);
   id.sendu_oa  = tl["stagen"]->AddTask(&MHD::SendU_OA, this, id.srctrms);
   id.recvu_oa  = tl["stagen"]->AddTask(&MHD::RecvU_OA, this, id.sendu_oa);
   id.restu     = tl["stagen"]->AddTask(&MHD::RestrictU, this, id.recvu_oa);
@@ -106,7 +107,7 @@ TaskStatus MHD::SaveMHDState(Driver *pdrive, int stage) {
 
 TaskStatus MHD::InitRecv(Driver *pdrive, int stage) {
   // post receives for U
-  TaskStatus tstat = pbval_u->InitRecv(nmhd+nscalars);
+  TaskStatus tstat = pbval_u->InitRecv(nvars);
   if (tstat != TaskStatus::complete) return tstat;
   // post receives for B
   tstat = pbval_b->InitRecv(3);
@@ -117,7 +118,7 @@ TaskStatus MHD::InitRecv(Driver *pdrive, int stage) {
   if (stage >= 0) {
     // with SMR/AMR, post receives for fluxes of U
     if (pmy_pack->pmesh->multilevel) {
-      tstat = pbval_u->InitFluxRecv(nmhd+nscalars);
+      tstat = pbval_u->InitFluxRecv(nvars + (use_dual_energy ? 1 : 0));
       if (tstat != TaskStatus::complete) return tstat;
     }
     // post receives for fluxes of B, which are used even with uniform grids
@@ -227,7 +228,7 @@ TaskStatus MHD::SendFlux(Driver *pdrive, int stage) {
   TaskStatus tstat = TaskStatus::complete;
   // Only execute BoundaryValues function with SMR/SMR
   if (pmy_pack->pmesh->multilevel)  {
-    tstat = pbval_u->PackAndSendFluxCC(uflx);
+    tstat = pbval_u->PackAndSendFluxCC(uflx, use_dual_energy ? &dual_vf : nullptr);
   }
   return tstat;
 }
@@ -241,7 +242,7 @@ TaskStatus MHD::RecvFlux(Driver *pdrive, int stage) {
   TaskStatus tstat = TaskStatus::complete;
   // Only execute BoundaryValues function with SMR/SMR
   if (pmy_pack->pmesh->multilevel) {
-    tstat = pbval_u->RecvAndUnpackFluxCC(uflx);
+    tstat = pbval_u->RecvAndUnpackFluxCC(uflx, use_dual_energy ? &dual_vf : nullptr);
   }
   return tstat;
 }
@@ -317,6 +318,7 @@ TaskStatus MHD::RestrictU(Driver *pdrive, int stage) {
   // Only execute Mesh function with SMR/AMR
   if (pmy_pack->pmesh->multilevel) {
     pmy_pack->pmesh->pmr->RestrictCC(u0, coarse_u0);
+    SynchronizeRestrictedDualEnergyField();
   }
   return TaskStatus::complete;
 }
@@ -541,6 +543,7 @@ TaskStatus MHD::ConToPrim(Driver *pdrive, int stage) {
   int n1m1 = indcs.nx1 + 2*ng - 1;
   int n2m1 = (indcs.nx2 > 1)? (indcs.nx2 + 2*ng - 1) : 0;
   int n3m1 = (indcs.nx3 > 1)? (indcs.nx3 + 2*ng - 1) : 0;
+  SynchronizeDualEnergyFieldFromTotal();
   peos->ConsToPrim(u0, b0, w0, bcc0, false, 0, n1m1, 0, n2m1, 0, n3m1);
   return TaskStatus::complete;
 }

--- a/src/mhd/mhd_update.cpp
+++ b/src/mhd/mhd_update.cpp
@@ -34,7 +34,7 @@ TaskStatus MHD::RKUpdate(Driver *pdriver, int stage) {
   Real &gam1 = pdriver->gam1[stage-1];
   Real beta_dt = (pdriver->beta[stage-1])*(pmy_pack->pmesh->dt);
   int nmb1 = pmy_pack->nmb_thispack - 1;
-  int nv1 = nmhd + nscalars - 1;
+  int nv1 = nvars - 1;
   auto u0_ = u0;
   auto u1_ = u1;
   auto flx1 = uflx.x1f;

--- a/src/mhd/rsolvers/dual_eint_mhd.hpp
+++ b/src/mhd/rsolvers/dual_eint_mhd.hpp
@@ -1,0 +1,64 @@
+#ifndef MHD_RSOLVERS_DUAL_EINT_MHD_HPP_
+#define MHD_RSOLVERS_DUAL_EINT_MHD_HPP_
+//========================================================================================
+// AthenaK astrophysical fluid dynamics and numerical relativity code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the AthenaK collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+//! \file dual_eint_mhd.hpp
+//! \brief auxiliary internal-energy flux helper for Newtonian MHD
+
+namespace mhd {
+
+KOKKOS_INLINE_FUNCTION
+Real DualEnergyInternalEnergyFloor(const EOS_Data &eos, const Real dens_in) {
+  const Real dens = fmax(dens_in, eos.dfloor);
+  Real eint_floor = eos.pfloor/(eos.gamma - 1.0);
+  if (eos.tfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.tfloor/(eos.gamma - 1.0));
+  }
+  if (eos.sfloor > 0.0) {
+    eint_floor = fmax(eint_floor, dens*eos.sfloor*pow(dens, eos.gamma - 1.0)/
+                                  (eos.gamma - 1.0));
+  }
+  return eint_floor;
+}
+
+KOKKOS_INLINE_FUNCTION
+void FloorDualEnergyFaceStates(TeamMember_t const &member, const EOS_Data &eos,
+                               const int dual_idx, const int il, const int iu,
+                               ScrArray2D<Real> &wl, ScrArray2D<Real> &wr) {
+  par_for_inner(member, il, iu, [&](const int i) {
+    wl(dual_idx, i) = fmax(wl(dual_idx, i),
+                           DualEnergyInternalEnergyFloor(eos, wl(IDN, i)));
+    wr(dual_idx, i) = fmax(wr(dual_idx, i),
+                           DualEnergyInternalEnergyFloor(eos, wr(IDN, i)));
+  });
+}
+
+KOKKOS_INLINE_FUNCTION
+void UpwindDualEnergyFlux(TeamMember_t const &member, const EOS_Data &eos,
+                          const int dual_idx, const int m, const int k, const int j,
+                          const int il, const int iu, const ScrArray2D<Real> &wl,
+                          const ScrArray2D<Real> &wr, DvceArray5D<Real> flx,
+                          DvceArray5D<Real> vf) {
+  par_for_inner(member, il, iu, [&](const int i) {
+    const Real mass_flux = flx(m, IDN, k, j, i);
+    if (mass_flux > 0.0) {
+      const Real dens = fmax(wl(IDN, i), eos.dfloor);
+      flx(m, dual_idx, k, j, i) = mass_flux*(wl(dual_idx, i)/dens);
+      vf(m, 0, k, j, i) = mass_flux/dens;
+    } else if (mass_flux < 0.0) {
+      const Real dens = fmax(wr(IDN, i), eos.dfloor);
+      flx(m, dual_idx, k, j, i) = mass_flux*(wr(dual_idx, i)/dens);
+      vf(m, 0, k, j, i) = mass_flux/dens;
+    } else {
+      flx(m, dual_idx, k, j, i) = 0.0;
+      vf(m, 0, k, j, i) = 0.0;
+    }
+  });
+}
+
+} // namespace mhd
+
+#endif // MHD_RSOLVERS_DUAL_EINT_MHD_HPP_

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -68,10 +68,10 @@ void RestartOutput::LoadOutputData(Mesh *pm) {
   TurbulenceDriver* pturb=pm->pmb_pack->pturb;
   int nhydro=0, nmhd=0, nrad=0, nforce=3, nadm=0, nz4c=0;
   if (phydro != nullptr) {
-    nhydro = phydro->nhydro + phydro->nscalars;
+    nhydro = phydro->nvars;
   }
   if (pmhd != nullptr) {
-    nmhd = pmhd->nmhd + pmhd->nscalars;
+    nmhd = pmhd->nvars;
   }
   if (pz4c != nullptr) {
     nz4c = pz4c->nz4c;
@@ -150,10 +150,10 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
   adm::ADM* padm = pm->pmb_pack->padm;
   int nhydro=0, nmhd=0, nrad=0, nforce=3, nz4c=0, nadm=0, nco=0;
   if (phydro != nullptr) {
-    nhydro = phydro->nhydro + phydro->nscalars;
+    nhydro = phydro->nvars;
   }
   if (pmhd != nullptr) {
-    nmhd = pmhd->nmhd + pmhd->nscalars;
+    nmhd = pmhd->nvars;
   }
   if (prad != nullptr) {
     nrad = prad->prgeo->nangles;

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -118,10 +118,10 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   TurbulenceDriver* pturb=pm->pmb_pack->pturb;
   int nrad = 0, nhydro = 0, nmhd = 0, nforce = 3, nadm = 0, nz4c = 0;
   if (phydro != nullptr) {
-    nhydro = phydro->nhydro + phydro->nscalars;
+    nhydro = phydro->nvars;
   }
   if (pmhd != nullptr) {
-    nmhd = pmhd->nmhd + pmhd->nscalars;
+    nmhd = pmhd->nvars;
   }
   if (prad != nullptr) {
     nrad = prad->prgeo->nangles;
@@ -247,6 +247,64 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
     data_size_ += nout1*nout2*nout3*nadm*sizeof(Real);   // adm u_adm
   }
 
+  int nhydro_file = nhydro;
+  int nmhd_file = nmhd;
+  bool hydro_restart_missing_dual = false;
+  bool hydro_restart_extra_dual = false;
+  bool mhd_restart_missing_dual = false;
+  bool mhd_restart_extra_dual = false;
+
+  if (data_size_ != data_size) {
+    const IOWrapperSizeT cc_cell_bytes = nout1*nout2*nout3*sizeof(Real);
+    IOWrapperSizeT fixed_data_size = data_size_;
+    if (phydro != nullptr) fixed_data_size -= cc_cell_bytes*nhydro;
+    if (pmhd != nullptr) fixed_data_size -= cc_cell_bytes*nmhd;
+
+    int hydro_file_options[2] = {nhydro, nhydro};
+    int nhydro_options = 1;
+    if (phydro != nullptr && phydro->use_dual_energy && phydro->naux == 1) {
+      hydro_file_options[1] = nhydro - 1;
+      nhydro_options = 2;
+    } else if (phydro != nullptr && !(phydro->use_dual_energy)) {
+      hydro_file_options[1] = nhydro + 1;
+      nhydro_options = 2;
+    }
+
+    int mhd_file_options[2] = {nmhd, nmhd};
+    int nmhd_options = 1;
+    if (pmhd != nullptr && pmhd->use_dual_energy && pmhd->naux == 1) {
+      mhd_file_options[1] = nmhd - 1;
+      nmhd_options = 2;
+    } else if (pmhd != nullptr && !(pmhd->use_dual_energy)) {
+      mhd_file_options[1] = nmhd + 1;
+      nmhd_options = 2;
+    }
+
+    bool matched_restart_layout = false;
+    for (int ih = 0; ih < nhydro_options && !matched_restart_layout; ++ih) {
+      for (int im = 0; im < nmhd_options && !matched_restart_layout; ++im) {
+        const int nhydro_candidate = (phydro != nullptr) ? hydro_file_options[ih] : 0;
+        const int nmhd_candidate = (pmhd != nullptr) ? mhd_file_options[im] : 0;
+        const IOWrapperSizeT candidate_size =
+            fixed_data_size + cc_cell_bytes*(nhydro_candidate + nmhd_candidate);
+        if (candidate_size != data_size) continue;
+
+        nhydro_file = nhydro_candidate;
+        nmhd_file = nmhd_candidate;
+        hydro_restart_missing_dual =
+            (phydro != nullptr) && phydro->use_dual_energy && (nhydro_file < nhydro);
+        hydro_restart_extra_dual =
+            (phydro != nullptr) && !(phydro->use_dual_energy) && (nhydro_file > nhydro);
+        mhd_restart_missing_dual =
+            (pmhd != nullptr) && pmhd->use_dual_energy && (nmhd_file < nmhd);
+        mhd_restart_extra_dual =
+            (pmhd != nullptr) && !(pmhd->use_dual_energy) && (nmhd_file > nmhd);
+        data_size_ = candidate_size;
+        matched_restart_layout = true;
+      }
+    }
+  }
+
   if (data_size_ != data_size) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
               << std::endl << "CC data size read from restart file not equal to size "
@@ -254,9 +312,28 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
               << std::endl;
     exit(EXIT_FAILURE);
   }
+  if (global_variable::my_rank == 0 || single_file_per_rank) {
+    if (hydro_restart_missing_dual) {
+      std::cout << "Restart has no hydro dual-energy auxiliary data. "
+                << "Initializing it from the restarted conserved energy." << std::endl;
+    }
+    if (hydro_restart_extra_dual) {
+      std::cout << "Restart contains hydro dual-energy auxiliary data, but "
+                << "<hydro>/dual_energy = false. Ignoring restart auxiliary field."
+                << std::endl;
+    }
+    if (mhd_restart_missing_dual) {
+      std::cout << "Restart has no MHD dual-energy auxiliary data. "
+                << "Initializing it from the restarted conserved energy." << std::endl;
+    }
+    if (mhd_restart_extra_dual) {
+      std::cout << "Restart contains MHD dual-energy auxiliary data, but "
+                << "<mhd>/dual_energy = false. Ignoring restart auxiliary field."
+                << std::endl;
+    }
+  }
 
   // read CC data into host array
-  int mygids = pm->gids_eachrank[global_variable::my_rank];
   IOWrapperSizeT offset_myrank = headeroffset;
   if (!single_file_per_rank) {
     offset_myrank += data_size_ * pm->gids_eachrank[global_variable::my_rank];
@@ -275,7 +352,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   }
 
   if (phydro != nullptr) {
-    Kokkos::realloc(ccin, nmb, nhydro, nout3, nout2, nout1);
+    Kokkos::realloc(ccin, nmb, nhydro_file, nout3, nout2, nout1);
     for (int m=0;  m<noutmbs_max; ++m) {
       // every rank has a MB to read, so read collectively
       if (m < noutmbs_min) {
@@ -308,14 +385,33 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         myoffset += data_size;
       }
     }
-    Kokkos::deep_copy(Kokkos::subview(phydro->u0, std::make_pair(0,nmb), Kokkos::ALL,
-                      Kokkos::ALL, Kokkos::ALL, Kokkos::ALL), ccin);
-    offset_myrank += nout1*nout2*nout3*nhydro*sizeof(Real); // hydro u0
+    if (nhydro_file == nhydro) {
+      Kokkos::deep_copy(Kokkos::subview(phydro->u0, std::make_pair(0,nmb), Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL), ccin);
+    } else {
+      HostArray5D<Real> ccfull("rst-hydro-full", nmb, nhydro, nout3, nout2, nout1);
+      Kokkos::deep_copy(ccfull, 0.0);
+      const int nhydro_copy = std::min(nhydro, nhydro_file);
+      for (int m=0; m<nmb; ++m) {
+        for (int n=0; n<nhydro_copy; ++n) {
+          for (int k=0; k<nout3; ++k) {
+            for (int j=0; j<nout2; ++j) {
+              for (int i=0; i<nout1; ++i) {
+                ccfull(m,n,k,j,i) = ccin(m,n,k,j,i);
+              }
+            }
+          }
+        }
+      }
+      Kokkos::deep_copy(Kokkos::subview(phydro->u0, std::make_pair(0,nmb), Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL), ccfull);
+    }
+    offset_myrank += nout1*nout2*nout3*nhydro_file*sizeof(Real); // hydro u0
     myoffset = offset_myrank;
   }
 
   if (pmhd != nullptr) {
-    Kokkos::realloc(ccin, nmb, nmhd, nout3, nout2, nout1);
+    Kokkos::realloc(ccin, nmb, nmhd_file, nout3, nout2, nout1);
     for (int m=0;  m<noutmbs_max; ++m) {
       // every rank has a MB to read, so read collectively
       if (m < noutmbs_min) {
@@ -347,9 +443,28 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         myoffset += data_size;
       }
     }
-    Kokkos::deep_copy(Kokkos::subview(pmhd->u0, std::make_pair(0,nmb), Kokkos::ALL,
-                      Kokkos::ALL, Kokkos::ALL, Kokkos::ALL), ccin);
-    offset_myrank += nout1*nout2*nout3*nmhd*sizeof(Real);   // mhd u0
+    if (nmhd_file == nmhd) {
+      Kokkos::deep_copy(Kokkos::subview(pmhd->u0, std::make_pair(0,nmb), Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL), ccin);
+    } else {
+      HostArray5D<Real> ccfull("rst-mhd-full", nmb, nmhd, nout3, nout2, nout1);
+      Kokkos::deep_copy(ccfull, 0.0);
+      const int nmhd_copy = std::min(nmhd, nmhd_file);
+      for (int m=0; m<nmb; ++m) {
+        for (int n=0; n<nmhd_copy; ++n) {
+          for (int k=0; k<nout3; ++k) {
+            for (int j=0; j<nout2; ++j) {
+              for (int i=0; i<nout1; ++i) {
+                ccfull(m,n,k,j,i) = ccin(m,n,k,j,i);
+              }
+            }
+          }
+        }
+      }
+      Kokkos::deep_copy(Kokkos::subview(pmhd->u0, std::make_pair(0,nmb), Kokkos::ALL,
+                        Kokkos::ALL, Kokkos::ALL, Kokkos::ALL), ccfull);
+    }
+    offset_myrank += nout1*nout2*nout3*nmhd_file*sizeof(Real);   // mhd u0
     myoffset = offset_myrank;
 
     Kokkos::realloc(fcin.x1f, nmb, nout3, nout2, nout1+1);
@@ -618,6 +733,12 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   // call problem generator again to re-initialize data, fn ptrs, as needed
   // second argument true since this IS a restart
   CallProblemGenerator(pin, true);
+  if (phydro != nullptr && phydro->use_dual_energy && !hydro_restart_missing_dual) {
+    phydro->dual_energy_needs_init = false;
+  }
+  if (pmhd != nullptr && pmhd->use_dual_energy && !mhd_restart_missing_dual) {
+    pmhd->dual_energy_needs_init = false;
+  }
 
   // Check that user defined BCs were enrolled if needed
   if (user_bcs) {

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -733,11 +733,11 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   // call problem generator again to re-initialize data, fn ptrs, as needed
   // second argument true since this IS a restart
   CallProblemGenerator(pin, true);
-  if (phydro != nullptr && phydro->use_dual_energy && !hydro_restart_missing_dual) {
-    phydro->dual_energy_needs_init = false;
+  if (phydro != nullptr && phydro->use_dual_energy) {
+    phydro->dual_energy_needs_init = hydro_restart_missing_dual;
   }
-  if (pmhd != nullptr && pmhd->use_dual_energy && !mhd_restart_missing_dual) {
-    pmhd->dual_energy_needs_init = false;
+  if (pmhd != nullptr && pmhd->use_dual_energy) {
+    pmhd->dual_energy_needs_init = mhd_restart_missing_dual;
   }
 
   // Check that user defined BCs were enrolled if needed


### PR DESCRIPTION
This PR adds optional Newtonian dual-energy support for Newtonian ideal-gas Hydro and MHD.

  - Adds a hidden auxiliary internal-energy density field for Hydro/MHD.
  - Advects the auxiliary field with the Riemann-solver mass flux.
  - Applies the gamma-law compressional update using the face-velocity divergence.
  - Uses eta1/eta2 switches to choose between conservative total energy and auxiliary internal energy.
  - Supports AMR migration, flux correction, and restart compatibility.
  - Keeps the auxiliary field out of normal passive-scalar output.

  Input parameters:
  - <hydro>/dual_energy
  - <hydro>/dual_energy_eta1
  - <hydro>/dual_energy_eta2
  - <mhd>/dual_energy
  - <mhd>/dual_energy_eta1
  - <mhd>/dual_energy_eta2

  Current limitations:
  - Newtonian ideal-gas Hydro/MHD only.
  - Not enabled with isothermal EOS, SR/GR, source terms, viscosity, conduction, resistivity, shearing box, or FOFC.

  Validation:
  - Targeted high-Mach C2P cancellation test:
    - without dual energy, internal energy falls to the floor;
    - with dual energy, the expected internal energy is recovered.
  - Hydro and MHD blast smoke tests.
  - Hydro and MHD AMR tests.
  - Restart compatibility:
    - dual -> dual
    - dual -> non-dual
    - legacy non-dual -> dual