### PR TITLE
Fix HLLD fluxes for weak nonzero normal magnetic fields

### DIFF
--- a/src/mhd/rsolvers/hlld_mhd.hpp
+++ b/src/mhd/rsolvers/hlld_mhd.hpp
@@ -214,42 +214,61 @@ void HLLD(TeamMember_t const &member, const EOS_Data &eos,
       // (KGF): group transverse by, bz terms for floating-point associativity symmetry
       urst.e = (sdr*ur.e - ptr*wr_ivx + ptst*spd[2] +
                 bxi*(wr_ivx*bxi + (wr_ivy*ur.by + wr_ivz*ur.bz) - vbstr))*sdmr_inv;
-      // ul** and ur**
-      Real invsumd = 1.0/(sqrtdl + sqrtdr);
-      Real bxsig = (bxi > 0.0 ? 1.0 : -1.0);
+      // ul** and ur**.  At exactly Bx=0, the rotational waves collapse onto the
+      // contact, so no double-star flux is selected below.
+      if (bxi == 0.0) {
+        uldst.d = ulst.d;
+        uldst.mx = ulst.mx;
+        uldst.my = ulst.my;
+        uldst.mz = ulst.mz;
+        uldst.e = ulst.e;
+        uldst.by = ulst.by;
+        uldst.bz = ulst.bz;
 
-      uldst.d = ulst.d;
-      urdst.d = urst.d;
+        urdst.d = urst.d;
+        urdst.mx = urst.mx;
+        urdst.my = urst.my;
+        urdst.mz = urst.mz;
+        urdst.e = urst.e;
+        urdst.by = urst.by;
+        urdst.bz = urst.bz;
+      } else {
+        Real invsumd = 1.0/(sqrtdl + sqrtdr);
+        Real bxsig = (bxi > 0.0 ? 1.0 : -1.0);
 
-      uldst.mx = ulst.mx;
-      urdst.mx = urst.mx;
+        uldst.d = ulst.d;
+        urdst.d = urst.d;
 
-      // eqn (59) of M&K
-      Real tmp = invsumd*(sqrtdl*(ulst.my*ulst_d_inv) + sqrtdr*(urst.my*urst_d_inv) +
-                          bxsig*(urst.by - ulst.by));
-      uldst.my = uldst.d * tmp;
-      urdst.my = urdst.d * tmp;
+        uldst.mx = ulst.mx;
+        urdst.mx = urst.mx;
 
-      // eqn (60) of M&K
-      tmp = invsumd*(sqrtdl*(ulst.mz*ulst_d_inv) + sqrtdr*(urst.mz*urst_d_inv) +
-                     bxsig*(urst.bz - ulst.bz));
-      uldst.mz = uldst.d * tmp;
-      urdst.mz = urdst.d * tmp;
+        // eqn (59) of M&K
+        Real tmp = invsumd*(sqrtdl*(ulst.my*ulst_d_inv) + sqrtdr*(urst.my*urst_d_inv) +
+                            bxsig*(urst.by - ulst.by));
+        uldst.my = uldst.d * tmp;
+        urdst.my = urdst.d * tmp;
 
-      // eqn (61) of M&K
-      tmp = invsumd*(sqrtdl*urst.by + sqrtdr*ulst.by +
-                     bxsig*sqrtdl*sqrtdr*((urst.my*urst_d_inv) - (ulst.my*ulst_d_inv)));
-      uldst.by = urdst.by = tmp;
+        // eqn (60) of M&K
+        tmp = invsumd*(sqrtdl*(ulst.mz*ulst_d_inv) + sqrtdr*(urst.mz*urst_d_inv) +
+                       bxsig*(urst.bz - ulst.bz));
+        uldst.mz = uldst.d * tmp;
+        urdst.mz = urdst.d * tmp;
 
-      // eqn (62) of M&K
-      tmp = invsumd*(sqrtdl*urst.bz + sqrtdr*ulst.bz +
-                     bxsig*sqrtdl*sqrtdr*((urst.mz*urst_d_inv) - (ulst.mz*ulst_d_inv)));
-      uldst.bz = urdst.bz = tmp;
+        // eqn (61) of M&K
+        tmp = invsumd*(sqrtdl*urst.by + sqrtdr*ulst.by + bxsig*sqrtdl*sqrtdr*
+                       ((urst.my*urst_d_inv) - (ulst.my*ulst_d_inv)));
+        uldst.by = urdst.by = tmp;
 
-      // eqn (63) of M&K
-      tmp = spd[2]*bxi + (uldst.my*uldst.by + uldst.mz*uldst.bz)/uldst.d;
-      uldst.e = ulst.e - sqrtdl*bxsig*(vbstl - tmp);
-      urdst.e = urst.e + sqrtdr*bxsig*(vbstr - tmp);
+        // eqn (62) of M&K
+        tmp = invsumd*(sqrtdl*urst.bz + sqrtdr*ulst.bz + bxsig*sqrtdl*sqrtdr*
+                       ((urst.mz*urst_d_inv) - (ulst.mz*ulst_d_inv)));
+        uldst.bz = urdst.bz = tmp;
+
+        // eqn (63) of M&K
+        tmp = spd[2]*bxi + (uldst.my*uldst.by + uldst.mz*uldst.bz)/uldst.d;
+        uldst.e = ulst.e - sqrtdl*bxsig*(vbstl - tmp);
+        urdst.e = urst.e + sqrtdr*bxsig*(vbstr - tmp);
+      }
 
       //--- Step 6.  Compute flux
       uldst.d = spd[1] * (uldst.d - ulst.d);

--- a/src/mhd/rsolvers/hlld_mhd.hpp
+++ b/src/mhd/rsolvers/hlld_mhd.hpp
@@ -214,47 +214,42 @@ void HLLD(TeamMember_t const &member, const EOS_Data &eos,
       // (KGF): group transverse by, bz terms for floating-point associativity symmetry
       urst.e = (sdr*ur.e - ptr*wr_ivx + ptst*spd[2] +
                 bxi*(wr_ivx*bxi + (wr_ivy*ur.by + wr_ivz*ur.bz) - vbstr))*sdmr_inv;
-      // ul** and ur** - if Bx is near zero, same as *-states
-      if (0.5*bxsq < (HLLD_SMALL_NUMBER)*ptst) {
-        uldst = ulst;
-        urdst = urst;
-      } else {
-        Real invsumd = 1.0/(sqrtdl + sqrtdr);
-        Real bxsig = (bxi > 0.0 ? 1.0 : -1.0);
+      // ul** and ur**
+      Real invsumd = 1.0/(sqrtdl + sqrtdr);
+      Real bxsig = (bxi > 0.0 ? 1.0 : -1.0);
 
-        uldst.d = ulst.d;
-        urdst.d = urst.d;
+      uldst.d = ulst.d;
+      urdst.d = urst.d;
 
-        uldst.mx = ulst.mx;
-        urdst.mx = urst.mx;
+      uldst.mx = ulst.mx;
+      urdst.mx = urst.mx;
 
-        // eqn (59) of M&K
-        Real tmp = invsumd*(sqrtdl*(ulst.my*ulst_d_inv) + sqrtdr*(urst.my*urst_d_inv) +
-                            bxsig*(urst.by - ulst.by));
-        uldst.my = uldst.d * tmp;
-        urdst.my = urdst.d * tmp;
+      // eqn (59) of M&K
+      Real tmp = invsumd*(sqrtdl*(ulst.my*ulst_d_inv) + sqrtdr*(urst.my*urst_d_inv) +
+                          bxsig*(urst.by - ulst.by));
+      uldst.my = uldst.d * tmp;
+      urdst.my = urdst.d * tmp;
 
-        // eqn (60) of M&K
-        tmp = invsumd*(sqrtdl*(ulst.mz*ulst_d_inv) + sqrtdr*(urst.mz*urst_d_inv) +
-                       bxsig*(urst.bz - ulst.bz));
-        uldst.mz = uldst.d * tmp;
-        urdst.mz = urdst.d * tmp;
+      // eqn (60) of M&K
+      tmp = invsumd*(sqrtdl*(ulst.mz*ulst_d_inv) + sqrtdr*(urst.mz*urst_d_inv) +
+                     bxsig*(urst.bz - ulst.bz));
+      uldst.mz = uldst.d * tmp;
+      urdst.mz = urdst.d * tmp;
 
-        // eqn (61) of M&K
-        tmp = invsumd*(sqrtdl*urst.by + sqrtdr*ulst.by +
-                       bxsig*sqrtdl*sqrtdr*((urst.my*urst_d_inv) - (ulst.my*ulst_d_inv)));
-        uldst.by = urdst.by = tmp;
+      // eqn (61) of M&K
+      tmp = invsumd*(sqrtdl*urst.by + sqrtdr*ulst.by +
+                     bxsig*sqrtdl*sqrtdr*((urst.my*urst_d_inv) - (ulst.my*ulst_d_inv)));
+      uldst.by = urdst.by = tmp;
 
-        // eqn (62) of M&K
-        tmp = invsumd*(sqrtdl*urst.bz + sqrtdr*ulst.bz +
-                       bxsig*sqrtdl*sqrtdr*((urst.mz*urst_d_inv) - (ulst.mz*ulst_d_inv)));
-        uldst.bz = urdst.bz = tmp;
+      // eqn (62) of M&K
+      tmp = invsumd*(sqrtdl*urst.bz + sqrtdr*ulst.bz +
+                     bxsig*sqrtdl*sqrtdr*((urst.mz*urst_d_inv) - (ulst.mz*ulst_d_inv)));
+      uldst.bz = urdst.bz = tmp;
 
-        // eqn (63) of M&K
-        tmp = spd[2]*bxi + (uldst.my*uldst.by + uldst.mz*uldst.bz)/uldst.d;
-        uldst.e = ulst.e - sqrtdl*bxsig*(vbstl - tmp);
-        urdst.e = urst.e + sqrtdr*bxsig*(vbstr - tmp);
-      }
+      // eqn (63) of M&K
+      tmp = spd[2]*bxi + (uldst.my*uldst.by + uldst.mz*uldst.bz)/uldst.d;
+      uldst.e = ulst.e - sqrtdl*bxsig*(vbstl - tmp);
+      urdst.e = urst.e + sqrtdr*bxsig*(vbstr - tmp);
 
       //--- Step 6.  Compute flux
       uldst.d = spd[1] * (uldst.d - ulst.d);
@@ -316,6 +311,15 @@ void HLLD(TeamMember_t const &member, const EOS_Data &eos,
         flxi.e  = fl.e  + ulst.e;
         flxi.by = fl.by + ulst.by;
         flxi.bz = fl.bz + ulst.bz;
+      } else if (spd[3] <= 0.0) {
+        // return Fr*
+        flxi.d = fr.d  + urst.d;
+        flxi.mx = fr.mx + urst.mx;
+        flxi.my = fr.my + urst.my;
+        flxi.mz = fr.mz + urst.mz;
+        flxi.e  = fr.e  + urst.e;
+        flxi.by = fr.by + urst.by;
+        flxi.bz = fr.bz + urst.bz;
       } else if (spd[2] >= 0.0) {
         // return Fl**
         flxi.d = fl.d  + ulst.d + uldst.d;
@@ -325,7 +329,7 @@ void HLLD(TeamMember_t const &member, const EOS_Data &eos,
         flxi.e  = fl.e  + ulst.e + uldst.e;
         flxi.by = fl.by + ulst.by + uldst.by;
         flxi.bz = fl.bz + ulst.bz + uldst.bz;
-      } else if (spd[3] > 0.0) {
+      } else {
         // return Fr**
         flxi.d = fr.d + urst.d + urdst.d;
         flxi.mx = fr.mx + urst.mx + urdst.mx;
@@ -334,15 +338,6 @@ void HLLD(TeamMember_t const &member, const EOS_Data &eos,
         flxi.e  = fr.e + urst.e + urdst.e;
         flxi.by = fr.by + urst.by + urdst.by;
         flxi.bz = fr.bz + urst.bz + urdst.bz;
-      } else {
-        // return Fr*
-        flxi.d = fr.d  + urst.d;
-        flxi.mx = fr.mx + urst.mx;
-        flxi.my = fr.my + urst.my;
-        flxi.mz = fr.mz + urst.mz;
-        flxi.e  = fr.e  + urst.e;
-        flxi.by = fr.by + urst.by;
-        flxi.bz = fr.bz + urst.bz;
       }
 
       flx(m,IDN,k,j,i) = flxi.d;

--- a/tst/test_suite/nr/test_nr_hlld_weak_bx_cpu.py
+++ b/tst/test_suite/nr/test_nr_hlld_weak_bx_cpu.py
@@ -1,14 +1,24 @@
 """Regression test for HLLD with a weak, nonzero face-normal magnetic field."""
 
 import numpy as np
+import pytest
 
 import athena_read
 import test_suite.testutils as testutils
 
 
-def test_moving_rotational_discontinuity():
-    """Check that HLLD upwinds a weak-Bx rotational discontinuity."""
-    basename = "hlld_weak_bx"
+@pytest.mark.parametrize(
+    ("case", "normal_velocity", "normal_field", "wave_speed"),
+    [
+        ("left_double_star", 0.005, 0.01, -0.005),
+        ("right_double_star", -0.005, -0.01, 0.005),
+    ],
+)
+def test_moving_rotational_discontinuity(
+    case, normal_velocity, normal_field, wave_speed
+):
+    """Check both double-star fluxes for a weak-Bx rotational discontinuity."""
+    basename = f"hlld_weak_bx_{case}"
     flags = [
         f"job/basename={basename}",
         "mesh/nx1=16",
@@ -22,18 +32,18 @@ def test_moving_rotational_discontinuity():
         "mhd/rsolver=hlld",
         "problem/dl=1.0",
         "problem/pl=1.0",
-        "problem/ul=0.005",
+        f"problem/ul={normal_velocity}",
         "problem/vl=-1.0",
         "problem/wl=0.0",
-        "problem/bxl=0.01",
+        f"problem/bxl={normal_field}",
         "problem/byl=-1.0",
         "problem/bzl=0.0",
         "problem/dr=1.0",
         "problem/pr=1.0",
-        "problem/ur=0.005",
+        f"problem/ur={normal_velocity}",
         "problem/vr=1.0",
         "problem/wr=0.0",
-        "problem/bxr=0.01",
+        f"problem/bxr={normal_field}",
         "problem/byr=1.0",
         "problem/bzr=0.0",
         "output1/variable=mhd_w_bcc",
@@ -46,7 +56,7 @@ def test_moving_rotational_discontinuity():
         data = athena_read.tab(f"tab/{basename}.mhd_w_bcc.00001.tab")
 
         dx1 = 1.0 / 16.0
-        discontinuity = -0.005 * data["time"]
+        discontinuity = wave_speed * data["time"]
         left_faces = data["x1v"] - 0.5 * dx1
         left_fraction = np.clip((discontinuity - left_faces) / dx1, 0.0, 1.0)
         exact = 1.0 - 2.0 * left_fraction

--- a/tst/test_suite/nr/test_nr_hlld_weak_bx_cpu.py
+++ b/tst/test_suite/nr/test_nr_hlld_weak_bx_cpu.py
@@ -1,0 +1,60 @@
+"""Regression test for HLLD with a weak, nonzero face-normal magnetic field."""
+
+import numpy as np
+
+import athena_read
+import test_suite.testutils as testutils
+
+
+def test_moving_rotational_discontinuity():
+    """Check that HLLD upwinds a weak-Bx rotational discontinuity."""
+    basename = "hlld_weak_bx"
+    flags = [
+        f"job/basename={basename}",
+        "mesh/nx1=16",
+        "meshblock/nx1=16",
+        "mesh/nghost=2",
+        "time/integrator=rk2",
+        "time/cfl_number=0.1",
+        "time/nlim=1",
+        "time/tlim=1.0",
+        "mhd/reconstruct=dc",
+        "mhd/rsolver=hlld",
+        "problem/dl=1.0",
+        "problem/pl=1.0",
+        "problem/ul=0.005",
+        "problem/vl=-1.0",
+        "problem/wl=0.0",
+        "problem/bxl=0.01",
+        "problem/byl=-1.0",
+        "problem/bzl=0.0",
+        "problem/dr=1.0",
+        "problem/pr=1.0",
+        "problem/ur=0.005",
+        "problem/vr=1.0",
+        "problem/wr=0.0",
+        "problem/bxr=0.01",
+        "problem/byr=1.0",
+        "problem/bzr=0.0",
+        "output1/variable=mhd_w_bcc",
+        "output1/data_format=%24.17e",
+        "output1/dt=1.0",
+    ]
+
+    try:
+        assert testutils.run("inputs/rj2a.athinput", flags)
+        data = athena_read.tab(f"tab/{basename}.mhd_w_bcc.00001.tab")
+
+        dx1 = 1.0 / 16.0
+        discontinuity = -0.005 * data["time"]
+        left_faces = data["x1v"] - 0.5 * dx1
+        left_fraction = np.clip((discontinuity - left_faces) / dx1, 0.0, 1.0)
+        exact = 1.0 - 2.0 * left_fraction
+
+        vely_error = np.max(np.abs(data["vely"] - exact))
+        by_error = np.max(np.abs(data["bcc2"] - exact))
+        assert vely_error < 2.0e-5
+        assert by_error < 2.0e-5
+        assert np.max(np.abs(data["vely"])) <= 1.0 + 1.0e-8
+    finally:
+        testutils.cleanup()


### PR DESCRIPTION
## Summary

This fixes a weak-normal-field defect in the ideal-EOS HLLD solver.

- Remove the finite weak-field cutoff that collapsed double-star states onto single-star states.
- Retain the shortcut only at exactly `B_n = 0`, where rotational waves collapse onto the contact and no double-star flux can be selected.
- Restore the reference HLLD wave-fan selection order.
- Add symmetric regressions covering `F_L**`, `F_R**`, both signs of `B_n`, and rotational-state sign handling.

This is an adapted port of [Athena++ PR 620](https://github.com/PrincetonUniversity/athena/pull/620) ([reference commit](https://github.com/PrincetonUniversity/athena/commit/0e3ca3dde5a6faffcfd72d8e41e5df0db1ce5111)): it removes the finite weak-field cutoff while retaining an exact-zero shortcut.

This addresses the HLLD correctness portion of #601. It does not close that issue because AthenaK does not currently include the LHLLD solver discussed there.

## Root cause

`B_n` is the magnetic-field component normal to the cell face (local `bxi` after coordinate permutation). The old solver replaced `U_L**` and `U_R**` with single-star states when `0.5 B_n^2 < 1e-4 p_t*`. This includes finite, dynamically meaningful fields.

For finite `B_n`, rotational waves remain separated from the contact at `S_L* = S_M - |B_n|/sqrt(rho_L*)` and `S_R* = S_M + |B_n|/sqrt(rho_R*)`. Collapsing them discards the transverse Rankine-Hugoniot correction and can return `F_L*` or `F_R*` where `F_L**` or `F_R**` is required, producing transverse velocity and field overshoots.

At exactly `B_n = 0`, `S_L* = S_M = S_R*`; double-star regions are unreachable. That path copies only the seven initialized star-state fields and avoids copying the unused, uninitialized `bx` member.

## Focused reproducer

One RK2 step of a 16-cell moving rotational discontinuity, donor-cell reconstruction, HLLD, CFL 0.1, ideal EOS with `rho = p = 1`, and transverse states `v_t, B_t: -1 -> +1`:

| Path | `v_n` | `B_n` | exact speed |
| --- | ---: | ---: | ---: |
| `F_L**` | +0.005 | +0.010 | -0.005 |
| `F_R**` | -0.005 | -0.010 | +0.005 |

| Measurement | Legacy | Corrected |
| --- | ---: | ---: |
| L-infinity error, `v_t` | 6.104872656e-4 | 3.874392791e-6 |
| L-infinity error, `B_t` | 6.105933597e-4 | 1.898416560e-6 |
| `v_t` overshoot | 6.067976387e-4 | 0 |

Both symmetric cases give the same result. The committed regression requires errors below `2e-5` and no overshoot.

## Additional validation

- 36-case sweep: `v_n = +/-0.005`; `B_n = 0, +/-0.005, +/-0.010, +/-0.016, +/-0.020`; both Alfven correlations and double-star paths. Corrected maxima: `2.119350234e-5` in `v_t`, `9.421971221e-6` in `B_t`, zero overshoot.
- Rotating the critical case through x1/x2/x3 produced identical results.
- At exactly `B_n = 0`, corrected and legacy output are bit-for-bit identical for every primitive field and output time.
- Existing RJ2a reconstruction/solver matrix: all 12 combinations passed. HLLD convergence ratios: PLM 0.519243, PPM4 0.460520, PPMX 0.457106, WENO-Z 0.510944; all below 0.6.
- Focused regression: 2 passed. C++/Python style: 2 passed.
- Final-source Frontier gfx90a HIP+MPI Release build passed with CPE 25.09, CCE 20, cray-mpich 9.0.1, and ROCm 6.4.2.
- A synthetic #757 + final-fix merge passed the focused regression and Frontier HIP build.
- [GitHub Actions, final SHA](https://github.com/IAS-Astrophysics/athenak/actions/runs/29840993135).

## GPU analysis

A literal unconditional port increased HLLD scratch and spills on gfx90a. This exact-zero path restores upstream compiler resources while applying the correction for every finite nonzero `B_n`:

| Variant | VGPR | scratch/lane x1/x2/x3 | spills x1/x2/x3 | occupancy |
| --- | ---: | ---: | ---: | ---: |
| Upstream HLLD | 128 | 80/80/72 B | 15/16/14 | 4 waves/SIMD |
| Unconditional correction | 128 | 128/136/136 B | 28/30/30 | 4 waves/SIMD |
| This PR | 128 | 80/80/72 B | 15/16/14 | 4 waves/SIMD |

These are compiler reports, not runtime timings.

The broader GPU bottleneck is the monolithic reconstruction/Riemann kernel. #757 splits it into flat kernels with global intermediate buffers. A direct Frontier MI250X-GCD A/B compared this PR with a synthetic #757 + this-fix integration: 128^3 cells, 64 blocks of 32^3, 3D diagonal ideal-MHD linear wave, PLM+HLLD+RK2, 200 cycles, outputs disabled, one warmup and seven drift-balanced samples.

| Variant | median GZCPS | MAD | relative |
| --- | ---: | ---: | ---: |
| This PR | 0.062926720 | 0.000271140 | 1.000 |
| #757 + fix | 0.078068650 | 0.000702080 | 1.240628 |

A deterministic 20,000-resample bootstrap gives a 95% interval of 1.223587x-1.255651x. This is whole-workload performance: #757 also specializes reconstruction, adds launches, and adds global buffers. It is one GPU, one decomposition, PLM, and a linear wave; WENO-Z/PPMX, turbulence, and multi-GPU scaling remain separate work.

Keeping optimization in #757 preserves this PR as a narrow correctness change. The current #757 head still contains the weak-`B_n` defect and should carry this correction when rebased.

## Scope

Only ideal-EOS nonrelativistic HLLD and its focused CPU regression change. Reconstruction, constrained transport, other solvers, and isothermal HLLD are untouched.

cc @davidvelasco07
