### PR TITLE
Changed estimate of buffer sizes during LB

### DIFF
--- a/src/mesh/load_balance.cpp
+++ b/src/mesh/load_balance.cpp
@@ -127,7 +127,7 @@ void MeshRefinement::InitRecvAMR(int nleaf) {
   }
   if (nmb_recv == 0) return;  // nothing to do
 
-  // allocate array of recv buffers
+  // allocate array of recv buffer metadata
   Kokkos::realloc(recvbuf, nmb_recv);
   recv_req = new MPI_Request[nmb_recv];
   for (int n=0; n<nmb_recv; ++n) {
@@ -153,7 +153,7 @@ void MeshRefinement::InitRecvAMR(int nleaf) {
   }
 
   // Step 2. (InitRecvAMR)
-  // loop over new MBs on this rank, initialize recv buffers
+  // loop over new MBs on this rank, initialize recv buffer metadata
   auto &indcs = pmy_mesh->mb_indcs;
   auto &is = indcs.is, &ie = indcs.ie;
   auto &js = indcs.js, &je = indcs.je;
@@ -259,7 +259,7 @@ void MeshRefinement::InitRecvAMR(int nleaf) {
       }
     }
   }
-  // Sync dual array, reallocate receive data array
+  // Sync dual array
   recvbuf.template modify<HostMemSpace>();
   recvbuf.template sync<DevExeSpace>();
   // Note: No need to reallocate recv_data buffer as it is fixed length
@@ -379,7 +379,7 @@ void MeshRefinement::PackAndSendAMR(int nleaf) {
 
   if (nmb_send == 0) return;  // nothing to do
 
-  // allocate array of send buffers
+  // allocate array of send buffer metadata
   Kokkos::realloc(sendbuf, nmb_send);
   send_req = new MPI_Request[nmb_send];
   for (int n=0; n<nmb_send; ++n) {
@@ -405,7 +405,7 @@ void MeshRefinement::PackAndSendAMR(int nleaf) {
   }
 
   // Step 2. (PackAndSendAMR)
-  // loop over old MBs on this rank, initialize send buffers
+  // loop over old MBs on this rank, initialize send buffer metadata
   auto &indcs = pmy_mesh->mb_indcs;
   auto &is = indcs.is, &ie = indcs.ie;
   auto &js = indcs.js, &je = indcs.je;
@@ -513,7 +513,7 @@ void MeshRefinement::PackAndSendAMR(int nleaf) {
       }
     }
   }
-  // Sync dual array, reallocate send data array
+  // Sync dual array
   sendbuf.template modify<HostMemSpace>();
   sendbuf.template sync<DevExeSpace>();
   // Note: No need to reallocate send_date as it is fixed length

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -111,8 +111,11 @@ MeshRefinement::MeshRefinement(Mesh *pm, ParameterInput *pin) :
     ncc_tosend += (pm->pmb_pack->pz4c->nz4c);
   }
   int nmb = std::max((pm->pmb_pack->nmb_thispack), (pm->nmb_maxperrank));
-  auto &indcs = pm->mb_indcs;
-  int ndata = nmb*(ncc_tosend + nfc_tosend)*(indcs.nx1)*(indcs.nx2)*(indcs.nx3);
+  // number of cells per MB, including ghost zones
+  int ncells = (pm->mb_indcs.nx1 + 2*pm->mb_indcs.ng);
+  if (pm->multi_d) ncells *= (pm->mb_indcs.nx2 + 2*pm->mb_indcs.ng);
+  if (pm->three_d) ncells *= (pm->mb_indcs.nx3 + 2*pm->mb_indcs.ng);
+  int ndata = nmb*(ncc_tosend + nfc_tosend)*ncells;
   Kokkos::realloc(recv_data, ndata);
   Kokkos::realloc(send_data, ndata);
 #endif

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -19,12 +19,12 @@ inline int CreateAMR_MPI_Tag(int lid, int ox1, int ox2, int ox3) {
 }
 
 //----------------------------------------------------------------------------------------
-//! \struct AMRBuffer
+//! \struct AMRBufferData
 //! \brief container for index ranges, storage, and flags for AMR buffers used with load
 //! balancing.
 
 #if MPI_PARALLEL_ENABLED
-struct AMRBuffer {
+struct AMRBufferData {
   int bis, bie, bjs, bje, bks, bke;  // start/end indices of data to be packed/unpacked
   int cntcc, cntfc;          // number of CC and FC array elements to be sent/recv per var
   int cnt;                   // total number of elements stored in buffer incl all vars
@@ -90,10 +90,10 @@ class MeshRefinement {
 
 #if MPI_PARALLEL_ENABLED
   int nmb_send, nmb_recv;
-  MPI_Comm amr_comm;                         // unique communicator for AMR
-  DualArray1D<AMRBuffer> sendbuf, recvbuf; // send/recv buffers
+  MPI_Comm amr_comm;                           // unique communicator for AMR
+  DualArray1D<AMRBufferData> sendbuf, recvbuf; // send/recv buffer metadata
   MPI_Request *send_req, *recv_req;
-  DvceArray1D<Real> send_data, recv_data;    // send/recv device data
+  DvceArray1D<Real> send_data, recv_data;      // send/recv device data
 #endif
 
   // functions


### PR DESCRIPTION
The method used to estimate the size of the load balancing buffers with AMR was updated.  Old method did not
include ghost zones in estimate, and this can lead to segfault when there are many small MBs.