### PR TITLE
Fix derived temperature output

### DIFF
--- a/src/outputs/derived_variables.cpp
+++ b/src/outputs/derived_variables.cpp
@@ -99,11 +99,11 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
     if (derived_var.extent(4) <= 1)
       Kokkos::realloc(derived_var, nmb_alloc, n_dv, n3, n2, n1);
     auto dv = derived_var;
-    auto &w0_ = (name.compare("hydro_wz") == 0)?
+    auto &w0_ = (pm->pmb_pack->phydro != nullptr)?
       pm->pmb_pack->phydro->w0 : pm->pmb_pack->pmhd->w0;
     par_for("temperature", DevExeSpace(), 0, (nmb-1), ks, ke, js, je, is, ie,
     KOKKOS_LAMBDA(int m, int k, int j, int i) {
-      dv(m,i_dv,k,j,i) = (w0_(m,IEN,k,j,i+1) / w0_(m,IDN,k,j,i-1));
+      dv(m,i_dv,k,j,i) = w0_(m,IPR,k,j,i) / w0_(m,IDN,k,j,i);
     });
     i_dv += 1; // increment derived variable index
   }


### PR DESCRIPTION
This fixes the derived `temperature` output.

The previous implementation computed:

pressure(i+1) / density(i-1)

which is inconsistent with the comment temperature = pressure / density and can introduce ghost-zone or meshblock-boundary artifacts.

This PR changes the derived temperature calculation to use same-cell pressure and density:

pressure(i) / density(i)

It also selects the hydro or MHD primitive array based on which pack is available, rather than checking an unrelated derived-variable name.