### PR TITLE
Hotfix/walls+bugs

### DIFF
--- a/src/athena.hpp
+++ b/src/athena.hpp
@@ -152,6 +152,7 @@ using ScrArray2D = Kokkos::View<T **, LayoutWrapper, ScratchMemSpace,
 
 //----------------------------------------------------------------------------------------
 // struct for storing face-centered (area-averaged) variables, e.g. magnetic field
+/* [using old C-style comments to prevent multi-line-comment warning with -Wall]
 //                 ___________
 //                 |x3f[k+1,j,i]
 //                 | \    X    \
@@ -161,6 +162,7 @@ using ScrArray2D = Kokkos::View<T **, LayoutWrapper, ScratchMemSpace,
 //   x2 x3          \  |    X    |
 //    \ |            \ |         |
 //     \|__x1         \|_________|
+*/
 
 template <typename T>
 struct DvceFaceFld4D {
@@ -194,6 +196,7 @@ struct HostFaceFld4D {
 
 //----------------------------------------------------------------------------------------
 // struct for storing edge-centered (line-averaged) variables, e.g. EMF
+/* [using old C-style comments to prevent multi-line-comment warning with -Wall]
 //             _____________
 //             |\           \
 //             | \           \
@@ -204,6 +207,7 @@ struct HostFaceFld4D {
 //               \ |           |
 //                \|_____*_____|
 //                    x1e[k,j,i]
+*/
 
 template <typename T>
 struct DvceEdgeFld4D {

--- a/src/athena_tensor.hpp
+++ b/src/athena_tensor.hpp
@@ -526,10 +526,10 @@ class AthenaPointTensor<T, sym, ndim, 4> {
         Kokkos::kokkos_swap(c, d);
       }
       return data_[(b*( 2*ndim - b +1)/2 + a - b)*ndof2_ + d*( 2*ndim - d +1)/2 + c - d];
-    } else {                                                                      
-      static_assert(AthenaPointTensor<T, sym, ndim, 4>::allowed_sym,              
-                    "Undefined symmetry for rank-4 AthenaPointTensor.");          
-      return data_[0];  
+    } else {
+      static_assert(AthenaPointTensor<T, sym, ndim, 4>::allowed_sym,
+                    "Undefined symmetry for rank-4 AthenaPointTensor.");
+      return data_[0];
     }
   }
 
@@ -547,10 +547,10 @@ class AthenaPointTensor<T, sym, ndim, 4> {
         Kokkos::kokkos_swap(c, d);
       }
       return data_[(b*( 2*ndim - b +1)/2 + a - b)*ndof2_ + d*( 2*ndim - d +1)/2 + c - d];
-    } else {                                                                      
-      static_assert(AthenaPointTensor<T, sym, ndim, 4>::allowed_sym,              
-                    "Undefined symmetry for rank-4 AthenaPointTensor.");          
-      return data_[0]; 
+    } else {
+      static_assert(AthenaPointTensor<T, sym, ndim, 4>::allowed_sym,
+                    "Undefined symmetry for rank-4 AthenaPointTensor.");
+      return data_[0];
     }
   }
 
@@ -564,7 +564,7 @@ class AthenaPointTensor<T, sym, ndim, 4> {
  private:
   Real data_[TensorDOF<sym,ndim,4>];
   int ndof_;
-  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||                 
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||
                                        sym == TensorSymm::SYM22);
 };
 
@@ -665,10 +665,10 @@ class AthenaScratchTensor<T, sym, ndim, 2> {
         Kokkos::kokkos_swap(a, b);
       }
       return data_(b*( 2*ndim - b +1)/2 + a - b, i);
-    } else {                                                                      
-      static_assert(AthenaScratchTensor<T, sym, ndim, 2>::allowed_sym,            
-                    "Undefined symmetry for rank-2 AthenaScratchTensor.");        
-      return data_[0]; 
+    } else {
+      static_assert(AthenaScratchTensor<T, sym, ndim, 2>::allowed_sym,
+                    "Undefined symmetry for rank-2 AthenaScratchTensor.");
+      return data_[0];
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -683,8 +683,8 @@ class AthenaScratchTensor<T, sym, ndim, 2> {
  private:
   ScrArray2D<T> data_;
   int ndof_;
-  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||                 
-                                       sym == TensorSymm::SYM2); 
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||
+                                       sym == TensorSymm::SYM2);
 };
 
 //----------------------------------------------------------------------------------------
@@ -725,9 +725,9 @@ class AthenaScratchTensor<T, sym, ndim, 3> {
         Kokkos::kokkos_swap(a, b);
       }
       return data_((b*(2*ndim - b +1)/2 + a - b)*ndim + c,i);
-    } else {                                                                      
-      static_assert(AthenaScratchTensor<T, sym, ndim, 3>::allowed_sym,            
-                    "Undefined symmetry for rank-3 AthenaScratchTensor.");        
+    } else {
+      static_assert(AthenaScratchTensor<T, sym, ndim, 3>::allowed_sym,
+                    "Undefined symmetry for rank-3 AthenaScratchTensor.");
       return data_[0];
     }
   }
@@ -743,7 +743,7 @@ class AthenaScratchTensor<T, sym, ndim, 3> {
  private:
   ScrArray2D<T> data_;
   int ndof_;
-  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||                 
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||
                                 sym == TensorSymm::SYM2 || sym == TensorSymm::ISYM2);
 };
 

--- a/src/athena_tensor.hpp
+++ b/src/athena_tensor.hpp
@@ -10,6 +10,7 @@
 //
 //  Convention: indices a,b,c,d are tensor indices. Indices n,i,j,k are grid indices.
 
+#include <type_traits>
 #include <cassert> // assert
 #include <utility>
 #include "athena.hpp"
@@ -379,6 +380,10 @@ class AthenaPointTensor<T, sym, ndim, 2> {
       } else {
         return data_[a*(2*ndim - a + 1)/2+b-a];
       }
+    } else {
+      static_assert(AthenaPointTensor<T, sym, ndim, 2>::allowed_sym,
+                    "Undefined symmetry for rank-2 AthenaPointTensor.");
+      return data_[0];
     }
     //return data_[idxmap_[a][b]];
   }
@@ -392,6 +397,10 @@ class AthenaPointTensor<T, sym, ndim, 2> {
       } else {
         return data_[a*(2*ndim - a + 1)/2+b-a];
       }
+    } else {
+      static_assert(AthenaPointTensor<T, sym, ndim, 2>::allowed_sym,
+                    "Undefined symmetry for rank-2 AthenaPointTensor.");
+      return data_[0];
     }
     //return data_[idxmap_[a][b]];
   }
@@ -404,6 +413,8 @@ class AthenaPointTensor<T, sym, ndim, 2> {
 
  private:
   Real data_[TensorDOF<sym, ndim, 2>]; // NOLINT
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||
+                                       sym == TensorSymm::SYM2);
 };
 
 //----------------------------------------------------------------------------------------
@@ -436,6 +447,10 @@ class AthenaPointTensor<T, sym, ndim, 3> {
       } else {
         return data_[c + ndim*(a*(2*ndim - a + 1)/2 + b - a)];
       }
+    } else {
+      static_assert(AthenaPointTensor<T, sym, ndim, 3>::allowed_sym,
+                    "Undefined symmetry for rank-3 AthenaPointTensor.");
+      return data_[0];
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -455,6 +470,10 @@ class AthenaPointTensor<T, sym, ndim, 3> {
       } else {
         return data_[c + ndim*(a*(2*ndim - a + 1)/2 + b - a)];
       }
+    } else {
+      static_assert(AthenaPointTensor<T, sym, ndim, 3>::allowed_sym,
+                    "Undefined symmetry for rank-3 AthenaPointTensor.");
+      return data_[0];
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -466,6 +485,9 @@ class AthenaPointTensor<T, sym, ndim, 3> {
 
  private:
   Real data_[TensorDOF<sym,ndim,3>];
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||
+                                       sym == TensorSymm::SYM2 ||
+                                       sym == TensorSymm::ISYM2);
 };
 
 //----------------------------------------------------------------------------------------
@@ -504,6 +526,10 @@ class AthenaPointTensor<T, sym, ndim, 4> {
         Kokkos::kokkos_swap(c, d);
       }
       return data_[(b*( 2*ndim - b +1)/2 + a - b)*ndof2_ + d*( 2*ndim - d +1)/2 + c - d];
+    } else {                                                                      
+      static_assert(AthenaPointTensor<T, sym, ndim, 4>::allowed_sym,              
+                    "Undefined symmetry for rank-4 AthenaPointTensor.");          
+      return data_[0];  
     }
   }
 
@@ -521,6 +547,10 @@ class AthenaPointTensor<T, sym, ndim, 4> {
         Kokkos::kokkos_swap(c, d);
       }
       return data_[(b*( 2*ndim - b +1)/2 + a - b)*ndof2_ + d*( 2*ndim - d +1)/2 + c - d];
+    } else {                                                                      
+      static_assert(AthenaPointTensor<T, sym, ndim, 4>::allowed_sym,              
+                    "Undefined symmetry for rank-4 AthenaPointTensor.");          
+      return data_[0]; 
     }
   }
 
@@ -534,6 +564,8 @@ class AthenaPointTensor<T, sym, ndim, 4> {
  private:
   Real data_[TensorDOF<sym,ndim,4>];
   int ndof_;
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||                 
+                                       sym == TensorSymm::SYM22);
 };
 
 // Here tensors are defined as static 1D arrays, with compile-time dimension calculated as
@@ -628,11 +660,15 @@ class AthenaScratchTensor<T, sym, ndim, 2> {
   decltype(auto) operator()(int a, int b, int i) const {
     if constexpr (sym == TensorSymm::NONE) {
       return data_(ndim * a + b, i);
-    } else {
+    } else if (sym == TensorSymm::SYM2) {
       if (a < b) {
         Kokkos::kokkos_swap(a, b);
       }
       return data_(b*( 2*ndim - b +1)/2 + a - b, i);
+    } else {                                                                      
+      static_assert(AthenaScratchTensor<T, sym, ndim, 2>::allowed_sym,            
+                    "Undefined symmetry for rank-2 AthenaScratchTensor.");        
+      return data_[0]; 
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -647,6 +683,8 @@ class AthenaScratchTensor<T, sym, ndim, 2> {
  private:
   ScrArray2D<T> data_;
   int ndof_;
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||                 
+                                       sym == TensorSymm::SYM2); 
 };
 
 //----------------------------------------------------------------------------------------
@@ -687,6 +725,10 @@ class AthenaScratchTensor<T, sym, ndim, 3> {
         Kokkos::kokkos_swap(a, b);
       }
       return data_((b*(2*ndim - b +1)/2 + a - b)*ndim + c,i);
+    } else {                                                                      
+      static_assert(AthenaScratchTensor<T, sym, ndim, 3>::allowed_sym,            
+                    "Undefined symmetry for rank-3 AthenaScratchTensor.");        
+      return data_[0];
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -701,6 +743,8 @@ class AthenaScratchTensor<T, sym, ndim, 3> {
  private:
   ScrArray2D<T> data_;
   int ndof_;
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||                 
+                                sym == TensorSymm::SYM2 || sym == TensorSymm::ISYM2);
 };
 
 //----------------------------------------------------------------------------------------
@@ -740,6 +784,10 @@ class AthenaScratchTensor<T, sym, ndim, 4> {
       }
       return data_((b*( 2*ndim - b +1)/2 + a - b)*(ndim + 1)*ndim/2 +
                     d*( 2*ndim - d +1)/2 + c - d,i);
+    } else {
+      static_assert(AthenaScratchTensor<T, sym, ndim, 4>::allowed_sym,
+                    "Undefined symmetry for rank-4 AthenaScratchTensor.");
+      return data_[0];
     }
   }
 
@@ -755,6 +803,8 @@ class AthenaScratchTensor<T, sym, ndim, 4> {
  private:
   ScrArray2D<T> data_;
   int ndof_;
+  static constexpr bool allowed_sym = (sym == TensorSymm::NONE ||
+                                       sym == TensorSymm::SYM22);
 };
 
 #endif // ATHENA_TENSOR_HPP_

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -245,9 +245,6 @@ particles::ParticlesBoundaryValues::ParticlesBoundaryValues(
 #endif
     pmy_part(pp) {
 #if MPI_PARALLEL_ENABLED
-  // Guess that no more than 10% of particles will be communicated to set size of buffer
-  int npart = pmy_part->nprtcl_thispack;
-
   //resize vectors over number of ranks
   nsends_eachrank.resize(global_variable::nranks);
 

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -24,11 +24,11 @@
 // MeshBoundaryValues constructor:
 
 MeshBoundaryValues::MeshBoundaryValues(MeshBlockPack *pp, ParameterInput *pin, bool z4c) :
-  pmy_pack(pp),
-  is_z4c_(z4c),
   u_in("uin",1,1),
   b_in("bin",1,1),
-  i_in("iin",1,1) {
+  i_in("iin",1,1),
+  pmy_pack(pp),
+  is_z4c_(z4c) {
   // allocate vector of status flags and MPI requests (if needed)
   int nnghbr = pmy_pack->pmb->nnghbr;
 

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -39,7 +39,7 @@ class Particles;
 //! \brief calculate an MPI tag for boundary buffer communications.  Note maximum size of
 //! lid that can be encoded is set by (NUM_BITS_LID) macro defined in athena.hpp.
 //! The convention in AthenaK is lid and bufid are both for the *receiving* process.
-static int CreateBvals_MPI_Tag(int lid, int bufid) {
+inline int CreateBvals_MPI_Tag(int lid, int bufid) {
   return (bufid << (NUM_BITS_LID)) | lid;
 }
 

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -109,7 +109,7 @@ class MeshBlockPack;
 class MeshBoundaryValues {
  public:
   MeshBoundaryValues(MeshBlockPack *ppack, ParameterInput *pin, bool z4c);
-  ~MeshBoundaryValues();
+  virtual ~MeshBoundaryValues();
 
   // data for all 56 buffers in most general 3D case. Not all elements used in most cases.
   // However each MeshBoundaryBuffer is lightweight, so the convenience of fixed array

--- a/src/bvals/flux_correct_fc.cpp
+++ b/src/bvals/flux_correct_fc.cpp
@@ -65,7 +65,7 @@ TaskStatus MeshBoundaryValuesFC::PackAndSendFluxFC(DvceEdgeFld4D<Real> &flx) {
         ku = sbuf[n].iflux_coar[v].bke;
         ndat = sbuf[n].iflxc_ndat;
       // if neighbor is at same level, use sindices to pack buffer
-      } else if (nghbr.d_view(m,n).lev == mblev.d_view(m)) {
+      } else {
         il = sbuf[n].iflux_same[v].bis;
         iu = sbuf[n].iflux_same[v].bie;
         jl = sbuf[n].iflux_same[v].bjs;

--- a/src/coordinates/adm.cpp
+++ b/src/coordinates/adm.cpp
@@ -27,8 +27,8 @@ char const * const ADM::ADM_names[ADM::nadm] = {
 //----------------------------------------------------------------------------------------
 // constructor: initializes data structures and parameters
 ADM::ADM(MeshBlockPack *ppack, ParameterInput *pin):
-    SetADMVariables(&ADM::SetADMVariablesToKerrSchild),
     u_adm("u_adm",1,1,1,1,1),
+    SetADMVariables(&ADM::SetADMVariablesToKerrSchild),
     pmy_pack(ppack) {
   is_dynamic = pin->GetOrAddBoolean("adm" , "dynamic", false);
 

--- a/src/coordinates/cartesian_ks.hpp
+++ b/src/coordinates/cartesian_ks.hpp
@@ -158,9 +158,9 @@ void ComputeADMDecomposition(Real x, Real y, Real z, bool minkowski, Real a,
              *gxx, *gxy, *gxz, *gyy, *gyz, *gzz,
              &uxx, &uxy, &uxz, &uyy, &uyz, &uzz);
   Real const g_uu[3][3] = {
-    uxx, uxy, uxz,
-    uxy, uyy, uyz,
-    uxz, uyz, uzz
+    {uxx, uxy, uxz},
+    {uxy, uyy, uyz},
+    {uxz, uyz, uzz}
   };
 
   //
@@ -190,7 +190,7 @@ void ComputeADMDecomposition(Real x, Real y, Real z, bool minkowski, Real a,
     - SQR(z)/(SQR(r)*r) * ( qb )/( qa ) + 1.0/r},
   };
 
-  Real dg_ddd[3][3][3] = {0.0};
+  Real dg_ddd[3][3][3] = {};
   for (int i = 0; i < 3; i++)
   for (int a = 0; a < 3; a++)
   for (int b = 0; b < 3; b++) {

--- a/src/coordinates/coordinates.cpp
+++ b/src/coordinates/coordinates.cpp
@@ -23,9 +23,9 @@
 // constructor, initializes coordinates data
 
 Coordinates::Coordinates(ParameterInput *pin, MeshBlockPack *ppack) :
-    pmy_pack(ppack),
     excision_floor("excision_floor",1,1,1,1),
-    excision_flux("excision_flux",1,1,1,1) {
+    excision_flux("excision_flux",1,1,1,1),
+    pmy_pack(ppack) {
   // Check for relativistic dynamics
   // WGC: idea for handling new EOS
   is_dynamical_relativistic = (pin->DoesBlockExist("adm") || pin->DoesBlockExist("z4c"))

--- a/src/coordinates/excision.cpp
+++ b/src/coordinates/excision.cpp
@@ -59,12 +59,6 @@ void Coordinates::SetExcisionMasks(DvceArray4D<bool> &excision_floor,
     Real &x3min = size.d_view(m).x3min;
     Real &x3max = size.d_view(m).x3max;
 
-    // We calculate the distance to the corner to make sure that only cells completely
-    // inside the horizon are excised.
-    Real &dx1 = size.d_view(m).dx1;
-    Real &dx2 = size.d_view(m).dx2;
-    Real &dx3 = size.d_view(m).dx3;
-
     Real x1v   = CellCenterX(i  -is, indcs.nx1, x1min, x1max);
     Real x1vm1 = CellCenterX(i-1-is, indcs.nx1, x1min, x1max);
     Real x1vp1 = CellCenterX(i+1-is, indcs.nx1, x1min, x1max);

--- a/src/diffusion/current_density.hpp
+++ b/src/diffusion/current_density.hpp
@@ -15,6 +15,7 @@
 //! \fn CurrentDensity()
 //  \brief Calculates the three components of the current density at cell edges
 //  Each component of J is centered identically to the edge-electric-field
+/* [using old C-style comments to prevent multi-line-comment warning with -Wall]
 //               _____________
 //               |\           \
 //               | \           \
@@ -25,6 +26,7 @@
 //   x2 x3         \ |           |
 //    \ |           \|_____*_____|
 //     \|__x1             J1
+*/
 
 KOKKOS_INLINE_FUNCTION
 void CurrentDensity(TeamMember_t const &member, const int m, const int k, const int j,

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -56,15 +56,15 @@
 // "timestep" = "cycle" in explicit, multistage methods.
 
 Driver::Driver(ParameterInput *pin, Mesh *pmesh, Real wtlim, Kokkos::Timer* ptimer) :
+  impl_src("ru",1,1,1,1,1,1),
   tlim(-1.0),
   nlim(-1),
   ndiag(1),
-  nmb_updated_(0),
-  npart_updated_(0),
-  lb_efficiency_(0),
   pwall_clock_(ptimer),
   wall_time(wtlim),
-  impl_src("ru",1,1,1,1,1,1) {
+  nmb_updated_(0),
+  npart_updated_(0),
+  lb_efficiency_(0) {
   // set time-evolution option (no default)
   {
     std::string evolution_t = pin->GetString("time","evolution");

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -234,8 +234,8 @@ Driver::Driver(ParameterInput *pin, Mesh *pmesh, Real wtlim, Kokkos::Timer* ptim
       nimp_stages = 4;
       nexp_stages = 3;
       cfl_limit = 1.0;
-      gam0[0] = 0.0;
-      gam1[0] = 1.0;
+      gam0[0] = 1.0;
+      gam1[0] = 0.0;
       beta[0] = 1.0;
 
       gam0[1] = 0.25;

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -544,7 +544,7 @@ void Driver::OutputCycleDiagnostics(Mesh *pm) {
 //! slightly below the wall clock time while others determine that it's time to quit.
 
 Real Driver::UpdateWallClock() {
-  Real tnow;
+  Real tnow = 0.0;
   if (global_variable::my_rank == 0) {
     tnow = pwall_clock_->seconds();
   }

--- a/src/dyn_grmhd/dyn_grmhd.cpp
+++ b/src/dyn_grmhd/dyn_grmhd.cpp
@@ -564,13 +564,13 @@ void DynGRMHDPS<EOSPolicy, ErrorPolicy>::AddCoordTermsEOS(const DvceArray5D<Real
     for (int a = 0; a < ndim; a++) {
       dalpha_d[a] = Dx<NGHOST>(a, idx, adm.alpha, m, k, j, i);
     }
-    Real dbeta_du[3][3] = {0.};
+    Real dbeta_du[3][3] = {};
     for (int a = 0; a < 3; a++) {
       for (int b = 0; b < ndim; b++) {
         dbeta_du[b][a] = Dx<NGHOST>(b, idx, adm.beta_u, m, a, k, j, i);
       }
     }
-    Real dg_ddd[3][3][3] = {0.};
+    Real dg_ddd[3][3][3] = {};
     for (int a = 0; a < 3; ++a) {
       for (int b = 0; b < 3; ++b) {
         for (int c = 0; c < ndim; ++c) {

--- a/src/dyn_grmhd/dyn_grmhd.cpp
+++ b/src/dyn_grmhd/dyn_grmhd.cpp
@@ -549,8 +549,6 @@ void DynGRMHDPS<EOSPolicy, ErrorPolicy>::AddCoordTermsEOS(const DvceArray5D<Real
                            adm.g_dd(m,0,2,k,j,i), adm.g_dd(m,1,1,k,j,i),
                            adm.g_dd(m,1,2,k,j,i), adm.g_dd(m,2,2,k,j,i)};
     const Real& alpha = adm.alpha(m, k, j, i);
-    Real beta_u[3] = {adm.beta_u(m,0,k,j,i),
-                      adm.beta_u(m,1,k,j,i), adm.beta_u(m,2,k,j,i)};
     Real detg = adm::SpatialDet(g3d[S11], g3d[S12], g3d[S13],
                                 g3d[S22], g3d[S23], g3d[S33]);
     Real vol = sqrt(detg);

--- a/src/dyn_grmhd/dyn_grmhd.cpp
+++ b/src/dyn_grmhd/dyn_grmhd.cpp
@@ -119,8 +119,8 @@ DynGRMHD* BuildDynGRMHD(MeshBlockPack *ppack, ParameterInput *pin) {
 }
 
 DynGRMHD::DynGRMHD(MeshBlockPack *pp, ParameterInput *pin) :
-    pmy_pack(pp),
-    temperature("temperature",1,1,1,1,1) {
+    temperature("temperature",1,1,1,1,1),
+    pmy_pack(pp) {
   std::string rsolver = pin->GetString("mhd", "rsolver");
   if (rsolver.compare("llf") == 0) {
     rsolver_method = DynGRMHD_RSolver::llf_dyngr;

--- a/src/eos/primitive-solver/eos_compose.cpp
+++ b/src/eos/primitive-solver/eos_compose.cpp
@@ -195,10 +195,10 @@ void EOSCompOSE<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_min_h = std::numeric_limits<Real>::max();
     // New form of bound based on properties of NQT functions and their
     // departure from 'true' log behaviour
-    int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
-    for (int in = 0; in < m_nn-1; ++in) {
+    size_t it = 0; // T = T_min is a safe assumption for the minimum enthalpy
+    for (size_t in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
-      for (int iy = 0; iy < m_ny-1; ++iy) {
+      for (size_t iy = 0; iy < m_ny-1; ++iy) {
         Real min_log2_e_in = Kokkos::fmin(host_table(ECLOGE,in,iy,it),
                                           host_table(ECLOGE,in,iy+1,it));
         Real max_log2_e_in = Kokkos::fmax(host_table(ECLOGE,in,iy,it),

--- a/src/eos/primitive-solver/eos_compose.hpp
+++ b/src/eos/primitive-solver/eos_compose.hpp
@@ -505,8 +505,8 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
 
     // initialize the iteration variables
     int n_iter = 0;
-    Real J[2][2] = {0.0};
-    Real invJ[2][2] = {0.0};
+    Real J[2][2] = {};
+    Real invJ[2][2] = {};
     Real dx1[2] = {0.0};
     Real dxa[2] = {0.0};
     Real norm[2] = {0.0};

--- a/src/eos/primitive-solver/eos_compose.hpp
+++ b/src/eos/primitive-solver/eos_compose.hpp
@@ -62,9 +62,9 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
     m_id_log_nb = std::numeric_limits<Real>::quiet_NaN();
     m_id_log_t = std::numeric_limits<Real>::quiet_NaN();
     m_id_yq = std::numeric_limits<Real>::quiet_NaN();
-    m_nn = std::numeric_limits<int>::quiet_NaN();
-    m_nt = std::numeric_limits<int>::quiet_NaN();
-    m_ny = std::numeric_limits<int>::quiet_NaN();
+    m_nn = 0;
+    m_nt = 0;
+    m_ny = 0;
     m_min_h = std::numeric_limits<Real>::max();
     mb =    std::numeric_limits<Real>::quiet_NaN();
     min_n = std::numeric_limits<Real>::quiet_NaN();
@@ -363,7 +363,7 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
     // use in and in+1.
     if (*in < 0) {
       *in = 0;
-    } else if (*in > m_nn - 2) {
+    } else if (*in > static_cast<int>(m_nn) - 2) {
       *in = m_nn - 2;
     }
     *w1 = (log_n - m_log_nb(*in))*m_id_log_nb;
@@ -376,7 +376,7 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
     // Clamp iy. See weight_idx_ln.
     if (*iy < 0) {
       *iy = 0;
-    } else if (*iy > m_ny - 2) {
+    } else if (*iy > static_cast<int>(m_ny) - 2) {
       *iy = m_ny - 2;
     }
     *w1 = (yq - m_yq(*iy))*m_id_yq;
@@ -391,7 +391,7 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
     // Clamp it. See weight_idx_ln.
     if (*it < 0) {
       *it = 0;
-    } else if (*it > m_nt - 2) {
+    } else if (*it > static_cast<int>(m_nt) - 2) {
       *it = m_nt - 2;
     }
     *w1 = (log_t - m_log_t(*it))*m_id_log_t;
@@ -740,7 +740,7 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
   // Inverse of table spacing
   Real m_id_log_nb, m_id_yq, m_id_log_t;
   // Table size
-  int m_nn, m_nt, m_ny;
+  size_t m_nn, m_nt, m_ny;
   // Minimum enthalpy per baryon
   Real m_min_h;
 

--- a/src/eos/primitive-solver/eos_compose.hpp
+++ b/src/eos/primitive-solver/eos_compose.hpp
@@ -51,8 +51,8 @@ class EOSCompOSE : public EOSPolicyInterface, public LogPolicy, public SupportsE
   /// Constructor
   EOSCompOSE() :
       m_log_nb("log nb",1),
-      m_log_t("log T",1),
       m_yq("yq",1),
+      m_log_t("log T",1),
       m_table("EoS table",1,1,1,1) {
     n_species = 1;
     eos_units = MakeNuclear();

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -125,7 +125,7 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_min_h = std::numeric_limits<Real>::max();
     // New form of bound based on properties of NQT functions and their
     // departure from 'true' log behaviour
-    for (int in = 0; in < m_nn-1; ++in) {
+    for (size_t in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
       Real log2_e_in   = host_table(ECLOGE,in);
       Real log2_e_inp1 = host_table(ECLOGE,in+1);

--- a/src/eos/primitive-solver/eos_hybrid.cpp
+++ b/src/eos/primitive-solver/eos_hybrid.cpp
@@ -125,7 +125,6 @@ void EOSHybrid<LogPolicy>::ReadTableFromFile(std::string fname) {
     m_min_h = std::numeric_limits<Real>::max();
     // New form of bound based on properties of NQT functions and their
     // departure from 'true' log behaviour
-    int it = 0; // T = T_min is a safe assumption for the minimum enthalpy
     for (int in = 0; in < m_nn-1; ++in) {
       Real const nb = exp2_(host_log_nb(in));
       Real log2_e_in   = host_table(ECLOGE,in);

--- a/src/eos/primitive-solver/eos_hybrid.hpp
+++ b/src/eos/primitive-solver/eos_hybrid.hpp
@@ -57,7 +57,7 @@ class EOSHybrid : public EOSPolicyInterface, public LogPolicy {
 
     // These will be set properly when the table is read
     m_id_log_nb = std::numeric_limits<Real>::quiet_NaN();
-    m_nn = std::numeric_limits<int>::quiet_NaN();
+    m_nn = 0;
     m_min_h = std::numeric_limits<Real>::max();
     mb =    std::numeric_limits<Real>::quiet_NaN();
 
@@ -283,7 +283,7 @@ class EOSHybrid : public EOSPolicyInterface, public LogPolicy {
   // Inverse of table spacing
   Real m_id_log_nb;
   // Table size
-  int m_nn;
+  size_t m_nn;
   // Minimum enthalpy per baryon
   Real m_min_h;
 

--- a/src/eos/primitive-solver/primitive_solver.hpp
+++ b/src/eos/primitive-solver/primitive_solver.hpp
@@ -554,7 +554,7 @@ SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim[NPRIM]
 template<typename EOSPolicy, typename ErrorPolicy>
 KOKKOS_INLINE_FUNCTION
 Error PrimitiveSolver<EOSPolicy, ErrorPolicy>::PrimToCon(Real prim[NPRIM],
-      Real cons[NCONS], Real bu[NMAG], Real g3d[NMETRIC]) const {
+      Real cons[NCONS], Real bu[NMAG], Real g3d[NSPMETRIC]) const {
   // Extract the primitive variables
   const Real &n = prim[PRH]; // number density
   const Real Wv_u[3] = {prim[PVX], prim[PVY], prim[PVZ]};

--- a/src/eos/primitive_solver_hyd.hpp
+++ b/src/eos/primitive_solver_hyd.hpp
@@ -189,8 +189,8 @@ class PrimitiveSolverHydro {
     // FIXME(JF): Is this needed if the first-order flux correction is enabled?
     prim_pt[PTM] = prim_pt_old[PTM] = eos.GetTemperatureFromP(prim_pt[PRH],
                                         prim_pt[PPR], &prim_pt[PYF]);
-    bool floored = ps.GetEOS().ApplyPrimitiveFloor(prim_pt[PRH], &prim_pt[PVX],
-                                         prim_pt[PPR], prim_pt[PTM], &prim_pt[PYF]);
+    ps.GetEOS().ApplyPrimitiveFloor(prim_pt[PRH], &prim_pt[PVX],
+                                    prim_pt[PPR], prim_pt[PTM], &prim_pt[PYF]);
 
     ps.PrimToCon(prim_pt, cons_pt, bin, g3d);
 
@@ -321,7 +321,6 @@ class PrimitiveSolverHydro {
     auto &excision_floor_ = pmy_pack->pcoord->excision_floor;
     auto &excision_flux_ = pmy_pack->pcoord->excision_flux;
     auto &dexcise_ = pmy_pack->pcoord->coord_data.dexcise;
-    auto &pexcise_ = pmy_pack->pcoord->coord_data.pexcise;
     auto &texcise_ = pmy_pack->pcoord->coord_data.texcise;
 
     auto &adm  = pmy_pack->padm->adm;

--- a/src/eos/primitive_solver_hyd.hpp
+++ b/src/eos/primitive_solver_hyd.hpp
@@ -345,7 +345,7 @@ class PrimitiveSolverHydro {
     Real mb = eos_.GetBaryonMass();
 
     // FIXME: This only works for a flooring policy that has these functions!
-    bool prim_failure, cons_failure;
+    bool prim_failure=false, cons_failure=false;
     if (floors_only) {
       prim_failure = ps.GetEOSMutable().IsPrimitiveFlooringFailure();
       cons_failure = ps.GetEOSMutable().IsConservedFlooringFailure();

--- a/src/geodesic-grid/gauss_legendre.cpp
+++ b/src/geodesic-grid/gauss_legendre.cpp
@@ -24,15 +24,15 @@
 // constructor, initializes data structures and parameters
 
 GaussLegendreGrid::GaussLegendreGrid(MeshBlockPack *pmy_pack, int ntheta, Real rad):
-  pmy_pack(pmy_pack),
-  radius(rad),
   ntheta(ntheta),
+  radius(rad),
   int_weights("int_weights",1),
-  polar_pos("polar_pos",1,1),
   cart_pos("cart_pos",1,1),
+  polar_pos("polar_pos",1,1),
+  interp_vals("interp_vals",1),
   interp_indcs("interp_indcs",1,1),
   interp_wghts("interp_wghts",1,1,1),
-  interp_vals("interp_vals",1) {
+  pmy_pack(pmy_pack) {
   // reallocate and set interpolation coordinates, indices, and weights
   int &ng = pmy_pack->pmesh->mb_indcs.ng;
   nangles = 2*ntheta*ntheta;

--- a/src/geodesic-grid/geodesic_grid.cpp
+++ b/src/geodesic-grid/geodesic_grid.cpp
@@ -18,13 +18,6 @@
 // constructor, initializes data structures and parameters
 
 GeodesicGrid::GeodesicGrid(int nlev, bool rotate, bool fluxes) :
-    nlevel(nlev),
-    rotate_geo(rotate),
-    geo_fluxes(fluxes),
-    amesh_normals("amesh_normals",1,1,1,1),
-    ameshp_normals("ameshp_normals",1,1),
-    amesh_indices("amesh_indices",1,1,1),
-    ameshp_indices("ameshp_indices",1),
     num_neighbors("num_neighbors",1),
     ind_neighbors("ind_neighbors",1,1),
     ind_neighbors_edges("ind_neighbors_edges",1,1),
@@ -34,7 +27,14 @@ GeodesicGrid::GeodesicGrid(int nlev, bool rotate, bool fluxes) :
     cart_pos_mid("cart_pos_mid",1,1,1),
     polar_pos("polar_pos",1,1),
     polar_pos_mid("polar_pos_mid",1,1,1),
-    unit_flux("unit_flux",1,1,1) {
+    unit_flux("unit_flux",1,1,1),
+    nlevel(nlev),
+    rotate_geo(rotate),
+    geo_fluxes(fluxes),
+    amesh_normals("amesh_normals",1,1,1,1),
+    ameshp_normals("ameshp_normals",1,1),
+    amesh_indices("amesh_indices",1,1,1),
+    ameshp_indices("ameshp_indices",1) {
   if (nlevel > 0) {  // construct geodesic mesh
     // number of angles
     nangles = 5*2*SQR(nlevel) + 2;

--- a/src/geodesic-grid/spherical_grid.cpp
+++ b/src/geodesic-grid/spherical_grid.cpp
@@ -25,12 +25,12 @@
 
 SphericalGrid::SphericalGrid(MeshBlockPack *ppack, int nlev, Real rad, int nintp):
     GeodesicGrid(nlev,true,false),
-    pmy_pack(ppack),
     radius(rad),
     interp_coord("interp_coord",1,1),
+    interp_vals("interp_vals",1,1),
+    pmy_pack(ppack),
     interp_indcs("interp_indcs",1,1),
-    interp_wghts("interp_wghts",1,1,1),
-    interp_vals("interp_vals",1,1) {
+    interp_wghts("interp_wghts",1,1,1) {
   // reallocate and set interpolation coordinates, indices, and weights
   ninterp = (nintp <= 0) ? pmy_pack->pmesh->mb_indcs.ng*2 : nintp;
   if (ninterp > pmy_pack->pmesh->mb_indcs.ng*2+1) {

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -27,15 +27,15 @@ namespace hydro {
 // constructor, initializes data structures and parameters
 
 Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
-    pmy_pack(ppack),
     u0("cons",1,1,1,1,1),
     w0("prim",1,1,1,1,1),
     coarse_u0("ccons",1,1,1,1,1),
     coarse_w0("cprim",1,1,1,1,1),
     u1("cons1",1,1,1,1,1),
     uflx("uflx",1,1,1,1,1),
+    fofc("fofc",1,1,1,1),
     utest("utest",1,1,1,1,1),
-    fofc("fofc",1,1,1,1) {
+    pmy_pack(ppack) {
   // Total number of MeshBlocks on this rank to be used in array dimensioning
   int nmb = std::max((ppack->nmb_thispack), (ppack->pmesh->nmb_maxperrank));
 

--- a/src/ion-neutral/ion-neutral_tasks.cpp
+++ b/src/ion-neutral/ion-neutral_tasks.cpp
@@ -107,10 +107,10 @@ TaskStatus IonNeutral::FirstTwoImpRK(Driver *pdrive, int stage) {
   Kokkos::deep_copy(DevExeSpace(), pmhd->b1.x3f, pmhd->b0.x3f);
 
   // Solve implicit equations first time (nexp_stage = -1)
-  auto status = ImpRKUpdate(pdrive, -1);
+  ImpRKUpdate(pdrive, -1);
 
   // Solve implicit equations second time (nexp_stage = 0)
-  status = ImpRKUpdate(pdrive, 0);
+  ImpRKUpdate(pdrive, 0);
 
   // update primitive variables for both hydro and MHD
   auto &indcs = pmy_pack->pmesh->mb_indcs;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,7 +261,6 @@ int main(int argc, char *argv[]) {
     // read parameters from restart file
     restartfile.Open(restart_file.c_str(),IOWrapper::FileMode::read,single_file_per_rank);
     pinput->LoadFromFile(restartfile, single_file_per_rank);
-    IOWrapperSizeT headeroffset = restartfile.GetPosition(single_file_per_rank);
   }
 
   // read parameters from input file.  If both -r and -i are specified, this will

--- a/src/mesh/build_tree.cpp
+++ b/src/mesh/build_tree.cpp
@@ -321,8 +321,6 @@ void Mesh::BuildTreeFromRestart(ParameterInput *pin, IOWrapper &resfile,
                                                      bool single_file_per_rank) {
   // At this point, the restartfile is already open and the ParameterInput (input file)
   // data has already been read in main(). Thus the file pointer is set to after <par_end>
-  IOWrapperSizeT headeroffset = resfile.GetPosition();
-
   // following must be identical to calculation of headeroffset (excluding size of
   // ParameterInput data) in restart.cpp
   IOWrapperSizeT headersize = 3*sizeof(int) + 2*sizeof(Real)

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -44,16 +44,16 @@
 //! only after the Mesh constructor has finished.
 
 Mesh::Mesh(ParameterInput *pin) :
+  strictly_periodic(true),
   one_d(false),
   two_d(false),
   three_d(false),
   multi_d(false),
-  strictly_periodic(true),
-  nmb_packs_thisrank(1),
   nprtcl_thisrank(0),
   nprtcl_total(0),
   dtold(0.),
-  dt_last_completed(0.) {
+  dt_last_completed(0.),
+  nmb_packs_thisrank(1) {
   // Set physical size and number of cells in mesh (root level)
   mesh_size.x1min = pin->GetReal("mesh", "x1min");
   mesh_size.x1max = pin->GetReal("mesh", "x1max");

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -366,8 +366,8 @@ void Mesh::PrintMeshDiagnostics() {
 
   // if more than one physical level: compute/output # of blocks and cost per level
   if ((max_level - root_level) > 1) {
-    int nb_per_plevel[max_level];      // NOLINT(runtime/arrays)
-    float cost_per_plevel[max_level];  // NOLINT(runtime/arrays)
+    int *nb_per_plevel = new int[max_level];
+    float *cost_per_plevel = new float[max_level];
     for (int i=0; i<max_level; ++i) {
       nb_per_plevel[i] = 0;
       cost_per_plevel[i] = 0.0;
@@ -383,13 +383,15 @@ void Mesh::PrintMeshDiagnostics() {
                   << cost_per_plevel[i-root_level] <<  std::endl;
       }
     }
+    delete[] nb_per_plevel;
+    delete[] cost_per_plevel;
   }
 
   std::cout << "Number of parallel ranks = " << global_variable::nranks << std::endl;
   // if more than one rank: compute/output # of blocks and cost per rank
   if (global_variable::nranks > 1) {
-    int nb_per_rank[global_variable::nranks];    // NOLINT(runtime/arrays)
-    int cost_per_rank[global_variable::nranks];  // NOLINT(runtime/arrays)
+    int *nb_per_rank = new int[global_variable::nranks];
+    float *cost_per_rank = new float[global_variable::nranks];
     for (int i=0; i<global_variable::nranks; ++i) {
       nb_per_rank[i] = 0;
       cost_per_rank[i] = 0;
@@ -398,8 +400,8 @@ void Mesh::PrintMeshDiagnostics() {
       nb_per_rank[rank_eachmb[i]]++;
       cost_per_rank[rank_eachmb[i]] += cost_eachmb[i];
     }
-    int mincost = std::numeric_limits<int>::max();
-    int maxcost = 0, totalcost = 0;
+    float mincost = std::numeric_limits<float>::max();
+    float maxcost = 0.0, totalcost = 0.0;
     for (int i=0; i<global_variable::nranks; ++i) {
       std::cout << "  Rank = " << i << ": " << nb_per_rank[i] <<" MeshBlocks, cost = "
                 << cost_per_rank[i] << std::endl;
@@ -410,10 +412,11 @@ void Mesh::PrintMeshDiagnostics() {
 
     // output normalized costs per rank
     std::cout << "Load Balancing:" << std::endl;
-    std::cout << "  Maximum normalized cost = "
-      << static_cast<float>(maxcost)/static_cast<float>(mincost) << ", Average = "
-      << static_cast<float>(totalcost)/static_cast<float>(global_variable::nranks*mincost)
+    std::cout << "  Maximum normalized cost = " << maxcost/mincost
+      << ", Average = " << totalcost/(global_variable::nranks*mincost)
       << std::endl;
+    delete[] nb_per_rank;
+    delete[] cost_per_rank;
   }
 }
 

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -257,7 +257,7 @@ void MeshRefinement::UpdateMeshBlockTree(int &nnew, int &ndel) {
   }
 
   // allocate memory for logical location arrays over total number MBs refined/derefined
-  LogicalLocation *llref, *llderef, *cllderef;
+  LogicalLocation *llref=NULL, *llderef=NULL, *cllderef=NULL;
   if (tnref > 0) {
     llref = new LogicalLocation[tnref];
   }
@@ -345,10 +345,6 @@ void MeshRefinement::UpdateMeshBlockTree(int &nnew, int &ndel) {
     std::sort(cllderef, &(cllderef[ctnd-1]), Mesh::GreaterLevel);
   }
 
-  if (tnderef >= nleaf) {
-    delete [] llderef;
-  }
-
   // Now the lists of the blocks to be refined and derefined are completed
   // Start tree manipulation.  Note all ranks manipulate entire tree, so each rank has
   // a complete and updated copy of the entire tree.
@@ -366,9 +362,9 @@ void MeshRefinement::UpdateMeshBlockTree(int &nnew, int &ndel) {
     MeshBlockTree *bt = pmy_mesh->ptree->FindMeshBlock(cllderef[n]);
     bt->Derefine(ndel);
   }
-
   if (tnderef >= nleaf) {
     delete [] cllderef;
+    delete [] llderef;
   }
 
   return;

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -40,21 +40,21 @@
 // called from Mesh::BuildTree (before physics modules are enrolled)
 
 MeshRefinement::MeshRefinement(Mesh *pm, ParameterInput *pin) :
-  pmy_mesh(pm),
-  refine_flag("rflag",pm->nmb_total),
-  ncyc_since_ref("cyc_since_ref",pm->nmb_total),
   nmb_created(0),
   nmb_deleted(0),
   nmb_sent_thisrank(0),
   ncyc_check_amr(1),
   refinement_interval(5),
+  prolong_prims(false),
+  refine_flag("rflag",pm->nmb_total),
+  ncyc_since_ref("cyc_since_ref",pm->nmb_total),
 #if MPI_PARALLEL_ENABLED
   sendbuf("lb send buff",1),
   recvbuf("lb recv buff",1),
   send_data("lb send data",1),
   recv_data("lb recv data",1),
 #endif
-  prolong_prims(false) {
+  pmy_mesh(pm) {
   if (pin->DoesBlockExist("mesh_refinement")) {
     // read interval (in cycles) between check of AMR and derefinement
     ncyc_check_amr = pin->GetOrAddReal("mesh_refinement", "ncycle_check", 1);

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -14,7 +14,7 @@
 //! lid that can be encoded is set by (NUM_BITS_LID) macro.
 //! The convention in Athena++ is lid is for the *receiving* process.
 //! The MPI standard requires signed int tag, with MPI_TAG_UB>=2^15-1 = 32,767 (inclusive)
-static int CreateAMR_MPI_Tag(int lid, int ox1, int ox2, int ox3) {
+inline int CreateAMR_MPI_Tag(int lid, int ox1, int ox2, int ox3) {
   return (ox1<<(NUM_BITS_LID+2)) | (ox2<<(NUM_BITS_LID+1))| (ox3<<(NUM_BITS_LID)) | lid;
 }
 

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -23,11 +23,11 @@
 // by SetNeighbors function called by BuildTree***() functions.
 
 MeshBlock::MeshBlock(MeshBlockPack* ppack, int igids, int nmb) :
-  pmy_pack(ppack),
   mb_gid("mb_gid",nmb),
   mb_lev("mb_lev",nmb),
   mb_size("mbsize",nmb),
-  mb_bcs("mbbcs",nmb,6) {
+  mb_bcs("mbbcs",nmb,6),
+  pmy_pack(ppack) {
   Mesh* pm = pmy_pack->pmesh;
   auto &ms = pm->mesh_size;
 

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -28,7 +28,6 @@ namespace mhd {
 // constructor, initializes data structures and parameters
 
 MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
-    pmy_pack(ppack),
     u0("cons",1,1,1,1,1),
     w0("prim",1,1,1,1,1),
     b0("B_fc",1,1,1,1),
@@ -40,21 +39,22 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     b1("B_fc1",1,1,1,1),
     uflx("uflx",1,1,1,1,1),
     efld("efld",1,1,1,1),
-    wsaved("wsaved",1,1,1,1,1),
-    bccsaved("bccsaved",1,1,1,1,1),
     e3x1("e3x1",1,1,1,1),
     e2x1("e2x1",1,1,1,1),
     e1x2("e1x2",1,1,1,1),
     e3x2("e3x2",1,1,1,1),
     e2x3("e2x3",1,1,1,1),
     e1x3("e1x3",1,1,1,1),
-    e1_cc("e1_cc",1,1,1,1),
-    e2_cc("e2_cc",1,1,1,1),
-    e3_cc("e3_cc",1,1,1,1),
+    wsaved("wsaved",1,1,1,1,1),
+    bccsaved("bccsaved",1,1,1,1,1),
+    fofc("fofc",1,1,1,1),
+    fofc_scal("fofc_scal",1,1,1,1,1),
     utest("utest",1,1,1,1,1),
     bcctest("bcctest",1,1,1,1,1),
-    fofc("fofc",1,1,1,1),
-    fofc_scal("fofc_scal",1,1,1,1,1) {
+    pmy_pack(ppack),
+    e1_cc("e1_cc",1,1,1,1),
+    e2_cc("e2_cc",1,1,1,1),
+    e3_cc("e3_cc",1,1,1,1) {
   // Total number of MeshBlocks on this rank to be used in array dimensioning
   int nmb = std::max((ppack->nmb_thispack), (ppack->pmesh->nmb_maxperrank));
 

--- a/src/mhd/rsolvers/llf_mhd_singlestate.hpp
+++ b/src/mhd/rsolvers/llf_mhd_singlestate.hpp
@@ -41,7 +41,7 @@ void SingleStateLLF_MHD(const MHDPrim1D &wl, const MHDPrim1D &wr, const Real &bx
   fsum.by = wl.by*wl.vx + wr.by*wr.vx - bxi*(wl.vy + wr.vy);
   fsum.bz = wl.bz*wl.vx + wr.bz*wr.vx - bxi*(wl.vz + wr.vz);
 
-  Real el,er,pl,pr;
+  Real el=0.0, er=0.0, pl,pr;
   if (eos.is_ideal) {
     pl = eos.IdealGasPressure(wl.e);
     pr = eos.IdealGasPressure(wr.e);
@@ -53,6 +53,7 @@ void SingleStateLLF_MHD(const MHDPrim1D &wl, const MHDPrim1D &wr, const Real &bx
     fsum.e  -= bxi*(wr.by*wr.vy + wr.bz*wr.vz);
   } else {
     fsum.mx += SQR(eos.iso_cs)*(wl.d + wr.d);
+    fsum.e   = 0.0;
   }
 
   // Compute max wave speed in L,R states (see Toro eq. 10.43)

--- a/src/outputs/basetype_output.cpp
+++ b/src/outputs/basetype_output.cpp
@@ -39,10 +39,10 @@
 // Creates vector of output variable data
 
 BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters opar) :
+    out_params(opar),
     derived_var("derived-var",1,1,1,1,1),
     outarray("cc_outvar",1,1,1,1,1),
-    outfield("fc_outvar",1,1,1,1),
-    out_params(opar) {
+    outfield("fc_outvar",1,1,1,1) {
   // exit for history, restart, or event log files
   if (out_params.file_type.compare("hst") == 0 ||
       out_params.file_type.compare("rst") == 0 ||

--- a/src/outputs/basetype_output.cpp
+++ b/src/outputs/basetype_output.cpp
@@ -8,10 +8,10 @@
 
 #include <iostream>
 #include <sstream>
-#include <string>   // std::string, to_string()
-#include <cstdio> // snprintf
+#include <string>    // std::string, to_string()
+#include <cstdio>    // snprintf
 #include <algorithm> // min_element
-#include <utility> // pair<>
+#include <utility>   // pair<>
 #include <vector>
 
 #include "athena.hpp"
@@ -273,7 +273,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nhyd + pm->pmb_pack->phydro->nscalars;
       for (int n=nhyd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number),"%02d",(n - nhyd)%100);
+        std::snprintf(number,sizeof(number)+1,"%02d",(n - nhyd)%100);
         std::string vname;
         vname.assign("r_");
         vname.append(number);
@@ -290,7 +290,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nhyd + pm->pmb_pack->phydro->nscalars;
       for (int n=nhyd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number),"%02d",(n - nhyd)%100);
+        std::snprintf(number,sizeof(number)+1,"%02d",(n - nhyd)%100);
         std::string vname;
         vname.assign("s_");
         vname.append(number);
@@ -409,7 +409,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nmhd + pm->pmb_pack->pmhd->nscalars;
       for (int n=nmhd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number),"%02d",(n - nmhd)%100);
+        std::snprintf(number,sizeof(number)+1,"%02d",(n - nmhd)%100);
         std::string vname;
         vname.assign("r_");
         vname.append(number);
@@ -428,7 +428,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nmhd + pm->pmb_pack->pmhd->nscalars;
       for (int n=nmhd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number),"%02d",(n - nmhd)%100);
+        std::snprintf(number,sizeof(number)+1,"%02d",(n - nmhd)%100);
         std::string vname;
         vname.assign("s_");
         vname.append(number);

--- a/src/outputs/basetype_output.cpp
+++ b/src/outputs/basetype_output.cpp
@@ -273,7 +273,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nhyd + pm->pmb_pack->phydro->nscalars;
       for (int n=nhyd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number)+1,"%02d",(n - nhyd)%100);
+        std::snprintf(number,sizeof(number),"%02d",(n - nhyd)%100);
         std::string vname;
         vname.assign("r_");
         vname.append(number);
@@ -290,7 +290,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nhyd + pm->pmb_pack->phydro->nscalars;
       for (int n=nhyd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number)+1,"%02d",(n - nhyd)%100);
+        std::snprintf(number,sizeof(number),"%02d",(n - nhyd)%100);
         std::string vname;
         vname.assign("s_");
         vname.append(number);
@@ -409,7 +409,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nmhd + pm->pmb_pack->pmhd->nscalars;
       for (int n=nmhd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number)+1,"%02d",(n - nmhd)%100);
+        std::snprintf(number,sizeof(number),"%02d",(n - nmhd)%100);
         std::string vname;
         vname.assign("r_");
         vname.append(number);
@@ -428,7 +428,7 @@ BaseTypeOutput::BaseTypeOutput(ParameterInput *pin, Mesh *pm, OutputParameters o
       int nvars = nmhd + pm->pmb_pack->pmhd->nscalars;
       for (int n=nmhd; n<nvars; ++n) {
         char number[3];
-        std::snprintf(number,sizeof(number)+1,"%02d",(n - nmhd)%100);
+        std::snprintf(number,sizeof(number),"%02d",(n - nmhd)%100);
         std::string vname;
         vname.assign("s_");
         vname.append(number);

--- a/src/outputs/binary.cpp
+++ b/src/outputs/binary.cpp
@@ -96,7 +96,7 @@ void MeshBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         << "  size of variable=" << sizeof(float) << std::endl
         << "  number of variables=" << outvars.size() << std::endl
         << "  variables:  ";
-    for (int n=0; n<outvars.size(); n++) {
+    for (size_t n=0; n<outvars.size(); n++) {
       msg << outvars[n].label.c_str() << "  ";
     }
     msg << std::endl;

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -296,7 +296,6 @@ void CoarsenedBinaryOutput::LoadOutputData(Mesh *pm) {
 //   All MeshBlocks are written to the same file.
 
 void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
-
   // create filename: "cbin_"+"file_id"+"_"+"coarsening_factor"+"/file_basename"
   // + "." + "file_id" + "." + XXXXX + ".cbin"
   // where XXXXX = 5-digit file_number

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -351,14 +351,14 @@ void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
       << "  variables:  ";
   if (out_params.compute_moments) {
     // need to write the label for each of the 4 moments
-    for (int n=0; n<outvars.size(); n++) {
+    for (size_t n=0; n<outvars.size(); n++) {
       msg << outvars[n].label.c_str() << "_1st  ";
       msg << outvars[n].label.c_str() << "_2nd  ";
       msg << outvars[n].label.c_str() << "_3rd  ";
       msg << outvars[n].label.c_str() << "_4th  ";
     }
   } else {
-    for (int n=0; n<outvars.size(); n++) {
+    for (size_t n=0; n<outvars.size(); n++) {
       msg << outvars[n].label.c_str() << "  ";
     }
   }

--- a/src/outputs/coarsened_binary.cpp
+++ b/src/outputs/coarsened_binary.cpp
@@ -296,8 +296,6 @@ void CoarsenedBinaryOutput::LoadOutputData(Mesh *pm) {
 //   All MeshBlocks are written to the same file.
 
 void CoarsenedBinaryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
-  // check if slicing
-  bool bin_slice = (out_params.slice1 || out_params.slice2 || out_params.slice3);
 
   // create filename: "cbin_"+"file_id"+"_"+"coarsening_factor"+"/file_basename"
   // + "." + "file_id" + "." + XXXXX + ".cbin"

--- a/src/outputs/derived_variables.cpp
+++ b/src/outputs/derived_variables.cpp
@@ -99,11 +99,11 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
     if (derived_var.extent(4) <= 1)
       Kokkos::realloc(derived_var, nmb_alloc, n_dv, n3, n2, n1);
     auto dv = derived_var;
-    auto &w0_ = (name.compare("hydro_wz") == 0)?
+    auto &w0_ = (pm->pmb_pack->phydro != nullptr)?
       pm->pmb_pack->phydro->w0 : pm->pmb_pack->pmhd->w0;
     par_for("temperature", DevExeSpace(), 0, (nmb-1), ks, ke, js, je, is, ie,
     KOKKOS_LAMBDA(int m, int k, int j, int i) {
-      dv(m,i_dv,k,j,i) = (w0_(m,IEN,k,j,i+1) / w0_(m,IDN,k,j,i-1));
+      dv(m,i_dv,k,j,i) = (w0_(m,IPR,k,j,i) / w0_(m,IDN,k,j,i));
     });
     i_dv += 1; // increment derived variable index
   }
@@ -123,6 +123,7 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
       if (multi_d) {
         dv(m,i_dv,k,j,i) -=(w0_(m,IVX,k,j+1,i) - w0_(m,IVX,k,j-1,i))/size.d_view(m).dx2;
       }
+      dv(m,i_dv,k,j,i) *= 0.5; // accounts for divide by 2*dx
     });
     i_dv += 1; // increment derived variable index
   }
@@ -149,7 +150,7 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
         w1 -= (w0_(m,IVY,k+1,j,i) - w0_(m,IVY,k-1,j,i))/size.d_view(m).dx3;
         w2 += (w0_(m,IVX,k+1,j,i) - w0_(m,IVX,k-1,j,i))/size.d_view(m).dx3;
       }
-      dv(m,i_dv,k,j,i) = w1*w1 + w2*w2 + w3*w3;
+      dv(m,i_dv,k,j,i) = 0.25*(w1*w1 + w2*w2 + w3*w3); // accounts for divide by 2*dx
     });
     i_dv += 1; // increment derived variable index
   }
@@ -168,6 +169,7 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
       if (multi_d) {
         dv(m,i_dv,k,j,i) -=(bcc(m,IBX,k,j+1,i) - bcc(m,IBX,k,j-1,i))/size.d_view(m).dx2;
       }
+      dv(m,i_dv,k,j,i) *= 0.5; // accounts for divide by 2*dx
     });
     i_dv += 1; // increment derived variable index
   }
@@ -192,7 +194,7 @@ void BaseTypeOutput::ComputeDerivedVariable(std::string name, Mesh *pm) {
         j1 -= (bcc(m,IBY,k+1,j,i) - bcc(m,IBY,k-1,j,i))/size.d_view(m).dx3;
         j2 += (bcc(m,IBX,k+1,j,i) - bcc(m,IBX,k-1,j,i))/size.d_view(m).dx3;
       }
-      dv(m,i_dv,k,j,i) = j1*j1 + j2*j2 + j3*j3;
+      dv(m,i_dv,k,j,i) = 0.25*(j1*j1 + j2*j2 + j3*j3); // accounts for divide by 2*dx
     });
     i_dv += 1; // increment derived variable index
   }

--- a/src/outputs/formatted_table.cpp
+++ b/src/outputs/formatted_table.cpp
@@ -99,7 +99,7 @@ void FormattedTableOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     std::fclose(pfile);   // don't forget to close the output file
   }
 #if MPI_PARALLEL_ENABLED
-  int ierr = MPI_Barrier(MPI_COMM_WORLD);
+  MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
   // now all ranks open file and append data
@@ -174,7 +174,7 @@ void FormattedTableOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     }
     std::fflush(pfile);
 #if MPI_PARALLEL_ENABLED
-    int ierr = MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(MPI_COMM_WORLD);
 #endif
   }
 

--- a/src/outputs/pdf.cpp
+++ b/src/outputs/pdf.cpp
@@ -126,7 +126,8 @@ PDFOutput::PDFOutput(ParameterInput *pin, Mesh *pm, OutputParameters op) :
     Kokkos::deep_copy(pdf_data.bins2, bins2_host);
     Kokkos::fence();
 
-    if (pdf_data.pdf_dimension == 2 && pdf_data.bins2.extent(0) != op.nbin2 + 1) {
+    if (pdf_data.pdf_dimension == 2 && 
+        static_cast<int>(pdf_data.bins2.extent(0)) != op.nbin2 + 1) {
       std::cerr << "Error: pdf_data.bins2 size mismatch. Expected size: "
                 << op.nbin2 + 1 << ", Actual size: " << pdf_data.bins2.extent(0)
                 << std::endl;

--- a/src/outputs/pdf.cpp
+++ b/src/outputs/pdf.cpp
@@ -126,7 +126,7 @@ PDFOutput::PDFOutput(ParameterInput *pin, Mesh *pm, OutputParameters op) :
     Kokkos::deep_copy(pdf_data.bins2, bins2_host);
     Kokkos::fence();
 
-    if (pdf_data.pdf_dimension == 2 && 
+    if (pdf_data.pdf_dimension == 2 &&
         static_cast<int>(pdf_data.bins2.extent(0)) != op.nbin2 + 1) {
       std::cerr << "Error: pdf_data.bins2 size mismatch. Expected size: "
                 << op.nbin2 + 1 << ", Actual size: " << pdf_data.bins2.extent(0)

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -324,7 +324,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(outarray_hyd, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at_all(mbptr.data(),mbcnt,myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -339,7 +339,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(outarray_hyd, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at(mbptr.data(), mbcnt, myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -360,7 +360,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(outarray_mhd, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at_all(mbptr.data(),mbcnt,myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -375,7 +375,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(outarray_mhd, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at(mbptr.data(), mbcnt, myoffset,"Real",
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -394,7 +394,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
       if (m < noutmbs_min) {
         // get ptr to x1-face field
         auto x1fptr = Kokkos::subview(outfield.x1f,m,Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
-        int fldcnt = x1fptr.size();
+        size_t fldcnt = x1fptr.size();
         if (resfile.Write_any_type_at_all(x1fptr.data(),fldcnt,myoffset,"Real",
                                           single_file_per_rank) != fldcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -434,7 +434,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
       } else if (m < pm->nmb_thisrank) {
         // get ptr to x1-face field
         auto x1fptr = Kokkos::subview(outfield.x1f,m,Kokkos::ALL,Kokkos::ALL,Kokkos::ALL);
-        int fldcnt = x1fptr.size();
+        size_t fldcnt = x1fptr.size();
         if (resfile.Write_any_type_at(x1fptr.data(),fldcnt,myoffset,"Real",
                                       single_file_per_rank) != fldcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -484,7 +484,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(outarray_rad, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at_all(mbptr.data(),mbcnt,myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -499,7 +499,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(outarray_rad, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at(mbptr.data(),mbcnt,myoffset,"Real",
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -521,7 +521,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(outarray_force, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at_all(mbptr.data(),mbcnt,myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -536,7 +536,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(outarray_force, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at(mbptr.data(), mbcnt, myoffset,"Real",
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -558,7 +558,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(outarray_z4c, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at_all(mbptr.data(),mbcnt,myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -573,7 +573,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(outarray_z4c, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at(mbptr.data(), mbcnt, myoffset,"Real",
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -593,7 +593,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(outarray_adm, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at_all(mbptr.data(),mbcnt,myoffset,"Real",
                                           single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -608,7 +608,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(outarray_adm, m, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL, Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Write_any_type_at(mbptr.data(), mbcnt, myoffset,"Real",
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__

--- a/src/outputs/track_prtcl.cpp
+++ b/src/outputs/track_prtcl.cpp
@@ -85,7 +85,6 @@ void TrackedParticleOutput::LoadOutputData(Mesh *pm) {
 //! With MPI, all particles are written to the same file.
 
 void TrackedParticleOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
-
   // create filename: "trk/file_basename".trk
   std::string fname;
   fname.assign("trk/");

--- a/src/outputs/track_prtcl.cpp
+++ b/src/outputs/track_prtcl.cpp
@@ -50,8 +50,9 @@ void TrackedParticleOutput::LoadOutputData(Mesh *pm) {
   auto &pi = pm->pmb_pack->ppart->prtcl_idata;
   int counter=0;
   int *pcounter = &counter;
+  int ntrack_ = ntrack;
   par_for("part_update",DevExeSpace(),0,(npart-1), KOKKOS_LAMBDA(const int p) {
-    if (pi(PTAG,p) < ntrack) {
+    if (pi(PTAG,p) < ntrack_) {
       int index = Kokkos::atomic_fetch_add(pcounter,1);
       tracked_prtcl.d_view(index).tag = pi(PTAG,p);
       tracked_prtcl.d_view(index).x   = pr(IPX,p);

--- a/src/outputs/track_prtcl.cpp
+++ b/src/outputs/track_prtcl.cpp
@@ -84,7 +84,6 @@ void TrackedParticleOutput::LoadOutputData(Mesh *pm) {
 //! With MPI, all particles are written to the same file.
 
 void TrackedParticleOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
-  int big_end = IsBigEndian(); // =1 on big endian machine
 
   // create filename: "trk/file_basename".trk
   std::string fname;

--- a/src/outputs/vtk_prtcl.cpp
+++ b/src/outputs/vtk_prtcl.cpp
@@ -160,7 +160,7 @@ void ParticleVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     std::size_t myoffset=header_offset + 3*rank_offset[global_variable::my_rank]*datasize;
     // collective writes for minimum number of particles across ranks
     if (partfile.Write_any_type_at_all(&(data[0]),3*npout_min,myoffset,"float")
-          != 3*npout_min) {
+          != static_cast<size_t>(3*npout_min)) {
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
           << std::endl << "particle data not written correctly to vtk particle file, "
           << "vtk file is broken." << std::endl;
@@ -171,7 +171,7 @@ void ParticleVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     int nremain = pm->nprtcl_thisrank - npout_min;
     if (nremain > 0) {
       if (partfile.Write_any_type_at(&(data[3*npout_min]),3*nremain,myoffset,"float")
-            != 3*nremain) {
+            != static_cast<size_t>(3*nremain)) {
         std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
             << std::endl << "particle data not written correctly to vtk particle file, "
             << "vtk file is broken." << std::endl;
@@ -221,7 +221,7 @@ void ParticleVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     std::size_t myoffset=header_offset + rank_offset[global_variable::my_rank]*datasize;
     // collective writes for minimum number of particles across ranks
     if (partfile.Write_any_type_at_all(&(data[0]),npout_min,myoffset,"float")
-          != npout_min) {
+          != static_cast<size_t>(npout_min)) {
       std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
           << std::endl << "particle data not written correctly to vtk particle file, "
           << "vtk file is broken." << std::endl;
@@ -232,7 +232,7 @@ void ParticleVTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     int nremain = pm->nprtcl_thisrank - npout_min;
     if (nremain > 0) {
       if (partfile.Write_any_type_at(&(data[npout_min]),nremain,myoffset,"float")
-            != nremain) {
+            != static_cast<size_t>(nremain)) {
         std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
             << std::endl << "particle data not written correctly to vtk particle file, "
             << "vtk file is broken." << std::endl;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -153,11 +153,10 @@ void ParameterInput::LoadFromStream(std::istream &is) {
   std::string line, block_name, param_name, param_value, param_comment;
   std::size_t first_char, last_char;
   InputBlock *pib{};
-  int line_num{-1}, blocks_found{0};
+  int blocks_found{0};
 
   while (is.good()) {
     std::getline(is, line);
-    line_num++;
     if (line.find('\t') != std::string::npos) {
       line.erase(std::remove(line.begin(), line.end(), '\t'), line.end());
     }

--- a/src/particles/particles_pushers.cpp
+++ b/src/particles/particles_pushers.cpp
@@ -17,34 +17,34 @@ namespace particles {
 //  \brief
 
 TaskStatus Particles::Push(Driver *pdriver, int stage) {
-  auto &indcs = pmy_pack->pmesh->mb_indcs;
-  int is = indcs.is;
-  int js = indcs.js;
-  int ks = indcs.ks;
+  //auto &indcs = pmy_pack->pmesh->mb_indcs;
+  //int is = indcs.is;
+  //int js = indcs.js;
+  //int ks = indcs.ks;
   bool &multi_d = pmy_pack->pmesh->multi_d;
   bool &three_d = pmy_pack->pmesh->three_d;
-  auto &mbsize = pmy_pack->pmb->mb_size;
-  auto &pi = prtcl_idata;
+  //auto &mbsize = pmy_pack->pmb->mb_size;
+  //auto &pi = prtcl_idata;
   auto &pr = prtcl_rdata;
   auto dt_ = (pmy_pack->pmesh->dt);
-  auto gids = pmy_pack->gids;
+  //auto gids = pmy_pack->gids;
 
   switch (pusher) {
     case ParticlesPusher::drift:
 
       par_for("part_update",DevExeSpace(),0,(nprtcl_thispack-1),
       KOKKOS_LAMBDA(const int p) {
-        int m = pi(PGID,p) - gids;
-        int ip = (pr(IPX,p) - mbsize.d_view(m).x1min)/mbsize.d_view(m).dx1 + is;
+        //int m = pi(PGID,p) - gids;
+        //int ip = (pr(IPX,p) - mbsize.d_view(m).x1min)/mbsize.d_view(m).dx1 + is;
         pr(IPX,p) += 0.5*dt_*pr(IPVX,p);
 
         if (multi_d) {
-          int jp = (pr(IPY,p) - mbsize.d_view(m).x2min)/mbsize.d_view(m).dx2 + js;
+          //int jp = (pr(IPY,p) - mbsize.d_view(m).x2min)/mbsize.d_view(m).dx2 + js;
           pr(IPY,p) += 0.5*dt_*pr(IPVY,p);
         }
 
         if (three_d) {
-          int kp = (pr(IPZ,p) - mbsize.d_view(m).x3min)/mbsize.d_view(m).dx3 + ks;
+          //int kp = (pr(IPZ,p) - mbsize.d_view(m).x3min)/mbsize.d_view(m).dx3 + ks;
           pr(IPZ,p) += 0.5*dt_*pr(IPVZ,p);
         }
       });

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -213,7 +213,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   std::memcpy(&data_size, &(variabledata[0]), sizeof(IOWrapperSizeT));
 
   // calculate total number of CC variables
-  IOWrapperSizeT headeroffset;
+  IOWrapperSizeT headeroffset=0;
   // master process gets file offset
   if (global_variable::my_rank == 0 || single_file_per_rank) {
     headeroffset = resfile.GetPosition(single_file_per_rank);
@@ -281,7 +281,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at_all(mbptr.data(), mbcnt, myoffset, single_file_per_rank)
             != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -296,7 +296,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at(mbptr.data(), mbcnt, myoffset, single_file_per_rank)
             != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -321,7 +321,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                    Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at_all(mbptr.data(), mbcnt, myoffset, single_file_per_rank)
             != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -335,7 +335,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at(mbptr.data(), mbcnt, myoffset, single_file_per_rank)
             != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -360,7 +360,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
       if (m < noutmbs_min) {
         // get ptr to x1-face field
         auto x1fptr = Kokkos::subview(fcin.x1f, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
-        int fldcnt = x1fptr.size();
+        size_t fldcnt = x1fptr.size();
 
         if (resfile.Read_Reals_at_all(x1fptr.data(), fldcnt, myoffset,
                                       single_file_per_rank) != fldcnt) {
@@ -401,7 +401,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
       } else if (m < pm->nmb_thisrank) {
         // get ptr to x1-face field
         auto x1fptr = Kokkos::subview(fcin.x1f, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
-        int fldcnt = x1fptr.size();
+        size_t fldcnt = x1fptr.size();
 
         if (resfile.Read_Reals_at(x1fptr.data(), fldcnt, myoffset,
                                       single_file_per_rank) != fldcnt) {
@@ -461,7 +461,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at_all(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -476,7 +476,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -501,7 +501,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at_all(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -516,7 +516,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -541,7 +541,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at_all(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -556,7 +556,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -582,7 +582,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to cell-centered MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at_all(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
@@ -597,7 +597,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
         // get ptr to MeshBlock data
         auto mbptr = Kokkos::subview(ccin, m, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL,
                                      Kokkos::ALL);
-        int mbcnt = mbptr.size();
+        size_t mbcnt = mbptr.size();
         if (resfile.Read_Reals_at(mbptr.data(), mbcnt, myoffset,
                                       single_file_per_rank) != mbcnt) {
           std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -134,7 +134,7 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
 
   // root process reads z4c last_output_time and tracker data
   if (pz4c != nullptr) {
-    Real last_output_time;
+    Real last_output_time = 0.0;
     if (global_variable::my_rank == 0 || single_file_per_rank) {
       if (resfile.Read_Reals(&last_output_time, 1,single_file_per_rank) != 1) {
         std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -256,7 +256,6 @@ ProblemGenerator::ProblemGenerator(ParameterInput *pin, Mesh *pm, IOWrapper resf
   }
 
   // read CC data into host array
-  int mygids = pm->gids_eachrank[global_variable::my_rank];
   IOWrapperSizeT offset_myrank = headeroffset;
   if (!single_file_per_rank) {
     offset_myrank += data_size_ * pm->gids_eachrank[global_variable::my_rank];

--- a/src/pgen/tests/gr_monopole.cpp
+++ b/src/pgen/tests/gr_monopole.cpp
@@ -667,7 +667,6 @@ void MonopoleDiagnostic(ParameterInput *pin, Mesh *pm) {
   for (int n=0; n<psph->nangles; ++n) {
     // extract coordinate data at this angle
     Real r = psph->radius;
-    Real theta = psph->polar_pos.h_view(n,0);
     Real x1 = psph->interp_coord.h_view(n,0);
     Real x2 = psph->interp_coord.h_view(n,1);
     Real x3 = psph->interp_coord.h_view(n,2);
@@ -710,7 +709,6 @@ void MonopoleDiagnostic(ParameterInput *pin, Mesh *pm) {
     Real a2 = SQR(spin);
     Real rad2 = SQR(x1)+SQR(x2)+SQR(x3);
     Real r2 = SQR(r);
-    Real sth = sin(theta);
     Real drdx = r*x1/(2.0*r2 - rad2 + a2);
     Real drdy = r*x2/(2.0*r2 - rad2 + a2);
     Real drdz = (r*x3 + a2*x3/r)/(2.0*r2-rad2+a2);

--- a/src/pgen/tests/linear_wave.cpp
+++ b/src/pgen/tests/linear_wave.cpp
@@ -1264,7 +1264,7 @@ void RelMHDPerturbations(LinWaveVariables lwv, Real u[4], Real b[4],
       Real lambda_fl, lambda_sl, lambda_sr, lambda_fr;
       QuarticRoots(coeff_3/coeff_4, coeff_2/coeff_4, coeff_1/coeff_4, coeff_0/coeff_4,
                    &lambda_fl, &lambda_sl, &lambda_sr, &lambda_fr);
-      Real lambda_other_ms;
+      Real lambda_other_ms=0.0;
       if (lwv.wave_flag == 0) {
         lambda = lambda_fl;
         lambda_other_ms = lambda_sl;

--- a/src/pgen/tests/linear_wave.cpp
+++ b/src/pgen/tests/linear_wave.cpp
@@ -789,8 +789,6 @@ void HydroEigensystemPrim(const Real d, const Real v1, const Real v2, const Real
                           Real eigenvalues[5], Real right_eigenmatrix[5][5]) {
   //--- Ideal Gas Hydrodynamics ---
   if (eos.is_ideal) {
-    Real vsq = v1*v1 + v2*v2 + v3*v3;
-    Real h = (p/(eos.gamma - 1.0) + 0.5*d*vsq + p)/d;
     Real a = std::sqrt(eos.gamma*p/d);
 
     // Compute eigenvalues (eq. B2)
@@ -889,12 +887,9 @@ void MHDEigensystemPrim(const Real d, const Real v1, const Real v2, const Real v
 
   //--- Ideal Gas MHD ---
   if (eos.is_ideal) {
-    Real vsq = v1*v1 + v2*v2 + v3*v3;
     Real gm1 = eos.gamma - 1.0;
-    Real h = (p/gm1 + 0.5*d*vsq + p + b1*b1 + btsq)/d;
     Real bt_starsq = (gm1 - (gm1 - 1.0)*y)*btsq;
     Real vaxsq = b1*b1/d;
-    Real hp = h - (vaxsq + btsq/d);
 
     // Compute fast- and slow-magnetosonic speeds (eq. A10)
     Real ct2 = bt_starsq/d;
@@ -907,13 +902,6 @@ void MHDEigensystemPrim(const Real d, const Real v1, const Real v2, const Real v
 
     Real cssq = asq*vaxsq/cfsq;
     Real cs = std::sqrt(cssq);
-
-    // Compute beta(s) (eqs. A17)
-    Real bt_star = std::sqrt(bt_starsq);
-    Real bet2_star = bet2/std::sqrt(gm1 - (gm1-1.0)*y);
-    Real bet3_star = bet3/std::sqrt(gm1 - (gm1-1.0)*y);
-    Real bet_starsq = bet2_star*bet2_star + bet3_star*bet3_star;
-    Real vbet = v2*bet2_star + v3*bet3_star;
 
     // Compute alpha(s) (eq. A16)
     Real alpha_f,alpha_s;
@@ -967,10 +955,6 @@ void MHDEigensystemPrim(const Real d, const Real v1, const Real v2, const Real v
     right_eigenmatrix[1][5] = 0.0;
     right_eigenmatrix[1][6] = cf*alpha_f;
 
-    Real qa = alpha_f*v2;
-    Real qb = alpha_s*v2;
-    Real qc = qs*bet2_star;
-    Real qd = qf*bet2_star;
     right_eigenmatrix[2][0] = qs*bet2;
     right_eigenmatrix[2][1] = -bet3;
     right_eigenmatrix[2][2] = -qf*bet2;
@@ -979,10 +963,6 @@ void MHDEigensystemPrim(const Real d, const Real v1, const Real v2, const Real v
     right_eigenmatrix[2][5] = bet3;
     right_eigenmatrix[2][6] = -qs*bet2;
 
-    qa = alpha_f*v3;
-    qb = alpha_s*v3;
-    qc = qs*bet3_star;
-    qd = qf*bet3_star;
     right_eigenmatrix[3][0] = qs*bet3;
     right_eigenmatrix[3][1] = bet2;
     right_eigenmatrix[3][2] = -qf*bet3;
@@ -1195,7 +1175,6 @@ void RelMHDPerturbations(LinWaveVariables lwv, Real u[4], Real b[4],
      Real &lambda, Real &delta_rho, Real &delta_pgas, Real delta_u[4], Real delta_b[4]) {
   Real b_sq = -SQR(b[0]) + SQR(b[1]) + SQR(b[2]) + SQR(b[3]);
   Real wtot = lwv.wgas + b_sq;
-  Real cs = std::sqrt(lwv.cs_sq);
   switch (lwv.wave_flag) {
     case 3: {  // entropy (A 46)
       lambda = lwv.vx_0;

--- a/src/pgen/tests/linear_wave.cpp
+++ b/src/pgen/tests/linear_wave.cpp
@@ -361,7 +361,8 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
 
     // Calculate linear wave perturbations in hydro
     Real rem[5][5], ev[5];
-    Real lambda, delta_rho, delta_pgas, delta_v[4];
+    Real lambda, delta_v[4];
+    Real delta_rho = 0.0, delta_pgas = 0.0;
     if (relativistic) {
       // Calculate background 4-vectors
       Real u[4];
@@ -482,7 +483,8 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
 
     // Calculate linear wave perturbations in MHD
     Real rem[7][7], ev[7];
-    Real lambda, delta_rho, delta_pgas,u[4],delta_u[4],delta_b[4];
+    Real lambda, u[4],delta_u[4],delta_b[4];
+    Real delta_rho = 0.0, delta_pgas = 0.0;
     if (relativistic) {
       // Calculate background 4-vectors
       Real v_sq = SQR(lwv.vx_0) + SQR(lwv.vy_0) + SQR(lwv.vz_0);

--- a/src/pgen/tests/mri3d.cpp
+++ b/src/pgen/tests/mri3d.cpp
@@ -103,9 +103,12 @@ void ProblemGenerator::MRI3d(ParameterInput *pin, const bool restart) {
   Real p0,hs;
   if (eos.is_ideal) {
     p0 = pin->GetReal("problem","pres");
+    // scale height using adiabatic speed of sound
+    hs = std::sqrt(eos.gamma*p0/d0)/(pmy_mesh_->pmb_pack->pmhd->psbox_u->omega0);
   } else {
     p0 = d0*SQR(eos.iso_cs);
-    hs = eos.iso_cs/(pmy_mesh_->pmb_pack->pmhd->psbox_u->omega0);   // scale height
+    // scale height using isothermal speed of sound
+    hs = eos.iso_cs/(pmy_mesh_->pmb_pack->pmhd->psbox_u->omega0);
   }
   Real binit = std::sqrt(2.0*p0/beta);
 

--- a/src/pgen/tests/rad_beam.cpp
+++ b/src/pgen/tests/rad_beam.cpp
@@ -81,7 +81,7 @@ void ProblemGenerator::RadiationBeam(ParameterInput *pin, const bool restart) {
       ComputeMetricAndInverse(x1v,x2v,x3v,flat,spin,glower,gupper);
 
       // Compute eta_alpha beta = g_mu nu e^mu_alpha e^nu_beta
-      Real test_eta[4][4] = {0.0};
+      Real test_eta[4][4] = {};
       for (int alpha=0; alpha<4; ++alpha) {
         for (int beta=0; beta<4; ++beta) {
           test_eta[alpha][beta] = 0.0;

--- a/src/pgen/tests/shock_tube.cpp
+++ b/src/pgen/tests/shock_tube.cpp
@@ -182,9 +182,9 @@ void ProblemGenerator::ShockTube(ParameterInput *pin, const bool restart) {
     wl.vy = pin->GetReal("problem","vl");
     wl.vz = pin->GetReal("problem","wl");
     wl.e  = (pin->GetReal("problem","pl"))/(eos.gamma - 1.0);
+    wl.bx = pin->GetReal("problem","bxl");
     wl.by = pin->GetReal("problem","byl");
     wl.bz = pin->GetReal("problem","bzl");
-    Real bx_l = pin->GetReal("problem","bxl");
     // compute Lorentz factor (needed for SR/GR)
     Real u0l = 1.0;
     if (pmbp->pcoord->is_special_relativistic || pmbp->pcoord->is_general_relativistic ||
@@ -202,9 +202,9 @@ void ProblemGenerator::ShockTube(ParameterInput *pin, const bool restart) {
     wr.vy = pin->GetReal("problem","vr");
     wr.vz = pin->GetReal("problem","wr");
     wr.e  = (pin->GetReal("problem","pr"))/(eos.gamma - 1.0);
+    wr.bx = pin->GetReal("problem","bxr");
     wr.by = pin->GetReal("problem","byr");
     wr.bz = pin->GetReal("problem","bzr");
-    Real bx_r = pin->GetReal("problem","bxr");
     // compute Lorentz factor (needed for SR/GR)
     Real u0r = 1.0;
     if (pmbp->pcoord->is_special_relativistic || pmbp->pcoord->is_general_relativistic ||
@@ -229,22 +229,22 @@ void ProblemGenerator::ShockTube(ParameterInput *pin, const bool restart) {
         Real &x1max = size.d_view(m).x1max;
         int nx1 = indcs.nx1;
         x = CellCenterX(i-is, nx1, x1min, x1max);
-        bxl = bx_l; byl = wl.by; bzl = wl.bz;
-        bxr = bx_r; byr = wr.by; bzr = wr.bz;
+        bxl = wl.bx; byl = wl.by; bzl = wl.bz;
+        bxr = wr.bx; byr = wr.by; bzr = wr.bz;
       } else if (shk_dir_ == 2) {
         Real &x2min = size.d_view(m).x2min;
         Real &x2max = size.d_view(m).x2max;
         int nx2 = indcs.nx2;
         x = CellCenterX(j-js, nx2, x2min, x2max);
-        bxl = wl.bz; byl = bx_l; bzl = wl.by;
-        bxr = wr.bz; byr = bx_r; bzr = wr.by;
+        bxl = wl.bz; byl = wl.bx; bzl = wl.by;
+        bxr = wr.bz; byr = wr.bx; bzr = wr.by;
       } else {
         Real &x3min = size.d_view(m).x3min;
         Real &x3max = size.d_view(m).x3max;
         int nx3 = indcs.nx3;
         x = CellCenterX(k-ks, nx3, x3min, x3max);
-        bxl = wl.by; byl = wl.bz; bzl = bx_l;
-        bxr = wr.by; byr = wr.bz; bzr = bx_r;
+        bxl = wl.by; byl = wl.bz; bzl = wl.bx;
+        bxr = wr.by; byr = wr.bz; bzr = wr.bx;
       }
 
       // in SR/GR, primitive variables use spatial components of 4-vel u^i = gamma * v^i

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -28,11 +28,6 @@ namespace radiation {
 // constructor, initializes data structures and parameters
 
 Radiation::Radiation(MeshBlockPack *ppack, ParameterInput *pin) :
-    pmy_pack(ppack),
-    i0("i0",1,1,1,1,1),
-    i1("i1",1,1,1,1,1),
-    iflx("iflx",1,1,1,1,1),
-    divfa("divfa",1,1,1,1,1),
     nh_c("nh_c",1,1),
     nh_f("nh_f",1,1,1),
     tet_c("tet_c",1,1,1,1,1,1),
@@ -41,7 +36,12 @@ Radiation::Radiation(MeshBlockPack *ppack, ParameterInput *pin) :
     tet_d2_x2f("tet_d2_x2f",1,1,1,1,1),
     tet_d3_x3f("tet_d3_x3f",1,1,1,1,1),
     na("na",1,1,1,1,1,1),
-    norm_to_tet("norm_to_tet",1,1,1,1,1,1) {
+    norm_to_tet("norm_to_tet",1,1,1,1,1,1),
+    i0("i0",1,1,1,1,1),
+    i1("i1",1,1,1,1,1),
+    iflx("iflx",1,1,1,1,1),
+    divfa("divfa",1,1,1,1,1),
+    pmy_pack(ppack) {
   // Check for general relativity
   if (!(pmy_pack->pcoord->is_general_relativistic)) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__

--- a/src/radiation/radiation_source.cpp
+++ b/src/radiation/radiation_source.cpp
@@ -77,7 +77,7 @@ TaskStatus Radiation::RadFluidCoupling(Driver *pdriver, int stage) {
   }
 
   // Extract adiabatic index
-  Real gm1;
+  Real gm1 = 0.0;
   if (is_hydro_enabled_) {
     gm1 = pmy_pack->phydro->peos->eos_data.gamma - 1.0;
   } else if (is_mhd_enabled_) {

--- a/src/radiation/radiation_tetrad.cpp
+++ b/src/radiation/radiation_tetrad.cpp
@@ -244,14 +244,14 @@ void Radiation::SetOrthonormalTetrad() {
       ComputeTetrad(x1v,x2v,x3v,flat,spin,glower,gupper,dgx,dgy,dgz,e,e_cov,omega);
 
       // Minkowski metric
-      Real eta[4][4] = {0.0};
+      Real eta[4][4] = {};
       eta[0][0] = -1.0;
       eta[1][1] = 1.0;
       eta[2][2] = 1.0;
       eta[3][3] = 1.0;
 
       // Calculate normal-to-coordinate transformation
-      Real norm_to_coord[4][4] = {0.0};
+      Real norm_to_coord[4][4] = {};
       Real alpha = 1.0/sqrt(-gupper[0][0]);
       norm_to_coord[0][0] = 1.0/alpha;
       norm_to_coord[1][0] = -alpha*gupper[0][1];

--- a/src/radiation/radiation_tetrad.hpp
+++ b/src/radiation/radiation_tetrad.hpp
@@ -53,7 +53,7 @@ void ComputeTetrad(Real x, Real y, Real z, const bool minkowski, const Real a,
   e[3][3] = iwa*wb;
 
   // Set derivatives of tetrad
-  Real de[4][4][4] = {0.0};
+  Real de[4][4][4] = {};
   Real qa = 2.0*SQR(r) - SQR(rad) + SQR(a);
   Real qb = SQR(r) + SQR(a);
   Real qc = 3.0*SQR(a * z)-SQR(r)*SQR(r);
@@ -125,7 +125,7 @@ void ComputeTetrad(Real x, Real y, Real z, const bool minkowski, const Real a,
   de[3][3][3]  = iwa*dwb_dx3 - iwasq*wb*dwa_dx3;
 
   // Stow metric derivatives in a temporary array
-  Real dg[4][4][4] = {0.0};
+  Real dg[4][4][4] = {};
   for (int i=0; i<4; ++i) {
     for (int j=0; j<4; ++j) {
       dg[0][i][j] = 0.0;
@@ -136,15 +136,15 @@ void ComputeTetrad(Real x, Real y, Real z, const bool minkowski, const Real a,
   }
 
   // Set Minkowski metric
-  Real eta[4][4] = {0.0};
+  Real eta[4][4] = {};
   eta[0][0] = -1.0;
   eta[1][1] = 1.0;
   eta[2][2] = 1.0;
   eta[3][3] = 1.0;
 
   // Calculate covariant tetrad, inverse tetrad, and connection coefficients
-  Real ei[4][4] = {0.0};
-  Real gamma[4][4][4] = {0.0};
+  Real ei[4][4] = {};
+  Real gamma[4][4][4] = {};
   for (int i=0; i<4; ++i) {
     for (int j=0; j<4; ++j) {
       ecov[i][j] = 0.0;

--- a/src/shearing_box/orbital_advection_cc.cpp
+++ b/src/shearing_box/orbital_advection_cc.cpp
@@ -226,9 +226,7 @@ TaskStatus OrbitalAdvectionCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
   int nfx = indcs.nx2 + 2*(ng + maxjshift);
 
   auto &mbsize = pmy_pack->pmb->mb_size;
-  auto &mesh_size = pmy_pack->pmesh->mesh_size;
   Real &dt = pmy_pack->pmesh->dt;
-  Real ly = (mesh_size.x2max - mesh_size.x2min);
   Real qo = qshear*omega0;
 
   int scr_lvl=0;

--- a/src/shearing_box/orbital_advection_fc.cpp
+++ b/src/shearing_box/orbital_advection_fc.cpp
@@ -250,7 +250,7 @@ TaskStatus OrbitalAdvectionFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b0,
     if (v==0) {
       // B3 located at x1-cell centers
       x1 = CellCenterX(i-is, nx1, x1min, x1max);
-    } else if (v==1) {
+    } else {
       // B1 located at x1-cell faces
       x1 = LeftEdgeX(i-is, nx1, x1min, x1max);
     }

--- a/src/shearing_box/orbital_advection_fc.cpp
+++ b/src/shearing_box/orbital_advection_fc.cpp
@@ -230,9 +230,7 @@ TaskStatus OrbitalAdvectionFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b0,
   int nfx = indcs.nx2 + 2*(ng + maxjshift);
 
   auto &mbsize = pmy_pack->pmb->mb_size;
-  auto &mesh_size = pmy_pack->pmesh->mesh_size;
   Real &dt = pmy_pack->pmesh->dt;
-  Real ly = (mesh_size.x2max - mesh_size.x2min);
   Real qo = qshear*omega0;
 
   int scr_lvl=0;

--- a/src/shearing_box/shearing_box_cc.cpp
+++ b/src/shearing_box/shearing_box_cc.cpp
@@ -256,6 +256,7 @@ TaskStatus ShearingBoxCC::PackAndSendCC(DvceArray5D<Real> &a, ReconstructionMeth
             int data_size = send_ptr.size();
             int ierr = MPI_Isend(send_ptr.data(), data_size, MPI_ATHENA_REAL, trank, tag,
                                  comm_sbox, &(sendbuf[n].vars_req[3*m + l]));
+            if (ierr != MPI_SUCCESS) {no_errors=false;}
 #endif
           }
         }

--- a/src/shearing_box/shearing_box_fc.cpp
+++ b/src/shearing_box/shearing_box_fc.cpp
@@ -276,6 +276,7 @@ TaskStatus ShearingBoxFC::PackAndSendFC(DvceFaceFld4D<Real> &b,
             int data_size = send_ptr.size();
             int ierr = MPI_Isend(send_ptr.data(), data_size, MPI_ATHENA_REAL, trank, tag,
                                  comm_sbox, &(sendbuf[n].vars_req[3*m + l]));
+            if (ierr != MPI_SUCCESS) {no_errors=false;}
 #endif
           }
         }

--- a/src/srcterms/srcterms.cpp
+++ b/src/srcterms/srcterms.cpp
@@ -228,9 +228,6 @@ void SourceTerms::BeamSource(DvceArray5D<Real> &i0, const Real bdt) {
   int nmb1 = (pmy_pack->nmb_thispack-1);
   int nang1 = (pmy_pack->prad->prgeo->nangles-1);
 
-  auto &excise = pmy_pack->pcoord->coord_data.bh_excise;
-  auto &rad_mask_ = pmy_pack->pcoord->excision_floor;
-
   auto &size = pmy_pack->pmb->mb_size;
   auto &flat = pmy_pack->pcoord->coord_data.is_minkowski;
   auto &spin = pmy_pack->pcoord->coord_data.bh_spin;

--- a/src/srcterms/turb_driver.cpp
+++ b/src/srcterms/turb_driver.cpp
@@ -29,7 +29,6 @@
 // constructor, initializes data structures and parameters
 
 TurbulenceDriver::TurbulenceDriver(MeshBlockPack *pp, ParameterInput *pin) :
-  pmy_pack(pp),
   force("force",1,1,1,1,1),
   force_tmp("force_tmp",1,1,1,1,1),
   xccc("xccc",1),xccs("xccs",1),xcsc("xcsc",1),xcss("xcss",1),
@@ -40,7 +39,8 @@ TurbulenceDriver::TurbulenceDriver(MeshBlockPack *pp, ParameterInput *pin) :
   zscc("zscc",1),zscs("zscs",1),zssc("zssc",1),zsss("zsss",1),
   kx_mode("kx_mode",1),ky_mode("ky_mode",1),kz_mode("kz_mode",1),
   xcos("xcos",1,1,1),xsin("xsin",1,1,1),ycos("ycos",1,1,1),
-  ysin("ysin",1,1,1),zcos("zcos",1,1,1),zsin("zsin",1,1,1) {
+  ysin("ysin",1,1,1),zcos("zcos",1,1,1),zsin("zsin",1,1,1),
+  pmy_pack(pp) {
   // allocate memory for force registers
   int nmb = pmy_pack->nmb_thispack;
   auto &indcs = pmy_pack->pmesh->mb_indcs;

--- a/src/srcterms/turb_driver.cpp
+++ b/src/srcterms/turb_driver.cpp
@@ -837,11 +837,11 @@ TaskStatus TurbulenceDriver::AddForcing(Driver *pdrive, int stage) {
     gcorr = std::sqrt(1.0 - fcorr*fcorr);
   }
 
-  EquationOfState *peos;
+  EquationOfState *peos=NULL;
 
   DvceArray5D<Real> u0, u0_;
   DvceArray5D<Real> w0;
-  DvceFaceFld4D<Real> *bcc0;
+  DvceFaceFld4D<Real> *bcc0=NULL;
   if (pmy_pack->phydro != nullptr) u0 = (pmy_pack->phydro->u0);
   if (pmy_pack->phydro != nullptr) peos = (pmy_pack->phydro->peos);
   if (pmy_pack->pmhd != nullptr) u0 = (pmy_pack->pmhd->u0);

--- a/src/srcterms/turb_driver.cpp
+++ b/src/srcterms/turb_driver.cpp
@@ -283,7 +283,7 @@ void TurbulenceDriver::Initialize() {
 void TurbulenceDriver::IncludeInitializeModesTask(std::shared_ptr<TaskList> tl,
                                                   TaskID start) {
   auto id_init = tl->AddTask(&TurbulenceDriver::InitializeModes, this, start);
-  auto id_add = tl->AddTask(&TurbulenceDriver::AddForcing, this, id_init);
+  tl->AddTask(&TurbulenceDriver::AddForcing, this, id_init);
   return;
 }
 
@@ -297,16 +297,16 @@ void TurbulenceDriver::IncludeAddForcingTask(std::shared_ptr<TaskList> tl, TaskI
   // These must be inserted after update task, but before send_u
   if (pmy_pack->pionn == nullptr) {
     if (pmy_pack->phydro != nullptr) {
-      auto id = tl->InsertTask(&TurbulenceDriver::AddForcing, this,
-                              pmy_pack->phydro->id.flux, pmy_pack->phydro->id.rkupdt);
+      tl->InsertTask(&TurbulenceDriver::AddForcing, this,
+                     pmy_pack->phydro->id.flux, pmy_pack->phydro->id.rkupdt);
     }
     if (pmy_pack->pmhd != nullptr) {
-      auto id = tl->InsertTask(&TurbulenceDriver::AddForcing, this,
-                              pmy_pack->pmhd->id.flux, pmy_pack->pmhd->id.rkupdt);
+      tl->InsertTask(&TurbulenceDriver::AddForcing, this,
+                     pmy_pack->pmhd->id.flux, pmy_pack->pmhd->id.rkupdt);
     }
   } else {
-    auto id = tl->InsertTask(&TurbulenceDriver::AddForcing, this,
-                            pmy_pack->pionn->id.n_flux, pmy_pack->pionn->id.n_rkupdt);
+    tl->InsertTask(&TurbulenceDriver::AddForcing, this,
+                   pmy_pack->pionn->id.n_flux, pmy_pack->pionn->id.n_rkupdt);
   }
 
   return;
@@ -1081,11 +1081,6 @@ TaskStatus TurbulenceDriver::AddForcing(Driver *pdrive, int stage) {
 
         Real dens = u_out.d;
 
-        auto &w = u;
-
-        Real lorentz = sqrt(1. + w.vx*w.vx + w.vy*w.vy + w.vz*w.vz);
-        Real beta = sqrt(w.vx*w.vx + w.vy*w.vy + w.vz*w.vz)/lorentz;
-
         u0(m,IDN,k,j,i) = dens;  // *uA_0*(1.-beta*betaA);
 
         // Does not require knowledge of v
@@ -1124,11 +1119,6 @@ TaskStatus TurbulenceDriver::AddForcing(Driver *pdrive, int stage) {
         Real sz = u_out.mz;
 
         Real dens = u_out.d;
-
-        auto &w = u;
-
-        Real lorentz = sqrt(1. + w.vx*w.vx + w.vy*w.vy + w.vz*w.vz);
-        Real beta = sqrt(w.vx*w.vx + w.vy*w.vy + w.vz*w.vz)/lorentz;
 
         u0(m,IDN,k,j,i) = dens;  //*uA_0*(1.-beta*betaA);
 

--- a/src/srcterms/turb_driver.hpp
+++ b/src/srcterms/turb_driver.hpp
@@ -48,7 +48,6 @@ class TurbulenceDriver {
   void Initialize();
 
  private:
-  bool first_time = true;   // flag to enable initialization on first call
   MeshBlockPack *pmy_pack;  // ptr to MeshBlockPack containing this TurbulenceDriver
 };
 

--- a/src/tasklist/numerical_relativity.hpp
+++ b/src/tasklist/numerical_relativity.hpp
@@ -155,7 +155,6 @@ class NumericalRelativity {
     AddExtraDependencies(dependencies, optional);
     // Add a new task to the queue.
     //std::cout << "Queuing " << name_string << "...\n";
-    auto& queue = SelectQueue(loc);
     SelectQueue(loc).push_back(QueuedTask(name, name_string, false, TaskID(),
       dependencies,
       [=](Driver *d, int s) mutable -> TaskStatus {return (obj->*func)(d,s);}));

--- a/src/utils/cart_grid.cpp
+++ b/src/utils/cart_grid.cpp
@@ -23,10 +23,10 @@
 
 CartesianGrid::CartesianGrid(MeshBlockPack *pmy_pack, Real center[3],
                                     Real extent[3], int numpoints[3], bool is_cheb):
+    interp_vals("interp_vals",1,1,1),
     pmy_pack(pmy_pack),
     interp_indcs("interp_indcs",1,1,1,1),
-    interp_wghts("interp_wghts",1,1,1,1,1),
-    interp_vals("interp_vals",1,1,1) {
+    interp_wghts("interp_wghts",1,1,1,1,1) {
   // initialize parameters for the grid
   // uniform grid or spectral grid
   is_cheby = is_cheb;

--- a/src/utils/derived_vars.cpp
+++ b/src/utils/derived_vars.cpp
@@ -43,8 +43,6 @@ void ComputeDerivedVariable(std::string name, int index, MeshBlockPack* pmbp,
   int &js = indcs.js;  int &je  = indcs.je;
   int &ks = indcs.ks;  int &ke  = indcs.ke;
   auto &size = pmbp->pmb->mb_size;
-  auto &multi_d = pmbp->pmesh->multi_d;
-  auto &three_d = pmbp->pmesh->three_d;
 
   // radiation coordinate frame energy density R^0^0
   if (name.compare("rad_coord_e") == 0) {

--- a/src/utils/lagrange_interpolator.cpp
+++ b/src/utils/lagrange_interpolator.cpp
@@ -22,9 +22,9 @@
 LagrangeInterpolator::LagrangeInterpolator(
   MeshBlockPack *pmy_pack,
   Real rcoords[3]):
-              pmy_pack(pmy_pack),
-              rcoord("rccord", 1), interp_indcs("interp_indcs", 1),
-              interp_wghts("interp_wghts", 1, 1), point_exist(false) {
+              point_exist(false), rcoord("rccord", 1),
+              pmy_pack(pmy_pack), interp_indcs("interp_indcs", 1),
+              interp_wghts("interp_wghts", 1, 1) {
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   // int &is = indcs.is; int &js = indcs.js; int &ks = indcs.ks;
   int &ng = indcs.ng;

--- a/src/utils/spherical_surface.cpp
+++ b/src/utils/spherical_surface.cpp
@@ -24,18 +24,18 @@
 
 SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
                                    Real rad, Real xc, Real yc, Real zc)
-    : pmy_pack(pmy_pack),
+    : ntheta(ntheta),
       radius(rad),
       xc(xc),
       yc(yc),
       zc(zc),
-      ntheta(ntheta),
       int_weights("int_weights", 1),
-      polar_pos("polar_pos", 1, 1),
       cart_pos("cart_pos", 1, 1),
+      polar_pos("polar_pos", 1, 1),
+      interp_vals("interp_vals", 1),
       interp_indcs("interp_indcs", 1, 1),
       interp_wghts("interp_wghts", 1, 1, 1),
-      interp_vals("interp_vals", 1) {
+      pmy_pack(pmy_pack) {
   // reallocate and set interpolation coordinates, indices, and weights
   int &ng = pmy_pack->pmesh->mb_indcs.ng;
   nangles = 2 * ntheta * ntheta;

--- a/src/z4c/cce/cce.cpp
+++ b/src/z4c/cce/cce.cpp
@@ -37,10 +37,8 @@
 
 namespace z4c {
 
-CCE::CCE(Mesh *const pm, ParameterInput *const pin, int index):
-  index(index),
-  pm(pm),
-  pin(pin) {
+CCE::CCE(Mesh *const pm, ParameterInput *const pin, int indx):
+  index(indx) {
   // pointer to meshblockpack
   pmbp = pm->pmb_pack;
 

--- a/src/z4c/cce/cce.cpp
+++ b/src/z4c/cce/cce.cpp
@@ -38,9 +38,9 @@
 namespace z4c {
 
 CCE::CCE(Mesh *const pm, ParameterInput *const pin, int index):
+  index(index),
   pm(pm),
-  pin(pin),
-  index(index) {
+  pin(pin) {
   // pointer to meshblockpack
   pmbp = pm->pmb_pack;
 

--- a/src/z4c/cce/cce.cpp
+++ b/src/z4c/cce/cce.cpp
@@ -165,11 +165,11 @@ void CCE::InterpolateAndDecompose(MeshBlockPack *pmbp) {
     fwrite(&rout, sizeof(Real), 1, cce_file);
     // Write the 4D array to the binary file
     size_t elementsWritten = fwrite(data_real, sizeof(Real), count, cce_file);
-    if (elementsWritten != count) {
+    if (elementsWritten != static_cast<size_t>(count)) {
       perror("Error writing to file");
     }
     elementsWritten = fwrite(data_imag, sizeof(Real), count, cce_file);
-    if (elementsWritten != count) {
+    if (elementsWritten != static_cast<size_t>(count)) {
       perror("Error writing to file");
     }
     // Close the file

--- a/src/z4c/cce/cce.hpp
+++ b/src/z4c/cce/cce.hpp
@@ -33,14 +33,12 @@ class CCE {
   int index;       // radius number/shell number
   Real rin;  // inner radius of shell
   Real rout; // outer radius of shell
-  Mesh *pm;             // mesh
   MeshBlockPack *pmbp;  // meshblockpack
-  ParameterInput *pin;  // param file
 
   int num_l_modes;    // number of l modes = n_theta (angular)
   int num_angular_modes; // total number of angular modes
   int num_n_modes;    // number of n modes = n_radius (radial)
-  int nlmmodes;       // total number of coefficients to store
+  //int nlmmodes;       // total number of coefficients to store (not yet implemented)
 
   int ntheta;         // number of collocation points in theta
   int nphi;           // number of collocation points in phi

--- a/src/z4c/compact_object_tracker.cpp
+++ b/src/z4c/compact_object_tracker.cpp
@@ -32,8 +32,8 @@
 
 //----------------------------------------------------------------------------------------
 CompactObjectTracker::CompactObjectTracker(Mesh *pmesh, ParameterInput *pin, int n):
-              owns_compact_object{false}, pos{NAN, NAN, NAN}, vel{NAN, NAN, NAN},
-              pmesh{pmesh}, out_every{1} {
+              owns_compact_object{false}, vel{NAN, NAN, NAN},
+              pmesh{pmesh}, out_every{1}, pos{NAN, NAN, NAN} {
   std::string nstr = std::to_string(n);
   std::string ofname = pin->GetString("job", "basename") + ".";
   ofname += pin->GetOrAddString("z4c", "filename", "co_");

--- a/src/z4c/fastflow.cpp
+++ b/src/z4c/fastflow.cpp
@@ -38,9 +38,7 @@
 //! \fn FastFlow::FastFlow(MeshBlockPack *pmbp, ParameterInput * pin, int n)
 //! \brief Constructor for FastFlow class.
 FastFlow::FastFlow(MeshBlockPack *pmbp, ParameterInput *pin, int n):
-  pmbp(pmbp),
-  pin(pin),
-  Y0("Y0",1,1), Ys("Ys",1,1), Yc("Yc",1,1),
+  Y0("Y0",1,1), Yc("Yc",1,1), Ys("Ys",1,1),
   dY0dth("dY0dth",1,1), dYcdth("dYcdth",1,1),
   dYsdth("dYsdth",1,1), dYcdph("dYcdph",1,1),
   dYsdph("dYsdph",1,1), dY0dth2("dY0dth2",1,1),
@@ -50,7 +48,8 @@ FastFlow::FastFlow(MeshBlockPack *pmbp, ParameterInput *pin, int n):
   a0("a0",1), ac("ac",1), as("as",1),
   rr("rr",1), rr_dth("rr_dth",1), rr_dph("rr_dph",1),
   rho("rho",1), dg("dg",1,1,1,1,1), g_interp("g_interp",1,1),
-  K_interp("K_interp",1,1), dg_interp("dg_interp",1,1) {
+  K_interp("K_interp",1,1), dg_interp("dg_interp",1,1),
+  pmbp(pmbp), pin(pin) {
   nh = n; // The n-th horizon
   std::string n_str = std::to_string(nh);
 

--- a/src/z4c/fastflow.hpp
+++ b/src/z4c/fastflow.hpp
@@ -93,7 +93,7 @@ class FastFlow {
   int lmpoints; // lmax * lmax
   int nh; // Counter variable
   bool wait_until_punc_are_close;
-  bool use_stored_metric_drvts;
+  [[maybe_unused]] bool use_stored_metric_drvts;
   int nhorizon; // Number of horizons
   std::string flow_function;
   int flowflag = 0;

--- a/src/z4c/horizon_dump.cpp
+++ b/src/z4c/horizon_dump.cpp
@@ -33,8 +33,8 @@
 
 //----------------------------------------------------------------------------------------
 HorizonDump::HorizonDump(MeshBlockPack *pmbp, ParameterInput *pin, int n, int is_common):
-              common_horizon{is_common}, pos{NAN, NAN, NAN},
-              pmbp{pmbp}, horizon_ind{n} {
+              common_horizon{is_common}, horizon_ind{n},
+              pos{NAN, NAN, NAN}, pmbp{pmbp} {
   std::string nstr = std::to_string(n);
 
   pos[0] = pin->GetOrAddReal("z4c", "co_" + nstr + "_x", 0.0);

--- a/src/z4c/horizon_dump.cpp
+++ b/src/z4c/horizon_dump.cpp
@@ -141,7 +141,7 @@ void HorizonDump::SetGridAndInterpolate(Real center[NDIM]) {
     fwrite(&pmbp->pmesh->time, sizeof(Real), 1, etk_output_file);
     // Write the 4D array to the binary file
     size_t elementsWritten = fwrite(data_out, sizeof(Real), count, etk_output_file);
-    if (elementsWritten != count) {
+    if (elementsWritten != static_cast<size_t>(count)) {
       perror("Error writing to file");
     }
     // Close the file

--- a/src/z4c/horizon_dump.cpp
+++ b/src/z4c/horizon_dump.cpp
@@ -265,11 +265,11 @@ void HorizonDump::ETK_setup_parfile() {
             "readBHaHdata::recent_ah_radius_max_filename = \"ah_radius_max_BH_1.txt\"\n");
 
   //if(commondata->time == 0) {
-    fprintf(etk_parfile,
-            "AHFinderDirect::initial_guess_method[1]"
-            "                = \"coordinate sphere\"\n"
-            "AHFinderDirect::initial_guess__coord_sphere__radius[1] = %e\n",
-            r_guess);
+  fprintf(etk_parfile,
+          "AHFinderDirect::initial_guess_method[1]"
+          "                = \"coordinate sphere\"\n"
+          "AHFinderDirect::initial_guess__coord_sphere__radius[1] = %e\n",
+          r_guess);
   /*} else {
     if(BH==LESSMASSIVE_BH_PREMERGER)
       fprintf(etk_parfile,

--- a/src/z4c/tmunu.cpp
+++ b/src/z4c/tmunu.cpp
@@ -21,8 +21,8 @@ char const * const Tmunu::Tmunu_names[Tmunu::N_Tmunu] = {
 //----------------------------------------------------------------------------------------
 // constructor: initializes data structures and parameters
 Tmunu::Tmunu(MeshBlockPack *ppack, ParameterInput *pin):
-  pmy_pack(ppack),
-  u_tmunu("u_tmunu",1,1,1,1,1) {
+  u_tmunu("u_tmunu",1,1,1,1,1),
+  pmy_pack(ppack) {
   int nmb = std::max((ppack->nmb_thispack), (ppack->pmesh->nmb_maxperrank));
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int ncells1 = indcs.nx1 + 2*(indcs.ng);

--- a/src/z4c/z4c.cpp
+++ b/src/z4c/z4c.cpp
@@ -59,16 +59,16 @@ char const * const Z4c::Constraint_names[Z4c::ncon] = {
 // constructor, initializes data structures and parameters
 
 Z4c::Z4c(MeshBlockPack *ppack, ParameterInput *pin) :
-  pmy_pack(ppack),
   u_con("u_con",1,1,1,1,1),
   //u_mat("u_mat",1,1,1,1,1),
   u0("u0 z4c",1,1,1,1,1),
-  coarse_u0("coarse u0 z4c",1,1,1,1,1),
   u1("u1 z4c",1,1,1,1,1),
   u_rhs("u_rhs z4c",1,1,1,1,1),
+  coarse_u0("coarse u0 z4c",1,1,1,1,1),
   u_weyl("u_weyl",1,1,1,1,1),
   coarse_u_weyl("coarse_u_weyl",1,1,1,1,1),
-  pamr(new Z4c_AMR(pin)) {
+  pamr(new Z4c_AMR(pin)),
+  pmy_pack(ppack) {
   // (1) read time-evolution option [already error checked in driver constructor]
   // Then initialize memory and algorithms for reconstruction and Riemann solvers
   std::string evolution_t = pin->GetString("time","evolution");

--- a/src/z4c/z4c_amr.cpp
+++ b/src/z4c/z4c_amr.cpp
@@ -256,7 +256,7 @@ void Z4c_AMR::RefineRadii(MeshBlockPack *pmbp) {
     };
     Real rmin2 = *std::min_element(&r2[0], &r2[8]);
 
-    for (int ir = 0; ir < radius.size(); ++ir) {
+    for (size_t ir = 0; ir < radius.size(); ++ir) {
       if (rmin2 < SQ(radius[ir])) {
         if (level < reflevel[ir]) {
           refine_flag.h_view(m + mbs) = 1;

--- a/src/z4c/z4c_calculate_weyl_scalars.cpp
+++ b/src/z4c/z4c_calculate_weyl_scalars.cpp
@@ -67,7 +67,7 @@ void Z4c::Z4cWeyl(MeshBlockPack *pmbp) {
     Real dotp1 = 0.0;
     Real dotp2 = 0.0;
     Real K = 0.0;            // trace of extrinsic curvature
-    Real KK = 0.0;           // K^a_b K^b_a
+//    Real KK = 0.0;           // K^a_b K^b_a (not used)
 
     // Vectors
     AthenaPointTensor<Real, TensorSymm::NONE, 3, 1> Gamma_u;
@@ -228,11 +228,11 @@ void Z4c::Z4cWeyl(MeshBlockPack *pmbp) {
       }
       K += K_ud(a,a);
     }
-    // K^a_b K^b_a
-    for(int a = 0; a < 3; ++a)
-    for(int b = 0; b < 3; ++b) {
-      KK += K_ud(a,b) * K_ud(b,a);
-    }
+    // K^a_b K^b_a (not used)
+//    for(int a = 0; a < 3; ++a)
+//    for(int b = 0; b < 3; ++b) {
+//      KK += K_ud(a,b) * K_ud(b,a);
+//    }
     // Covariant derivative of K
     for(int a = 0; a < 3; ++a)
     for(int b = 0; b < 3; ++b)


### PR DESCRIPTION
Lots of changes to lots of files to remove warnings when compiled with -Wall.  Note the warnings generated by clang and gcc are different, so both were tested.  No important bugs were found, but this PR cleans up the code significantly.

Note there are still warnings present in the eos logs.hpp file, however this is best fixed using extensions in C++20 and so will wait until we bump to Kokkos 5.x and adopt C++20 as a minimum standard.

This PR also fixes some important bugs in derived variables and IMEX3 integrator found by users over the last year.

This PR replaces #649, #650 (thanks Kyle!), and #754