### PR TITLE
Extend Spherical Surface Output class to multiple radii

### DIFF
--- a/src/outputs/spherical_surface.cpp
+++ b/src/outputs/spherical_surface.cpp
@@ -10,10 +10,14 @@
 
 #include <sys/stat.h>  // mkdir
 
+#include <algorithm>
+#include <cmath>
 #include <cstdio>  // snprintf
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "athena.hpp"
 #include "globals.hpp"
@@ -21,13 +25,105 @@
 #include "parameter_input.hpp"
 #include "outputs.hpp"
 
+namespace {
+//! \fn std::vector<Real> ParseRadii(ParameterInput *pin, const OutputParameters &op)
+//! \brief Build the list of surface radii requested by an <output> block.
+//! Accepted formats:
+//!   radius = 100.0                  (single surface)
+//!   radii  = 10.0, 20.0, 50.0       (explicit list)
+//!   r_min, r_max, nradii, r_spacing (linear or log-spaced list)
+std::vector<Real> ParseRadii(ParameterInput *pin, const OutputParameters &op) {
+  std::vector<Real> rad;
+  bool has_radius = pin->DoesParameterExist(op.block_name, "radius");
+  bool has_radii  = pin->DoesParameterExist(op.block_name, "radii");
+  bool has_range  = pin->DoesParameterExist(op.block_name, "nradii");
+
+  if (static_cast<int>(has_radius) + static_cast<int>(has_radii) +
+      static_cast<int>(has_range) != 1) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "Output block '" << op.block_name << "' must specify"
+              << "exactly one of 'radius', 'radii', or 'nradii' (with r_min/r_max)"
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  if (has_radius) {
+    rad.push_back(pin->GetReal(op.block_name, "radius"));
+  } else if (has_radii) {
+    std::string list = pin->GetString(op.block_name, "radii");
+    std::replace(list.begin(), list.end(), ',', ' ');
+    std::istringstream iss(list);
+    Real r;
+    while (iss >> r) {
+      rad.push_back(r);
+    }
+    if (rad.empty()) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "Could not parse any radii in output block '"
+                << op.block_name << "'" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  } else {
+    int nradii = pin->GetInteger(op.block_name, "nradii");
+    Real rmin  = pin->GetReal(op.block_name, "r_min");
+    Real rmax  = pin->GetReal(op.block_name, "r_max");
+    std::string spacing = pin->GetOrAddString(op.block_name, "r_spacing", "linear");
+
+    // Check that the input parameters for the list fulfill certain conditions.
+    if (nradii < 1) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "nradii must be >= 1 in output block '"
+                << op.block_name << "'" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    if (spacing.compare("log") == 0 && rmin <= 0.0) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "r_min must be > 0 for r_spacing=log in output block '"
+                << op.block_name << "'" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    if (rmin >= rmax) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "r_min = " << rmin << " must be smaller than r_max = "
+                << rmax << " in output block '" << op.block_name << "'" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+    for (int i = 0; i < nradii; ++i) {
+      // if nradii == 1, then single surface sits at r_min
+      Real f = (nradii > 1) ? static_cast<Real>(i)/static_cast<Real>(nradii - 1) : 0.0;
+      if (spacing.compare("log") == 0) {
+        rad.push_back(rmin * std::pow(rmax/rmin, f));
+      } else if (spacing.compare("linear") == 0) {
+        rad.push_back(rmin + (rmax - rmin) * f);
+      } else {
+        std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                  << std::endl << "Unrecognized r_spacing = '" << spacing
+                  << "' in output block '" << op.block_name
+                  << "' (must be 'linear' or 'log')" << std::endl;
+        exit(EXIT_FAILURE);
+      }
+    }
+  }
+
+  for (auto r : rad) {
+    if (r <= 0.0) {
+      std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+                << std::endl << "Surface radii must be > 0, found " << r
+                << " in output block '" << op.block_name << "'" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+  return rad;
+}
+} // namespace
 
 SphericalSurfaceOutput::SphericalSurfaceOutput(ParameterInput *pin, Mesh *pm,
                                                OutputParameters op)
     : BaseTypeOutput(pin, pm, op) {
   mkdir("sph", 0755);
 
-  Real rad = pin->GetReal(op.block_name, "radius");
+  std::vector<Real> rad = ParseRadii(pin, op);
   int ntheta = pin->GetOrAddInteger(op.block_name, "ntheta", 32);
   Real xc = pin->GetOrAddReal(op.block_name, "xc", 0.0);
   Real yc = pin->GetOrAddReal(op.block_name, "yc", 0.0);
@@ -45,7 +141,7 @@ void SphericalSurfaceOutput::LoadOutputData(Mesh *pm) {
   }
 
   int nout_vars = outvars.size();
-  Kokkos::realloc(outarray, nout_vars, 1, 1, 1, psurf->nangles);
+  Kokkos::realloc(outarray, nout_vars, 1, 1, 1, psurf->npoints);
 
   // Calculate derived variables, if required
   if (out_params.contains_derived) {
@@ -60,7 +156,7 @@ void SphericalSurfaceOutput::LoadOutputData(Mesh *pm) {
 #if MPI_PARALLEL_ENABLED
   // Note that InterpolateToSphere will set zero values for points not owned by
   // current rank
-  int count = nout_vars * psurf->nangles;
+  int count = nout_vars * psurf->npoints;
   if (0 == global_variable::my_rank) {
     MPI_Reduce(MPI_IN_PLACE, outarray.data(), count, MPI_ATHENA_REAL, MPI_SUM,
                0, MPI_COMM_WORLD);
@@ -77,44 +173,59 @@ void SphericalSurfaceOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
 #if MPI_PARALLEL_ENABLED
   if (0 == global_variable::my_rank) {
 #endif
+    int nradii = psurf->nradii;
+    int nangles = psurf->nangles;
+
     // Assemble filename
     char fname[BUFSIZ];
-    std::snprintf(fname, BUFSIZ, "sph/%s.r=%.2f.%s.%05d.vtk",
-                  out_params.file_basename.c_str(), psurf->radius,
-                  out_params.file_id.c_str(), out_params.file_number);
+    if (nradii == 1) {
+      std::snprintf(fname, BUFSIZ, "sph/%s.r=%.2f.%s.%05d.vtk",
+                    out_params.file_basename.c_str(), psurf->radii.h_view(0),
+                    out_params.file_id.c_str(), out_params.file_number);
+    } else {
+      std::snprintf(fname, BUFSIZ, "sph/%s.r=%.2f-%.2f.%s.%05d.vtk",
+                    out_params.file_basename.c_str(), psurf->radii.h_view(0),
+                    psurf->radii.h_view(nradii-1), out_params.file_id.c_str(),
+                    out_params.file_number);
+    }
 
     // Open file
     std::ofstream ofile(fname, std::ios::binary);
 
     ofile << "# vtk DataFile Version 3.0" << std::endl;
     ofile << "# AthenaK data at time=" << pm->time
-          << " cycle=" << pm->ncycle << " rad=" << psurf->radius
+          << " cycle=" << pm->ncycle << " nradii=" << nradii
+          << " rmin=" << psurf->radii.h_view(0)
+          << " rmax=" << psurf->radii.h_view(nradii-1)
           << " xc=" << psurf->xc << " yc=" << psurf->yc << " zc=" << psurf->zc
           << std::endl;
     ofile << "BINARY" << std::endl;
     ofile << "DATASET STRUCTURED_GRID" << std::endl;
-    ofile << "DIMENSIONS 1 " << psurf->ntheta << " " << 2 * psurf->ntheta
-          << std::endl;
-    ofile << "POINTS " << psurf->nangles << " float\n";
+    // radius varies fastest, then theta, then phi
+    ofile << "DIMENSIONS " << nradii << " " << psurf->ntheta
+          << " " << 2 * psurf->ntheta << std::endl;
+    ofile << "POINTS " << psurf->npoints << " float\n";
 
     for (int i = 0; i < psurf->nangles; ++i) {
-      float dline[3] = {static_cast<float>(psurf->radius),
-                        static_cast<float>(psurf->polar_pos.h_view(i, 0)),
-                        static_cast<float>(psurf->polar_pos.h_view(i, 1))};
-      if (!big_end) {
-        Swap4Bytes(&dline[0]);
-        Swap4Bytes(&dline[1]);
-        Swap4Bytes(&dline[2]);
-      }
+      for (int r = 0; r < nradii; ++r) {
+        float dline[3] = {static_cast<float>(psurf->radii.h_view(r)),
+                          static_cast<float>(psurf->polar_pos.h_view(i, 0)),
+                          static_cast<float>(psurf->polar_pos.h_view(i, 1))};
+        if (!big_end) {
+          Swap4Bytes(&dline[0]);
+          Swap4Bytes(&dline[1]);
+          Swap4Bytes(&dline[2]);
+        }
 
-      ofile.write(reinterpret_cast<char *>(&dline[0]), 3 * sizeof(float));
+        ofile.write(reinterpret_cast<char *>(&dline[0]), 3 * sizeof(float));
+      }
     }
 
     float t = static_cast<float>(pm->time);
     if (!big_end) {
       Swap4Bytes(&t);
     }
-    ofile << "\nFIELD FieldData 2\n";
+    ofile << "\nFIELD FieldData 3\n";
     ofile << "TIME 1 1 float\n";
     ofile.write(reinterpret_cast<char *>(&t), sizeof(float));
 
@@ -125,15 +236,28 @@ void SphericalSurfaceOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
     }
     ofile.write(reinterpret_cast<char *>(&cycle), sizeof(int));
 
-    ofile << "\nPOINT_DATA " << psurf->nangles << std::endl;
+    // write the radii explicitely
+    ofile << "\nRADII 1 " << nradii << " float\n";
+    for (int r = 0; r < nradii; ++r) {
+      float rr = static_cast<float>(psurf->radii.h_view(r));
+      if (!big_end) {
+        Swap4Bytes(&rr);
+      }
+      ofile.write(reinterpret_cast<char *>(&rr), sizeof(float));
+    }
+
+    ofile << "\nPOINT_DATA " << psurf->npoints << std::endl;
     ofile << "SCALARS weights float 1" << std::endl;
     ofile << "LOOKUP_TABLE default" << std::endl;
     for (int i = 0; i < psurf->nangles; ++i) {
-      float d = psurf->radius * psurf->radius * psurf->int_weights.h_view(i);
-      if (!big_end) {
-        Swap4Bytes(&d);
+      for (int r = 0; r < nradii; ++r) {
+        Real rad = psurf->radii.h_view(r);
+        float d = rad * rad * psurf->int_weights.h_view(i);
+        if (!big_end) {
+          Swap4Bytes(&d);
+        }
+        ofile.write(reinterpret_cast<char *>(&d), sizeof(float));
       }
-      ofile.write(reinterpret_cast<char *>(&d), sizeof(float));
     }
 
     int nout_vars = outvars.size();
@@ -141,11 +265,13 @@ void SphericalSurfaceOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
       ofile << "\nSCALARS " << outvars[n].label << " float 1" << std::endl;
       ofile << "LOOKUP_TABLE default" << std::endl;
       for (int i = 0; i < psurf->nangles; ++i) {
-        float d = outarray(n, 0, 0, 0, i);
-        if (!big_end) {
-          Swap4Bytes(&d);
+        for (int r = 0; r < nradii; ++r) {
+          float d = outarray(n, 0, 0, 0, r*nangles + i);
+          if (!big_end) {
+            Swap4Bytes(&d);
+          }
+          ofile.write(reinterpret_cast<char *>(&d), sizeof(float));
         }
-        ofile.write(reinterpret_cast<char *>(&d), sizeof(float));
       }
     }
 

--- a/src/utils/spherical_surface.cpp
+++ b/src/utils/spherical_surface.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <iostream>
 #include <list>
+#include <vector>
 
 #include "athena.hpp"
 #include "coordinates/cell_locations.hpp"
@@ -24,8 +25,14 @@
 
 SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
                                    Real rad, Real xc, Real yc, Real zc)
+    : SphericalSurface(pmy_pack, ntheta, std::vector<Real>{rad}, xc, yc, zc) {}
+
+SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
+                                   const std::vector<Real> &rad, Real xc, Real yc,
+                                   Real zc)
     : ntheta(ntheta),
-      radius(rad),
+      nradii(static_cast<int>(rad.size())),
+      radii("radii", 1),
       xc(xc),
       yc(yc),
       zc(zc),
@@ -39,12 +46,26 @@ SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
   // reallocate and set interpolation coordinates, indices, and weights
   int &ng = pmy_pack->pmesh->mb_indcs.ng;
   nangles = 2 * ntheta * ntheta;
+  npoints = nradii * nangles;
+
+  // Allocate memory for the radii DualArray1D<Real>
+  // and subsequently fill the array with the specified
+  // radii.
+  Kokkos::realloc(radii, nradii);
+  for (int r = 0; r < nradii; ++r) {
+    radii.h_view(r) = rad[r];
+  }
+
+  // Sync to GPU.
+  radii.template modify<HostMemSpace>();
+  radii.template sync<DevExeSpace>();
 
   Kokkos::realloc(int_weights, nangles);
   Kokkos::realloc(polar_pos, nangles, 2);
-  Kokkos::realloc(cart_pos, nangles, 3);
-  Kokkos::realloc(interp_indcs, nangles, 4);
-  Kokkos::realloc(interp_wghts, nangles, 2 * ng, 3);
+  Kokkos::realloc(cart_pos, npoints, 3);
+  Kokkos::realloc(interp_vals, npoints);
+  Kokkos::realloc(interp_indcs, npoints, 4);
+  Kokkos::realloc(interp_wghts, npoints, 2 * ng, 3);
 
   InitializeAngleAndWeights();
   InitializeRadius();
@@ -80,12 +101,16 @@ void SphericalSurface::InitializeAngleAndWeights() {
 }
 
 void SphericalSurface::InitializeRadius() {
-  for (int n = 0; n < nangles; ++n) {
-    Real &theta = polar_pos.h_view(n, 0);
-    Real &phi = polar_pos.h_view(n, 1);
-    cart_pos.h_view(n, 0) = radius * cos(phi) * sin(theta) + xc;
-    cart_pos.h_view(n, 1) = radius * sin(phi) * sin(theta) + yc;
-    cart_pos.h_view(n, 2) = radius * cos(theta) + zc;
+  for (int r = 0; r < nradii; ++r) {
+    Real &rad = radii.h_view(r);
+    for (int n = 0; n < nangles; ++n) {
+      Real &theta = polar_pos.h_view(n, 0);
+      Real &phi = polar_pos.h_view(n, 1);
+      int p = r * nangles + n;
+      cart_pos.h_view(p, 0) = rad * cos(phi) * sin(theta) + xc;
+      cart_pos.h_view(p, 1) = rad * sin(phi) * sin(theta) + yc;
+      cart_pos.h_view(p, 2) = rad * cos(theta) + zc;
+    }
   }
   cart_pos.template modify<HostMemSpace>();
   cart_pos.template sync<DevExeSpace>();
@@ -101,7 +126,7 @@ void SphericalSurface::SetInterpolationIndices() {
   auto &size = pmy_pack->pmb->mb_size;
 
   int nmb1 = pmy_pack->nmb_thispack - 1;
-  int nang1 = nangles - 1;
+  int nang1 = npoints - 1;
   auto &rcoord = cart_pos;
   auto &iindcs = interp_indcs;
   for (int n = 0; n <= nang1; ++n) {
@@ -136,6 +161,8 @@ void SphericalSurface::SetInterpolationIndices() {
             std::floor((rcoord.h_view(n, 1) - (x2min + dx2 / 2.0)) / dx2));
         iindcs.h_view(n, 3) = static_cast<int>(
             std::floor((rcoord.h_view(n, 2) - (x3min + dx3 / 2.0)) / dx3));
+        // MeshBlock bounds half-open; no other block can own this points
+        break;
       }
     }
   }
@@ -158,7 +185,7 @@ void SphericalSurface::SetInterpolationWeights() {
 
   auto &iindcs = interp_indcs;
   auto &iwghts = interp_wghts;
-  for (int n = 0; n < nangles; ++n) {
+  for (int n = 0; n < npoints; ++n) {
     // extract indices
     int &ii0 = iindcs.h_view(n, 0);
     int &ii1 = iindcs.h_view(n, 1);
@@ -235,11 +262,10 @@ void SphericalSurface::InterpolateToSphere(int var_ind,
   int &js = indcs.js;
   int &ks = indcs.ks;
   int &ng = indcs.ng;
-  int nang1 = nangles - 1;
+  int nang1 = npoints - 1;
   int v = var_ind;
 
   // reallocate container
-  Kokkos::realloc(interp_vals, nangles);
   auto &iindcs = interp_indcs;
   auto &iwghts = interp_wghts;
   auto &ivals = interp_vals;

--- a/src/utils/spherical_surface.hpp
+++ b/src/utils/spherical_surface.hpp
@@ -8,6 +8,8 @@
 //! \file geodesic_grid.hpp
 //  \brief definitions for GaussLegendreGrid class
 
+#include <vector>
+
 #include "athena.hpp"
 #include "athena_tensor.hpp"
 
@@ -16,19 +18,26 @@ class MeshBlockPack;
 
 //----------------------------------------------------------------------------------------
 //! \class SphericalSurface
-
+//! \brief One or more spherical surfaces sharing a common grid. The surface
+//! contains npoints = nradii*nangles. Point ir*nangles+n is angle n on shell ir.
 class SphericalSurface {
  public:
+  // Single-radius surface
   SphericalSurface(MeshBlockPack *pmy_pack, int ntheta, Real rad, Real xc = 0.0,
                    Real yc = 0.0, Real zc = 0.0);
+  // Multi-radii surface
+  SphericalSurface(MeshBlockPack *pmy_pack, int ntheta, const std::vector<Real> &rad,
+                   Real xc = 0.0, Real yc = 0.0, Real zc = 0.0);
   ~SphericalSurface();
-  int nangles;  // total number of gridpoints
+  int nangles;  // total number of gridpoints per surface
   int ntheta;   // number of gridpoints along theta direction, nphi = 2ntheta
-  Real radius;  // radius to initialize the sphere
+  int nradii;   // number of surfaces
+  int npoints;  // total number of grid points, nradii*nangles
+  DualArray1D<Real> radii;        // radii of the surfaces
   Real xc, yc, zc;                // sphere center
-  DualArray1D<Real> int_weights;  // weights for quadrature integration
+  DualArray1D<Real> int_weights;  // weights for quadrature integration (per angle)
   DualArray2D<Real> cart_pos;     // coord position (cartesian) at gridpoints
-  DualArray2D<Real> polar_pos;
+  DualArray2D<Real> polar_pos;    // (theta,phi) at gridpoints (per angle)
   DualArray1D<Real> interp_vals;  // container for data interpolated to sphere
 
   // functions


### PR DESCRIPTION
In the current implementation of AthenaK, if one desires to have `sph` output for a given variable, e.g. the density `dens`, at multiple radii then the natural approach is to add one `sph` output block for each radius. For things like a tracer analysis of outflowing material, where we require resolutions of $$N_r\times N_{\phi}\times N_{\theta}=128\times 256\times 128$$, so 128 radii, adding 128 output blocks for just one variable is a complete overkill. In GR-Athena++, this was solved in sort of a hacky way, but in AthenaK it is a natural extension of the `SphericalSurface` class and subsequently of `SphericalSurfaceOutput`. 

This PR adds this extension to multiple radii. The user can now specify the original single-radii output as before by specifying:
```
<outputx>
file_type = sph
variable = mhd_w_bcc
radius = 100.0
ntheta = 128
dt = 1.0
xc = 0.0
yc = 0.0
zc = 0.0
```
In addition to that, a list of radii can also be parsed by setting:
```
<outputx>
file_type = sph
variable = mhd_w_bcc
radius = 10.0, 20.0, 50.0
ntheta = 128
dt = 1.0
xc = 0.0
yc = 0.0
zc = 0.0
```
Lastly, a list of radii within some bounds can also be generated via:
```
<outputx>
file_type = sph
variable = mhd_w_bcc
r_min = 10.0
r_max = 100.0
nradii = 10
r_spacing = log # linear
ntheta = 128
dt = 1.0
xc = 0.0
yc = 0.0
zc = 0.0
```

The created VTK output therefore holds $$(r,\theta,\phi)$$ columns.