### PR TITLE
Initialise eps_pieces array in Piecewise Polytrope EOS

### DIFF
--- a/src/eos/primitive-solver/piecewise_polytrope.hpp
+++ b/src/eos/primitive-solver/piecewise_polytrope.hpp
@@ -205,6 +205,8 @@ class PiecewisePolytrope : public EOSPolicyInterface {
     density_pieces[0] = densities[1]/mb;
     gamma_pieces[0] = gammas[0];
     pressure_pieces[0] = P0;
+    eps_pieces[0] = 0.0;
+
 
     for (int i = 1; i < n; i++) {
       density_pieces[i] = densities[i]/mb;


### PR DESCRIPTION
In the Piecewise Polytrope EOS the eps_pieces array contains the offset for the specific internal energy. This is defined recursively [here](https://github.com/IAS-Astrophysics/athenak/blob/5f1993109bcb2e5d588ba41b4efc897408e9959a/src/eos/primitive-solver/piecewise_polytrope.hpp#L217) but the initial entry is never set. Here it is initialised to 0.