### PR TITLE
Fix CUDA build: copy file-scope fac to local for device lambda capture

### DIFF
--- a/src/pgen/fluids/blast.cpp
+++ b/src/pgen/fluids/blast.cpp
@@ -418,6 +418,7 @@ void SetADMVariablesToFLRW(MeshBlockPack *pmbp) {
 
   Real a = 1.0 + fac*(t-t0);
   Real a2 = a*a;
+  Real fac_ = fac;   // local copy: capturable by device lambda
   par_for("update_adm_vars", DevExeSpace(), 0,nmb-1,0,(n3-1),0,(n2-1),0,(n1-1),
   KOKKOS_LAMBDA(int m, int k, int j, int i) {
     Real &x1min = size.d_view(m).x1min;
@@ -439,12 +440,12 @@ void SetADMVariablesToFLRW(MeshBlockPack *pmbp) {
     adm.g_dd(m,1,2,k,j,i) = 0.0;
     adm.g_dd(m,2,2,k,j,i) = a2;
 
-    adm.vK_dd(m,0,0,k,j,i) = -a*fac;
+    adm.vK_dd(m,0,0,k,j,i) = -a*fac_;
     adm.vK_dd(m,0,1,k,j,i) = 0.0;
     adm.vK_dd(m,0,2,k,j,i) = 0.0;
-    adm.vK_dd(m,1,1,k,j,i) = -a*fac;
+    adm.vK_dd(m,1,1,k,j,i) = -a*fac_;
     adm.vK_dd(m,1,2,k,j,i) = 0.0;
-    adm.vK_dd(m,2,2,k,j,i) = -a*fac;
+    adm.vK_dd(m,2,2,k,j,i) = -a*fac_;
 
     adm.alpha(m,k,j,i) = 1.0;
     adm.beta_u(m,0,k,j,i) = 0.0;


### PR DESCRIPTION
While setting up on Bridges-2 I hit a CUDA build failure in pgen/fluids/blast.cpp: file-scope variable fac is referenced inside the par_for kernel (lines 442–447), and device lambdas can't see host globals - nvcc errors with "identifier undefined in device code." Fixed it locally by copying to a local (Real fac_ = fac;) before the kernel so it's captured by value. Builds and runs on V100 now.