### PR TITLE
Free MPI datatype after particle count exchange

### DIFF
--- a/src/bvals/bvals_part.cpp
+++ b/src/bvals/bvals_part.cpp
@@ -240,6 +240,7 @@ TaskStatus ParticlesBoundaryValues::CountSendsAndRecvs() {
   MPI_Allgatherv(MPI_IN_PLACE, nsends_eachrank[global_variable::my_rank],
                    mpi_ituple, sends_allranks.data(), nsends_eachrank.data(),
                    nsends_displ.data(), mpi_ituple, mpi_comm_part);
+  MPI_Type_free(&mpi_ituple);
 #endif
   return TaskStatus::complete;
 }


### PR DESCRIPTION
`mpi_ituple` is created and committed on every call to
`CountSendsAndRecvs()`, but it is never released, so MPI datatype
resources accumulate during long particle runs.

I found this after an MPI test for a dust module was OOM-killed. The
dust integration performs particle communication at every IMEX stage,
which exercises this path more frequently than the standard particle
update.

This adds the matching `MPI_Type_free()` immediately after
`MPI_Allgatherv()`, pairing the `MPI_Type_commit()` introduced in
IAS-Astrophysics/athenak@7db51b98f7c11c57456059a539aa073b23ac83af.