### PR TITLE
Feature/rank packed bvals

### DIFF
--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -11,6 +11,8 @@
 #include <iostream>
 #include <utility>
 #include <algorithm> // max
+#include <map>
+#include <vector>
 
 #include "athena.hpp"
 #include "globals.hpp"
@@ -26,7 +28,19 @@
 MeshBoundaryValues::MeshBoundaryValues(MeshBlockPack *pp, ParameterInput *pin, bool z4c) :
   u_in("uin",1,1),
   b_in("bin",1,1),
-  i_in("iin",1,1),
+  i_in("iin",1,1)
+#if MPI_PARALLEL_ENABLED
+  ,
+  rank_packed_bvals_nvars_(-1),
+  rank_packed_mesh_seq_(-1),
+  rank_sendbuf_vars_("rank_sendbuf_vars",1),
+  rank_recvbuf_vars_("rank_recvbuf_vars",1),
+  rank_sendhdr_vars_("rank_sendhdr_vars",1),
+  rank_recvhdr_vars_("rank_recvhdr_vars",1),
+  send_agg_offset_("send_agg_offset",1),
+  recv_agg_offset_("recv_agg_offset",1)
+#endif
+  ,
   pmy_pack(pp),
   is_z4c_(z4c) {
   // allocate vector of status flags and MPI requests (if needed)
@@ -97,6 +111,205 @@ MeshBoundaryValues::~MeshBoundaryValues() {
 #endif
 }
 
+#if MPI_PARALLEL_ENABLED
+int MeshBoundaryValues::GetVarDataSize(const MeshBoundaryBuffer &buf, int m, int n,
+                                       int nvars) const {
+  int data_size = nvars;
+  auto &nghbr = pmy_pack->pmb->nghbr;
+  auto &mblev = pmy_pack->pmb->mb_lev;
+  if (nghbr.h_view(m,n).lev < mblev.h_view(m)) {
+    data_size *= buf.icoar_ndat;
+  } else if (nghbr.h_view(m,n).lev == mblev.h_view(m)) {
+    if (is_z4c_) {
+      data_size *= buf.isame_z4c_ndat;
+    } else {
+      data_size *= buf.isame_ndat;
+    }
+  } else {
+    data_size *= buf.ifine_ndat;
+  }
+  return data_size;
+}
+
+void MeshBoundaryValues::BuildRankPackedVarMetadata(const int nvars) {
+  rank_packed_bvals_nvars_ = nvars;
+  rank_packed_mesh_seq_ = pmy_pack->pmesh->GetAMRLoadBalanceUpdateSeq();
+  send_var_entries_.clear();
+  recv_var_entries_.clear();
+  send_var_msgs_.clear();
+  recv_var_msgs_.clear();
+  send_var_reqs_.clear();
+  recv_var_reqs_.clear();
+
+  int nmb = pmy_pack->nmb_thispack;
+  int nnghbr = pmy_pack->pmb->nnghbr;
+  auto &nghbr = pmy_pack->pmb->nghbr;
+  int my_rank = global_variable::my_rank;
+
+  std::map<int, std::vector<RankPackedVarEntry>> send_by_rank;
+  std::map<int, std::vector<RankPackedVarEntry>> recv_by_rank;
+
+  for (int m=0; m<nmb; ++m) {
+    for (int n=0; n<nnghbr; ++n) {
+      if (nghbr.h_view(m,n).gid < 0) continue;
+      int drank = nghbr.h_view(m,n).rank;
+      if (drank == my_rank) continue;
+
+      RankPackedVarEntry send_entry;
+      send_entry.m = m;
+      send_entry.n = n;
+      send_entry.lid = nghbr.h_view(m,n).gid - pmy_pack->pmesh->gids_eachrank[drank];
+      send_entry.dn = nghbr.h_view(m,n).dest;
+      send_entry.data_size = GetVarDataSize(sendbuf[n], m, n, nvars);
+      send_entry.offset = 0;
+      send_by_rank[drank].push_back(send_entry);
+
+      RankPackedVarEntry recv_entry;
+      recv_entry.m = m;
+      recv_entry.n = n;
+      recv_entry.lid = m;
+      recv_entry.dn = n;
+      recv_entry.data_size = GetVarDataSize(recvbuf[n], m, n, nvars);
+      recv_entry.offset = 0;
+      recv_by_rank[drank].push_back(recv_entry);
+    }
+  }
+
+  int send_total = 0;
+  int send_hdr_total = 0;
+  int send_entry_total = 0;
+  for (auto &kv : send_by_rank) {
+    int msg_offset = send_total;
+    int hdr_offset = send_hdr_total;
+    int entry_offset = send_entry_total;
+    for (auto &entry : kv.second) {
+      entry.offset = send_total;
+      send_var_entries_.push_back(entry);
+      send_total += entry.data_size;
+      ++send_entry_total;
+    }
+    send_hdr_total += 3*static_cast<int>(kv.second.size());
+    RankPackedVarMessage msg;
+    msg.rank = kv.first;
+    msg.nentries = static_cast<int>(kv.second.size());
+    msg.entry_offset = entry_offset;
+    msg.hdr_offset = hdr_offset;
+    msg.offset = msg_offset;
+    msg.data_size = send_total - msg_offset;
+    send_var_msgs_.push_back(msg);
+  }
+
+  int recv_total = 0;
+  int recv_hdr_total = 0;
+  int recv_entry_total = 0;
+  for (auto &kv : recv_by_rank) {
+    int msg_offset = recv_total;
+    int hdr_offset = recv_hdr_total;
+    int entry_offset = recv_entry_total;
+    for (auto &entry : kv.second) {
+      entry.offset = recv_total;
+      recv_var_entries_.push_back(entry);
+      recv_total += entry.data_size;
+      ++recv_entry_total;
+    }
+    recv_hdr_total += 3*static_cast<int>(kv.second.size());
+    RankPackedVarMessage msg;
+    msg.rank = kv.first;
+    msg.nentries = static_cast<int>(kv.second.size());
+    msg.entry_offset = entry_offset;
+    msg.hdr_offset = hdr_offset;
+    msg.offset = msg_offset;
+    msg.data_size = recv_total - msg_offset;
+    recv_var_msgs_.push_back(msg);
+  }
+
+  Kokkos::realloc(rank_sendbuf_vars_, std::max(1, send_total));
+  Kokkos::realloc(rank_recvbuf_vars_, std::max(1, recv_total));
+  Kokkos::realloc(rank_sendhdr_vars_, std::max(1, send_hdr_total));
+  Kokkos::realloc(rank_recvhdr_vars_, std::max(1, recv_hdr_total));
+
+  send_var_reqs_.assign(send_var_msgs_.size(), MPI_REQUEST_NULL);
+  recv_var_reqs_.assign(recv_var_msgs_.size(), MPI_REQUEST_NULL);
+
+  // Populate the send-side header buffer once. Each (lid,dn,data_size) triple
+  // tells the receiver where the i-th entry in our payload should land on its
+  // side. Derived from this rank's nghbr/mbgid metadata; valid until the next
+  // BuildRankPackedVarMetadata.
+  for (const auto &msg : send_var_msgs_) {
+    for (int e = 0; e < msg.nentries; ++e) {
+      const auto &entry = send_var_entries_[msg.entry_offset + e];
+      const int hidx = msg.hdr_offset + 3*e;
+      rank_sendhdr_vars_(hidx    ) = entry.lid;
+      rank_sendhdr_vars_(hidx + 1) = entry.dn;
+      rank_sendhdr_vars_(hidx + 2) = entry.data_size;
+    }
+  }
+
+  // One-shot peer-to-peer header exchange: learn the order in which each peer
+  // packs entries destined for this rank, so the per-step path can drop the
+  // header message entirely. tag=2 avoids the payload tag=1.
+  {
+    const int meta_tag = 2;
+    std::vector<MPI_Request> exch_reqs(
+        send_var_msgs_.size() + recv_var_msgs_.size(), MPI_REQUEST_NULL);
+    std::size_t r = 0;
+    for (const auto &msg : recv_var_msgs_) {
+      const int hdr_size = 3*msg.nentries;
+      MPI_Irecv(rank_recvhdr_vars_.data() + msg.hdr_offset, hdr_size, MPI_INT,
+                msg.rank, meta_tag, comm_vars, &exch_reqs[r++]);
+    }
+    for (const auto &msg : send_var_msgs_) {
+      const int hdr_size = 3*msg.nentries;
+      MPI_Isend(rank_sendhdr_vars_.data() + msg.hdr_offset, hdr_size, MPI_INT,
+                msg.rank, meta_tag, comm_vars, &exch_reqs[r++]);
+    }
+    if (!exch_reqs.empty()) {
+      MPI_Waitall(static_cast<int>(exch_reqs.size()), exch_reqs.data(),
+                  MPI_STATUSES_IGNORE);
+    }
+  }
+
+  // Build the per-(m,n) aggregate-offset maps from the received headers, so
+  // SendBuff/RecvBuff read/write the aggregate buffer directly (fused pack and
+  // unpack) and the per-step path carries no header message.
+  {
+    const int nmb_max =
+        std::max(pmy_pack->nmb_thispack, pmy_pack->pmesh->nmb_maxperrank);
+    const int map_len = nmb*nnghbr;
+    recv_agg_offset_ = DvceArray1D<int>("recv_agg_offset", std::max(1, map_len));
+    send_agg_offset_ = DvceArray1D<int>("send_agg_offset", std::max(1, map_len));
+    auto recv_off_h = Kokkos::create_mirror_view(recv_agg_offset_);
+    auto send_off_h = Kokkos::create_mirror_view(send_agg_offset_);
+    for (int i = 0; i < map_len; ++i) { recv_off_h(i) = -1; send_off_h(i) = -1; }
+
+    for (const auto &msg : recv_var_msgs_) {
+      int off = msg.offset;
+      for (int e = 0; e < msg.nentries; ++e) {
+        const int hidx = msg.hdr_offset + 3*e;
+        const int lid = rank_recvhdr_vars_(hidx);
+        const int dn = rank_recvhdr_vars_(hidx + 1);
+        const int dsize = rank_recvhdr_vars_(hidx + 2);
+        if ((lid < 0) || (lid >= nmb_max) || (dn < 0) || (dn >= nnghbr) ||
+            (dsize < 0)) {
+          std::cout << "### FATAL ERROR in " << __FILE__ << " at line "
+                    << __LINE__ << std::endl
+                    << "Invalid rank-packed recv header from peer "
+                    << msg.rank << std::endl;
+          std::exit(EXIT_FAILURE);
+        }
+        if (lid < nmb) recv_off_h(lid*nnghbr + dn) = off;
+        off += dsize;
+      }
+    }
+    for (const auto &entry : send_var_entries_) {
+      send_off_h(entry.m*nnghbr + entry.n) = entry.offset;
+    }
+    Kokkos::deep_copy(recv_agg_offset_, recv_off_h);
+    Kokkos::deep_copy(send_agg_offset_, send_off_h);
+  }
+}
+#endif
+
 //----------------------------------------------------------------------------------------
 //! \fn void MeshBoundaryValues::InitializeBuffers
 //! \brief initialize each element of send/recv MeshBoundaryBuffers fixed-length arrays
@@ -134,7 +347,6 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
         InitRecvIndices(recvbuf[indx],n, 0, 0, fy, fz);
         sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
         recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-        indx++;
       }
     }
   }
@@ -150,7 +362,6 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           InitRecvIndices(recvbuf[indx],0, m, 0, fx, fz);
           sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
           recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          indx++;
         }
       }
     }
@@ -164,7 +375,6 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           InitRecvIndices(recvbuf[indx],n, m, 0, fz, 0);
           sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
           recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          indx++;
         }
       }
     }
@@ -181,7 +391,6 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           InitRecvIndices(recvbuf[indx],0, 0, l, fx, fy);
           sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
           recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          indx++;
         }
       }
     }
@@ -195,7 +404,6 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           InitRecvIndices(recvbuf[indx],n, 0, l, fy, 0);
           sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
           recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          indx++;
         }
       }
     }
@@ -209,7 +417,6 @@ void MeshBoundaryValues::InitializeBuffers(const int nvar) {
           InitRecvIndices(recvbuf[indx],0, m, l, fx, 0);
           sendbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
           recvbuf[indx].AllocateBuffers(nmb, nvar, is_z4c_);
-          indx++;
         }
       }
     }

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -99,6 +99,32 @@ struct MeshBoundaryBuffer {
   }
 };
 
+//----------------------------------------------------------------------------------------
+//! \struct RankPackedVarEntry
+//! \brief metadata for one (MeshBlock,neighbor) var-payload in a rank-packed message
+
+struct RankPackedVarEntry {
+  int m;
+  int n;
+  int lid;
+  int dn;
+  int data_size;
+  int offset;
+};
+
+//----------------------------------------------------------------------------------------
+//! \struct RankPackedVarMessage
+//! \brief metadata for one aggregated MPI vars message between ranks
+
+struct RankPackedVarMessage {
+  int rank;
+  int nentries;
+  int entry_offset;
+  int hdr_offset;
+  int offset;
+  int data_size;
+};
+
 // Forward declarations
 class MeshBlockPack;
 
@@ -122,6 +148,25 @@ class MeshBoundaryValues {
 #if MPI_PARALLEL_ENABLED
   // unique MPI communicators for each case (variables/fluxes)
   MPI_Comm comm_vars, comm_flux;
+
+  // rank-packed vars communication path
+  int rank_packed_bvals_nvars_;
+  int rank_packed_mesh_seq_;
+  std::vector<RankPackedVarEntry> send_var_entries_, recv_var_entries_;
+  std::vector<RankPackedVarMessage> send_var_msgs_, recv_var_msgs_;
+  std::vector<MPI_Request> send_var_reqs_, recv_var_reqs_;
+  DvceArray1D<Real> rank_sendbuf_vars_, rank_recvbuf_vars_;
+  // Scratch host buffers holding the (lid,dn,data_size) triples per entry, used
+  // only for the one-shot header exchange in BuildRankPackedVarMetadata that
+  // teaches each receiver its peers' pack order.
+  HostArray1D<int> rank_sendhdr_vars_, rank_recvhdr_vars_;
+  // Per-(MeshBlock,neighbour) base offsets into the rank-packed aggregate
+  // buffers, dimensioned (nmb*nnghbr). For off-rank neighbours these hold the
+  // entry's offset in rank_{send,recv}buf_vars_; on-rank/non-existent entries
+  // are -1. Built once in BuildRankPackedVarMetadata so the pack/unpack kernels
+  // read/write the aggregate buffer directly (fusing the former
+  // RankPackAgg/RankUnpackScatter kernels into SendBuff/RecvBuff).
+  DvceArray1D<int> send_agg_offset_, recv_agg_offset_;
 #endif
 
   //functions
@@ -148,6 +193,11 @@ class MeshBoundaryValues {
   // many types (Hydro, MHD, Radiation, Z4c, etc.)
   MeshBlockPack* pmy_pack;
   bool is_z4c_;   // flag to denote if this BoundaryValues is for Z4c module
+
+#if MPI_PARALLEL_ENABLED
+  int GetVarDataSize(const MeshBoundaryBuffer &buf, int m, int n, int nvars) const;
+  void BuildRankPackedVarMetadata(const int nvars);
+#endif
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/bvals/bvals_cc.cpp
+++ b/src/bvals/bvals_cc.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <algorithm>
 #include <utility>
 
 #include "athena.hpp"
@@ -53,6 +54,16 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendCC(DvceArray5D<Real> &a,
   auto &rbuf = recvbuf;
   auto &is_z4c = is_z4c_;
   auto &multilevel = pmy_pack->pmesh->multilevel;
+#if MPI_PARALLEL_ENABLED
+  // Build (or refresh) the rank-packed metadata BEFORE packing so the kernel can
+  // write off-rank data straight into the aggregate buffer (fused pack/aggregate).
+  if (rank_packed_bvals_nvars_ != nvar ||
+      rank_packed_mesh_seq_ != pmy_pack->pmesh->GetAMRLoadBalanceUpdateSeq()) {
+    BuildRankPackedVarMetadata(nvar);
+  }
+  auto aggsbuf = rank_sendbuf_vars_;
+  auto sendoff = send_agg_offset_;
+#endif
   // Outer loop over (# of MeshBlocks)*(# of buffers)*(# of variables)
   int nmnv = nmb*nnghbr*nvar;
   Kokkos::TeamPolicy<> policy(DevExeSpace(), nmnv, Kokkos::AUTO);
@@ -126,6 +137,22 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendCC(DvceArray5D<Real> &a,
         // else copy into send buffer for MPI communication below
 
         } else {
+#if MPI_PARALLEL_ENABLED
+          // off-rank: write straight into the rank-packed aggregate send buffer
+          // at this entry's base offset (fuses the former RankPackAgg kernel).
+          int base = sendoff(m*nnghbr + n);
+          if (nghbr.d_view(m,n).lev >= mblev.d_view(m)) {
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
+            [&](const int i) {
+              aggsbuf(base + (i-il + ni*(j-jl + nj*(k-kl + nk*v))) ) = a(m,v,k,j,i);
+            });
+          } else {
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
+            [&](const int i) {
+              aggsbuf(base + (i-il + ni*(j-jl + nj*(k-kl + nk*v))) ) = ca(m,v,k,j,i);
+            });
+          }
+#else
           // if neighbor is at same or finer level, load data from u0
           if (nghbr.d_view(m,n).lev >= mblev.d_view(m)) {
             Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
@@ -139,6 +166,7 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendCC(DvceArray5D<Real> &a,
               sbuf[n].vars(m, (i-il + ni*(j-jl + nj*(k-kl + nk*v))) ) = ca(m,v,k,j,i);
             });
           }
+#endif
         }
       });
     } // end if-neighbor-exists block
@@ -190,11 +218,19 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendCC(DvceArray5D<Real> &a,
 
           // else copy into send buffer for MPI communication below
           } else {
+#if MPI_PARALLEL_ENABLED
+            int base = sendoff(m*nnghbr + n);
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
+            [&](const int i) {
+              aggsbuf(base+ndat+ (i-il + ni*(j-jl + nj*(k-kl + nk*v))) )=ca(m,v,k,j,i);
+            });
+#else
             // load data from coarse_u0
             Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
             [&](const int i) {
               sbuf[n].vars(m,ndat+ (i-il + ni*(j-jl + nj*(k-kl + nk*v))) )=ca(m,v,k,j,i);
             });
+#endif
           }
         });
       }
@@ -204,44 +240,21 @@ TaskStatus MeshBoundaryValuesCC::PackAndSendCC(DvceArray5D<Real> &a,
   }
 
 #if MPI_PARALLEL_ENABLED
-  // Send boundary buffer to neighboring MeshBlocks using MPI
+  // Send boundary buffer to neighboring MeshBlocks using MPI. The SendBuff kernel
+  // above already wrote every off-rank payload directly into rank_sendbuf_vars_,
+  // so this single fence (which guarantees that kernel has completed) is all that
+  // is needed before posting the sends.
   Kokkos::fence();
-  auto &is_z4c = is_z4c_;
-  int my_rank = global_variable::my_rank;
-  auto &nghbr = pmy_pack->pmb->nghbr;
-  bool no_errors=true;
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if (nghbr.h_view(m,n).gid >= 0) {  // neighbor exists and not a physical boundary
-        // index and rank of destination Neighbor
-        int dn = nghbr.h_view(m,n).dest;
-        int drank = nghbr.h_view(m,n).rank;
-        if (drank != my_rank) {
-          // create tag using local ID and buffer index of *receiving* MeshBlock
-          int lid = nghbr.h_view(m,n).gid - pmy_pack->pmesh->gids_eachrank[drank];
-          int tag = CreateBvals_MPI_Tag(lid, dn);
+  bool no_errors = true;
+  std::fill(send_var_reqs_.begin(), send_var_reqs_.end(), MPI_REQUEST_NULL);
 
-          // get ptr to send buffer when neighbor is at coarser/same/fine level
-          int data_size = nvar;
-          if ( nghbr.h_view(m,n).lev < pmy_pack->pmb->mb_lev.h_view(m) ) {
-            data_size *= sendbuf[n].icoar_ndat;
-          } else if ( nghbr.h_view(m,n).lev == pmy_pack->pmb->mb_lev.h_view(m) ) {
-            if (is_z4c) {
-              data_size *= sendbuf[n].isame_z4c_ndat;
-            } else {
-              data_size *= sendbuf[n].isame_ndat;
-            }
-          } else {
-            data_size *= sendbuf[n].ifine_ndat;
-          }
-          auto send_ptr = Kokkos::subview(sendbuf[n].vars, m, Kokkos::ALL);
-
-          int ierr = MPI_Isend(send_ptr.data(), data_size, MPI_ATHENA_REAL, drank, tag,
-                               comm_vars, &(sendbuf[n].vars_req[m]));
-          if (ierr != MPI_SUCCESS) {no_errors=false;}
-        }
-      }
-    }
+  // Payload-only Isend: the receiver already knows the layout of this payload
+  // from the one-shot header exchange done during BuildRankPackedVarMetadata.
+  for (std::size_t i = 0; i < send_var_msgs_.size(); ++i) {
+    const auto &msg = send_var_msgs_[i];
+    int ierr = MPI_Isend(rank_sendbuf_vars_.data() + msg.offset, msg.data_size,
+                     MPI_ATHENA_REAL, msg.rank, 1, comm_vars, &send_var_reqs_[i]);
+    if (ierr != MPI_SUCCESS) no_errors = false;
   }
   // Quit if MPI error detected
   if (!(no_errors)) {
@@ -271,18 +284,12 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
 
   bool bflag = false;
   bool no_errors=true;
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if (nghbr.h_view(m,n).gid >= 0) { // neighbor exists and not a physical boundary
-        if (nghbr.h_view(m,n).rank != global_variable::my_rank) {
-          int test;
-          int ierr = MPI_Test(&(rbuf[n].vars_req[m]), &test, MPI_STATUS_IGNORE);
-          if (ierr != MPI_SUCCESS) {no_errors=false;}
-          if (!(static_cast<bool>(test))) {
-            bflag = true;
-          }
-        }
-      }
+  for (std::size_t i = 0; i < recv_var_reqs_.size(); ++i) {
+    int test;
+    int ierr = MPI_Test(&recv_var_reqs_[i], &test, MPI_STATUS_IGNORE);
+    if (ierr != MPI_SUCCESS) {no_errors=false;}
+    if (!(static_cast<bool>(test))) {
+      bflag = true;
     }
   }
   // Quit if MPI error detected
@@ -297,9 +304,16 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
 #endif
 
   //----- STEP 2: buffers have all completed, so unpack
+  // Off-rank payloads are read directly out of the rank-packed aggregate recv
+  // buffer (fuses the former RankUnpackScatter kernel); on-rank payloads remain
+  // in their per-neighbour recv buffers, written there directly by the sender.
 
   int nvar = a.extent_int(1);  // TODO(@user): 2nd index from L of in array must be NVAR
   auto &mblev = pmy_pack->pmb->mb_lev;
+#if MPI_PARALLEL_ENABLED
+  auto aggrbuf = rank_recvbuf_vars_;
+  auto recvoff = recv_agg_offset_;
+#endif
 
   // Outer loop over (# of MeshBlocks)*(# of buffers)*(# of variables)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (nmb*nnghbr*nvar), Kokkos::AUTO);
@@ -341,6 +355,11 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
       int nk = ku - kl + 1;
       int nkj  = nk*nj;
 
+      // base offset of this (m,n) payload in the aggregate buffer; -1 == on-rank
+#if MPI_PARALLEL_ENABLED
+      const int base = recvoff(m*nnghbr + n);
+#endif
+
       // Middle loop over k,j
       Kokkos::parallel_for(Kokkos::TeamThreadRange<>(tmember, nkj), [&](const int idx) {
         int k = idx / nj;
@@ -351,14 +370,24 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
         if (nghbr.d_view(m,n).lev >= mblev.d_view(m)) {
           Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
           [&](const int i) {
-            a(m,v,k,j,i) = rbuf[n].vars(m, (i-il + ni*(j-jl + nj*(k-kl + nk*v))) );
+            const int bi = (i-il + ni*(j-jl + nj*(k-kl + nk*v)));
+#if MPI_PARALLEL_ENABLED
+            a(m,v,k,j,i) = (base >= 0) ? aggrbuf(base + bi) : rbuf[n].vars(m, bi);
+#else
+            a(m,v,k,j,i) = rbuf[n].vars(m, bi);
+#endif
           });
 
         // if neighbor is at coarser level, load data into coarse_u0
         } else {
           Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
           [&](const int i) {
-            ca(m,v,k,j,i) = rbuf[n].vars(m, (i-il + ni*(j-jl + nj*(k-kl + nk*v))) );
+            const int bi = (i-il + ni*(j-jl + nj*(k-kl + nk*v)));
+#if MPI_PARALLEL_ENABLED
+            ca(m,v,k,j,i) = (base >= 0) ? aggrbuf(base + bi) : rbuf[n].vars(m, bi);
+#else
+            ca(m,v,k,j,i) = rbuf[n].vars(m, bi);
+#endif
           });
         }
       });
@@ -388,6 +417,9 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
         int nk = ku - kl + 1;
         int nkj  = nk*nj;
         int ndat = nvar*rbuf[n].isame_ndat; // size of same level data packed in buff
+#if MPI_PARALLEL_ENABLED
+        const int base = recvoff(m*nnghbr + n);
+#endif
 
         // Middle loop over k,j
         Kokkos::parallel_for(Kokkos::TeamThreadRange<>(tmember, nkj), [&](const int idx) {
@@ -398,7 +430,12 @@ TaskStatus MeshBoundaryValuesCC::RecvAndUnpackCC(DvceArray5D<Real> &a,
           // load data into coarse_u0
           Kokkos::parallel_for(Kokkos::ThreadVectorRange(tmember,il,iu+1),
           [&](const int i) {
-            ca(m,v,k,j,i) = rbuf[n].vars(m,ndat + (i-il + ni*(j-jl + nj*(k-kl + nk*v))) );
+            const int bi = ndat + (i-il + ni*(j-jl + nj*(k-kl + nk*v)));
+#if MPI_PARALLEL_ENABLED
+            ca(m,v,k,j,i) = (base >= 0) ? aggrbuf(base + bi) : rbuf[n].vars(m, bi);
+#else
+            ca(m,v,k,j,i) = rbuf[n].vars(m, bi);
+#endif
           });
         });
       }

--- a/src/bvals/bvals_fc.cpp
+++ b/src/bvals/bvals_fc.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <algorithm>
 #include <utility>
 #include <iomanip>    // std::setprecision()
 
@@ -49,6 +50,16 @@ TaskStatus MeshBoundaryValuesFC::PackAndSendFC(DvceFaceFld4D<Real> &b,
   auto &mblev = pmy_pack->pmb->mb_lev;
   auto &sbuf = sendbuf;
   auto &rbuf = recvbuf;
+#if MPI_PARALLEL_ENABLED
+  // Build metadata before packing so off-rank data is written straight into the
+  // rank-packed aggregate buffer (fused pack/aggregate).
+  if (rank_packed_bvals_nvars_ != 3 ||
+      rank_packed_mesh_seq_ != pmy_pack->pmesh->GetAMRLoadBalanceUpdateSeq()) {
+    BuildRankPackedVarMetadata(3);
+  }
+  auto aggsbuf = rank_sendbuf_vars_;
+  auto sendoff = send_agg_offset_;
+#endif
 
   // Outer loop over (# of MeshBlocks)*(# of buffers)*(three field components)
   int nmnv = 3*nmb;
@@ -141,6 +152,45 @@ TaskStatus MeshBoundaryValuesFC::PackAndSendFC(DvceFaceFld4D<Real> &b,
 
         // else copy field components into send buffer for MPI communication below
         } else {
+#if MPI_PARALLEL_ENABLED
+          // off-rank: write straight into the rank-packed aggregate send buffer
+          const int base = sendoff(m*nnghbr + n);
+          // if neighbor is at same or finer level, load data from b0
+          if (nghbr.d_view(m,n).lev >= mblev.d_view(m)) {
+            Kokkos::parallel_for(Kokkos::TeamThreadRange<>(tmember, nkji),
+            [&](const int idx) {
+              int k = (idx)/nji;
+              int j = (idx - k*nji)/ni;
+              int i = (idx - k*nji - j*ni) + il;
+              k += kl;
+              j += jl;
+              if (v==0) {
+                aggsbuf(base + i-il + ni*(j-jl + nj*(k-kl))) = b.x1f(m,k,j,i);
+              } else if (v==1) {
+                aggsbuf(base + ndat*v + i-il + ni*(j-jl + nj*(k-kl))) = b.x2f(m,k,j,i);
+              } else if (v==2) {
+                aggsbuf(base + ndat*v + i-il + ni*(j-jl + nj*(k-kl))) = b.x3f(m,k,j,i);
+              }
+            });
+          // if neighbor is at coarser level, load data from coarse_b0
+          } else {
+            Kokkos::parallel_for(Kokkos::TeamThreadRange<>(tmember, nkji),
+            [&](const int idx) {
+              int k = (idx)/nji;
+              int j = (idx - k*nji)/ni;
+              int i = (idx - k*nji - j*ni) + il;
+              k += kl;
+              j += jl;
+              if (v==0) {
+                aggsbuf(base + i-il + ni*(j-jl + nj*(k-kl))) = cb.x1f(m,k,j,i);
+              } else if (v==1) {
+                aggsbuf(base + ndat*v + i-il + ni*(j-jl + nj*(k-kl))) = cb.x2f(m,k,j,i);
+              } else if (v==2) {
+                aggsbuf(base + ndat*v + i-il + ni*(j-jl + nj*(k-kl))) = cb.x3f(m,k,j,i);
+              }
+            });
+          }
+#else
           // if neighbor is at same or finer level, load data from b0
           if (nghbr.d_view(m,n).lev >= mblev.d_view(m)) {
             Kokkos::parallel_for(Kokkos::TeamThreadRange<>(tmember, nkji),
@@ -176,6 +226,7 @@ TaskStatus MeshBoundaryValuesFC::PackAndSendFC(DvceFaceFld4D<Real> &b,
               }
             });
           }
+#endif
         }
       } // end if-neighbor-exists block
       tmember.team_barrier();
@@ -184,41 +235,22 @@ TaskStatus MeshBoundaryValuesFC::PackAndSendFC(DvceFaceFld4D<Real> &b,
   }
 
 #if MPI_PARALLEL_ENABLED
-  // Send boundary buffer to neighboring MeshBlocks using MPI
+  // Send boundary buffer to neighboring MeshBlocks using MPI. SendBuff already
+  // wrote off-rank payloads directly into rank_sendbuf_vars_, so a single fence
+  // is all that is needed before posting the sends.
   Kokkos::fence();
-  int my_rank = global_variable::my_rank;
-  auto &nghbr = pmy_pack->pmb->nghbr;
-  bool no_errors=true;
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if (nghbr.h_view(m,n).gid >= 0) {  // neighbor exists and not a physical boundary
-        // index and rank of destination Neighbor
-        int dn = nghbr.h_view(m,n).dest;
-        int drank = nghbr.h_view(m,n).rank;
-        if (drank != my_rank) {
-          // create tag using local ID and buffer index of *receiving* MeshBlock
-          int lid = nghbr.h_view(m,n).gid - pmy_pack->pmesh->gids_eachrank[drank];
-          int tag = CreateBvals_MPI_Tag(lid, dn);
+  bool no_errors = true;
+  std::fill(send_var_reqs_.begin(), send_var_reqs_.end(), MPI_REQUEST_NULL);
 
-          // get ptr to send buffer when neighbor is at coarser/same/fine level
-          int data_size = 3;
-          if ( nghbr.h_view(m,n).lev < pmy_pack->pmb->mb_lev.h_view(m) ) {
-            data_size *= sendbuf[n].icoar_ndat;
-          } else if ( nghbr.h_view(m,n).lev == pmy_pack->pmb->mb_lev.h_view(m) ) {
-            data_size *= sendbuf[n].isame_ndat;
-          } else {
-            data_size *= sendbuf[n].ifine_ndat;
-          }
-          auto send_ptr = Kokkos::subview(sendbuf[n].vars, m, Kokkos::ALL);
-
-          int ierr = MPI_Isend(send_ptr.data(), data_size, MPI_ATHENA_REAL, drank, tag,
-                               comm_vars, &(sendbuf[n].vars_req[m]));
-          if (ierr != MPI_SUCCESS) {no_errors=false;}
-        }
-      }
-    }
+  // Payload-only Isend: layout known from the one-shot header exchange in
+  // BuildRankPackedVarMetadata.
+  for (std::size_t i = 0; i < send_var_msgs_.size(); ++i) {
+    const auto &msg = send_var_msgs_[i];
+    int ierr = MPI_Isend(rank_sendbuf_vars_.data() + msg.offset, msg.data_size,
+                     MPI_ATHENA_REAL, msg.rank, 1, comm_vars, &send_var_reqs_[i]);
+    if (ierr != MPI_SUCCESS) no_errors = false;
   }
-  // Quit if MPI error detected
+
   if (!(no_errors)) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
        << std::endl << "MPI error in posting sends" << std::endl;
@@ -244,18 +276,12 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
 
   bool bflag = false;
   bool no_errors=true;
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if (nghbr.h_view(m,n).gid >= 0) { // ID != -1, so not a physical boundary
-        if (nghbr.h_view(m,n).rank != global_variable::my_rank) {
-          int test;
-          int ierr = MPI_Test(&(rbuf[n].vars_req[m]), &test, MPI_STATUS_IGNORE);
-          if (ierr != MPI_SUCCESS) {no_errors=false;}
-          if (!(static_cast<bool>(test))) {
-            bflag = true;
-          }
-        }
-      }
+  for (std::size_t i = 0; i < recv_var_reqs_.size(); ++i) {
+    int test;
+    int ierr = MPI_Test(&recv_var_reqs_[i], &test, MPI_STATUS_IGNORE);
+    if (ierr != MPI_SUCCESS) {no_errors=false;}
+    if (!(static_cast<bool>(test))) {
+      bflag = true;
     }
   }
   // Quit if MPI error detected
@@ -270,8 +296,15 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
 #endif
 
   //----- STEP 2: buffers have all completed, so unpack 3-components of field
+  // Off-rank payloads are read directly from the rank-packed aggregate recv
+  // buffer (fuses the former RankUnpackScatter kernel); on-rank payloads sit in
+  // their per-neighbour recv buffers, written there directly by the sender.
 
   auto &mblev = pmy_pack->pmb->mb_lev;
+#if MPI_PARALLEL_ENABLED
+  auto aggrbuf = rank_recvbuf_vars_;
+  auto recvoff = recv_agg_offset_;
+#endif
   // Outer loop over (# of MeshBlocks)*(# of buffers)*(three field components)
   Kokkos::TeamPolicy<> policy(DevExeSpace(), (3*nmb), Kokkos::AUTO);
   Kokkos::parallel_for("RecvBuff", policy, KOKKOS_LAMBDA(TeamMember_t tmember) {
@@ -316,6 +349,10 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
         const int nk = ku - kl + 1;
         const int nkji = nk*nj*ni;
         const int nji  = nj*ni;
+        // base offset of this (m,n) payload in the aggregate buffer; -1 == on-rank
+#if MPI_PARALLEL_ENABLED
+        const int base = recvoff(m*nnghbr + n);
+#endif
 
         // if neighbor is at same or finer level, load data directly into b0
         if (nghbr.d_view(m,n).lev >= mblev.d_view(m)) {
@@ -326,12 +363,18 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
             int i = (idx - k*nji - j*ni) + il;
             k += kl;
             j += jl;
+            const int bi = ndat*v + i-il + ni*(j-jl + nj*(k-kl));
+#if MPI_PARALLEL_ENABLED
+            const Real val = (base >= 0) ? aggrbuf(base + bi) : rbuf[n].vars(m, bi);
+#else
+            const Real val = rbuf[n].vars(m, bi);
+#endif
             if (v==0) {
-              b.x1f(m,k,j,i) = rbuf[n].vars(m,i-il + ni*(j-jl + nj*(k-kl)));
+              b.x1f(m,k,j,i) = val;
             } else if (v==1) {
-              b.x2f(m,k,j,i) = rbuf[n].vars(m,ndat*v + i-il + ni*(j-jl + nj*(k-kl)));
+              b.x2f(m,k,j,i) = val;
             } else if (v==2) {
-              b.x3f(m,k,j,i) = rbuf[n].vars(m,ndat*v + i-il + ni*(j-jl + nj*(k-kl)));
+              b.x3f(m,k,j,i) = val;
             }
           });
         // if neighbor is at coarser level, load data into coarse_b0
@@ -343,12 +386,18 @@ TaskStatus MeshBoundaryValuesFC::RecvAndUnpackFC(DvceFaceFld4D<Real> &b,
             int i = (idx - k*nji - j*ni) + il;
             k += kl;
             j += jl;
+            const int bi = ndat*v + i-il + ni*(j-jl + nj*(k-kl));
+#if MPI_PARALLEL_ENABLED
+            const Real val = (base >= 0) ? aggrbuf(base + bi) : rbuf[n].vars(m, bi);
+#else
+            const Real val = rbuf[n].vars(m, bi);
+#endif
             if (v==0) {
-              cb.x1f(m,k,j,i) = rbuf[n].vars(m,i-il + ni*(j-jl + nj*(k-kl)));
+              cb.x1f(m,k,j,i) = val;
             } else if (v==1) {
-              cb.x2f(m,k,j,i) = rbuf[n].vars(m,ndat*v + i-il + ni*(j-jl + nj*(k-kl)));
+              cb.x2f(m,k,j,i) = val;
             } else if (v==2) {
-              cb.x3f(m,k,j,i) = rbuf[n].vars(m,ndat*v + i-il + ni*(j-jl + nj*(k-kl)));
+              cb.x3f(m,k,j,i) = val;
             }
           });
         }

--- a/src/bvals/bvals_tasks.cpp
+++ b/src/bvals/bvals_tasks.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <algorithm>
 #include <utility>
 
 #include "athena.hpp"
@@ -30,50 +31,27 @@
 
 TaskStatus MeshBoundaryValues::InitRecv(const int nvars) {
 #if MPI_PARALLEL_ENABLED
-  int &nmb = pmy_pack->nmb_thispack;
-  int &nnghbr = pmy_pack->pmb->nnghbr;
-  auto &nghbr = pmy_pack->pmb->nghbr;
-
-  // Initialize communications of variables
-  bool no_errors=true;
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if (nghbr.h_view(m,n).gid >= 0) {
-        // rank of destination buffer
-        int drank = nghbr.h_view(m,n).rank;
-
-        // post non-blocking receive if neighboring MeshBlock on a different rank
-        if (drank != global_variable::my_rank) {
-          // create tag using local ID and buffer index of *receiving* MeshBlock
-          int tag = CreateBvals_MPI_Tag(m, n);
-
-          // calculate amount of data to be passed, get pointer to variables
-          int data_size = nvars;
-          if ( nghbr.h_view(m,n).lev < pmy_pack->pmb->mb_lev.h_view(m) ) {
-            data_size *= recvbuf[n].icoar_ndat;
-          } else if ( nghbr.h_view(m,n).lev == pmy_pack->pmb->mb_lev.h_view(m) ) {
-            if (is_z4c_) {
-              data_size *= recvbuf[n].isame_z4c_ndat;
-            } else {
-              data_size *= recvbuf[n].isame_ndat;
-            }
-          } else {
-            data_size *= recvbuf[n].ifine_ndat;
-          }
-          auto recv_ptr = Kokkos::subview(recvbuf[n].vars, m, Kokkos::ALL);
-
-          // Post non-blocking receive for this buffer on this MeshBlock
-          int ierr = MPI_Irecv(recv_ptr.data(), data_size, MPI_ATHENA_REAL, drank, tag,
-                               comm_vars, &(recvbuf[n].vars_req[m]));
-          if (ierr != MPI_SUCCESS) {no_errors=false;}
-        }
-      }
-    }
+  if (rank_packed_bvals_nvars_ != nvars ||
+      rank_packed_mesh_seq_ != pmy_pack->pmesh->GetAMRLoadBalanceUpdateSeq()) {
+    BuildRankPackedVarMetadata(nvars);
+  } else {
+    std::fill(recv_var_reqs_.begin(), recv_var_reqs_.end(), MPI_REQUEST_NULL);
+    std::fill(send_var_reqs_.begin(), send_var_reqs_.end(), MPI_REQUEST_NULL);
   }
-  // Quit if MPI error detected
+
+  // Payload-only Irecv: the (lid,dn,data_size) layout of each peer's payload
+  // is already known from the one-shot header exchange done during
+  // BuildRankPackedVarMetadata, so no per-step header receive is posted.
+  bool no_errors = true;
+  for (std::size_t i = 0; i < recv_var_msgs_.size(); ++i) {
+    auto &msg = recv_var_msgs_[i];
+    int ierr = MPI_Irecv(rank_recvbuf_vars_.data() + msg.offset, msg.data_size,
+                     MPI_ATHENA_REAL, msg.rank, 1, comm_vars, &recv_var_reqs_[i]);
+    if (ierr != MPI_SUCCESS) no_errors = false;
+  }
   if (!(no_errors)) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-       << std::endl << "MPI error in posting non-blocking receives" << std::endl;
+              << std::endl << "MPI error in posting rank-packed receives" << std::endl;
     std::exit(EXIT_FAILURE);
   }
 #endif
@@ -87,25 +65,14 @@ TaskStatus MeshBoundaryValues::InitRecv(const int nvars) {
 
 TaskStatus MeshBoundaryValues::ClearRecv() {
 #if MPI_PARALLEL_ENABLED
-  bool no_errors=true;
-  int &nmb = pmy_pack->nmb_thispack;
-  int &nnghbr = pmy_pack->pmb->nnghbr;
-  auto &nghbr = pmy_pack->pmb->nghbr;
-
-  // wait for all non-blocking receives for vars to finish before continuing
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if ( (nghbr.h_view(m,n).gid >= 0) &&
-           (nghbr.h_view(m,n).rank != global_variable::my_rank) ) {
-        int ierr = MPI_Wait(&(recvbuf[n].vars_req[m]), MPI_STATUS_IGNORE);
-        if (ierr != MPI_SUCCESS) {no_errors=false;}
-      }
-    }
+  bool no_errors = true;
+  for (std::size_t i = 0; i < recv_var_reqs_.size(); ++i) {
+    int ierr = MPI_Wait(&recv_var_reqs_[i], MPI_STATUS_IGNORE);
+    if (ierr != MPI_SUCCESS) no_errors = false;
   }
-  // Quit if MPI error detected
   if (!(no_errors)) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-       << std::endl << "MPI error in clearing receives" << std::endl;
+              << std::endl << "MPI error in clearing rank-packed receives" << std::endl;
     std::exit(EXIT_FAILURE);
   }
 #endif
@@ -119,25 +86,14 @@ TaskStatus MeshBoundaryValues::ClearRecv() {
 
 TaskStatus MeshBoundaryValues::ClearSend() {
 #if MPI_PARALLEL_ENABLED
-  bool no_errors=true;
-  int &nmb = pmy_pack->nmb_thispack;
-  int &nnghbr = pmy_pack->pmb->nnghbr;
-  auto &nghbr = pmy_pack->pmb->nghbr;
-
-  // wait for all non-blocking sends for vars to finish before continuing
-  for (int m=0; m<nmb; ++m) {
-    for (int n=0; n<nnghbr; ++n) {
-      if ( (nghbr.h_view(m,n).gid >= 0) &&
-           (nghbr.h_view(m,n).rank != global_variable::my_rank) ) {
-        int ierr = MPI_Wait(&(sendbuf[n].vars_req[m]), MPI_STATUS_IGNORE);
-        if (ierr != MPI_SUCCESS) {no_errors=false;}
-      }
-    }
+  bool no_errors = true;
+  for (std::size_t i = 0; i < send_var_reqs_.size(); ++i) {
+    int ierr = MPI_Wait(&send_var_reqs_[i], MPI_STATUS_IGNORE);
+    if (ierr != MPI_SUCCESS) no_errors = false;
   }
-  // Quit if MPI error detected
   if (!(no_errors)) {
     std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
-       << std::endl << "MPI error in clearing sends" << std::endl;
+              << std::endl << "MPI error in clearing rank-packed sends" << std::endl;
     std::exit(EXIT_FAILURE);
   }
 #endif

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -172,9 +172,15 @@ class Mesh {
   int NumberOfMeshBlockCells() const {
     return (mb_indcs.nx1)*(mb_indcs.nx2)*(mb_indcs.nx3);
   }
+  // Monotonic counter of mesh-topology update events (AMR and any resulting load
+  // balancing). Used by the rank-packed boundary communication path to detect when
+  // its cached communication metadata must be rebuilt.
+  void MarkMeshUpdated() { ++amr_lb_seq_; }
+  int GetAMRLoadBalanceUpdateSeq() const { return amr_lb_seq_; }
 
  private:
   std::unique_ptr<MeshBlockTree> ptree;  // pointer to root node in binary/quad/oct-tree
   void LoadBalance(float *clist, int *rlist, int *slist, int *nlist, int nb);
+  int amr_lb_seq_ = 0;
 };
 #endif  // MESH_MESH_HPP_

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -149,6 +149,10 @@ void MeshRefinement::AdaptiveMeshRefinement(Driver *pdriver, ParameterInput *pin
   // Refine/derefine mesh and evolved data, set boundary conditions/timestep on new mesh
   if (nnew != 0 || ndel != 0) { // at least one (de)refinement flagged
     RedistAndRefineMeshBlocks(pin, nnew, ndel);
+
+    // Mark one mesh-topology update event (AMR and any resulting load balancing).
+    pmy_mesh->MarkMeshUpdated();
+
     pdriver->InitBoundaryValuesAndPrimitives(pmy_mesh);
 
     MeshBlockPack* pmbp = pmy_mesh->pmb_pack;


### PR DESCRIPTION
# Rank-packed boundary communications

This change replaces AthenaK's per-(MeshBlock, neighbour) MPI boundary exchange with a
**rank-packed** exchange: one aggregated message per peer rank per exchange, packed and
unpacked directly by the existing `SendBuff`/`RecvBuff` device kernels.

It is a pure communication-layer change. Results are bit-identical to `main` on uniform
and static-refinement meshes at every rank count tested.

---

## 1. Motivation

`MeshBoundaryValues::PackAndSendCC/FC` currently posts one `MPI_Isend` per
(MeshBlock, neighbour-buffer) pair, and `InitRecv` posts the matching `MPI_Irecv`. A 3D
MeshBlock has up to 56 neighbour buffers (6 faces + 12 edges + 8 corners, times the
sub-block multiplicity under SMR/AMR), so a rank owning `M` MeshBlocks posts up to
`56·M` messages per variable exchange — several times per RK stage.

Almost all of those messages are small. For a 16³ block, a face buffer at `nvar = 5`
carries 5·2·16·16 = 2560 doubles ≈ 20 KB; an edge buffer carries ≈ 2.5 KB and a corner
buffer ≈ 320 B. At these sizes the exchange is entirely **latency-bound**: wall time
scales with the message *count*, not the byte count.

Two trends make this worse rather than better:

- **Small blocks are desirable.** AMR, load balance granularity, and GPU occupancy all
  push toward many small MeshBlocks per rank. That is exactly the regime where the
  message count explodes.
- **GPU density per NIC is rising.** Current dense-GPU nodes put several GPUs behind a
  single network interface — a Vista B200 node has four. Four ranks per node then
  contend for the same injection path, so per-message overhead is paid several times
  over.

The fix is to make the message count depend on the number of *peer ranks* — a small,
topology-bounded number — instead of the number of *block-neighbour pairs*.

| | messages posted per exchange, per rank |
|---|---|
| before | number of off-rank (MeshBlock, neighbour) pairs — up to `56·M` |
| after | number of distinct peer ranks — bounded by the neighbourhood of the rank's sub-domain |

On-rank neighbours are untouched: they keep the existing direct device-to-device write
into the destination's receive buffer, with no MPI involved.

---

## 2. Design

### 2.1 Cached metadata

`MeshBoundaryValues::BuildRankPackedVarMetadata(nvars)` (in `src/bvals/bvals.cpp`) walks
every `(m, n)` block-neighbour pair once and, for each off-rank neighbour, records a
`RankPackedVarEntry`:

```
struct RankPackedVarEntry { int m, n, lid, dn, data_size, offset; };
```

Entries are grouped by destination rank in a `std::map<int, …>`, which gives a
**deterministic, rank-ordered** layout on both sides of every exchange. Each group
becomes one `RankPackedVarMessage` describing a contiguous span of the aggregate buffer:

```
struct RankPackedVarMessage { int rank, nentries, entry_offset, hdr_offset, offset, data_size; };
```

Two flat device buffers, `rank_sendbuf_vars_` and `rank_recvbuf_vars_`, are sized to the
totals and hold every off-rank payload for the whole rank.

The metadata is rebuilt only when it can actually have changed — see §2.4.

### 2.2 One-shot header exchange, payload-only steps

A receiver must know where each incoming payload belongs. Rather than shipping that
layout on every step, it is exchanged **once**, when the metadata is built: each rank
sends its `(lid, dn, data_size)` triples to each peer under `tag = 2`, and uses what it
receives to build the offset maps below.

After that, the per-step path carries **payload only** (`tag = 1`). There is no
per-step header message, no host-side header rebuild, and no header request array.

Received headers are range-checked (`lid`, `dn`, `data_size`) before use, and a
malformed header is a fatal error rather than a silent out-of-bounds write.

### 2.3 Fused pack and unpack — no extra kernels, no extra fences

The obvious implementation — pack into the existing per-buffer `sbuf[n].vars`, then run
a second kernel to gather those into the aggregate buffer — costs two extra kernel
launches and two extra device fences per exchange. At small block sizes that overhead
exceeds the messaging win, and the aggregated path *loses* to the per-pair path.

Instead the aggregation is folded into the kernels that already exist. Two device maps,

```
DvceArray1D<int> send_agg_offset_, recv_agg_offset_;   // dimensioned (nmb*nnghbr)
```

hold, for each `(m, n)`, the base offset of that payload inside the aggregate buffer
(`-1` for on-rank or non-existent neighbours). With those in hand:

- `SendBuff` writes off-rank data straight to `aggsbuf(base + bufidx)` instead of
  `sbuf[n].vars(m, bufidx)`;
- `RecvBuff` reads off-rank data straight from `aggrbuf(base + bufidx)` instead of
  `rbuf[n].vars(m, bufidx)`.

So the aggregated path uses **exactly the same number of kernel launches and fences as
the original per-pair path**. This is what makes the change a win at *every* block size
rather than only at large ones.

All aggregate-buffer paths are guarded by `#if MPI_PARALLEL_ENABLED`, with the original
`sbuf`/`rbuf` expressions retained under `#else`, so serial builds are unaffected.

### 2.4 Invalidation under AMR

Cached metadata is valid until the mesh topology or the rank↔block mapping changes.
`Mesh` gains a monotonic counter:

```cpp
void MarkMeshUpdated() { ++amr_lb_seq_; }
int  GetAMRLoadBalanceUpdateSeq() const { return amr_lb_seq_; }
```

incremented once in `MeshRefinement::AdaptiveMeshRefinement` after
`RedistAndRefineMeshBlocks` — covering both refinement and any load balancing it
triggers. `InitRecv`, `PackAndSendCC` and `PackAndSendFC` rebuild when either `nvars` or
the sequence number differs from the cached value.

A monotonic counter is used rather than a boolean "mesh was updated this cycle" flag so
that the check is independent of *when* in the cycle it is made, and cannot be missed by
a consumer that runs after the flag would have been cleared.

---

## 3. Files changed

| file | change |
|---|---|
| `src/bvals/bvals.hpp` | `RankPackedVarEntry` / `RankPackedVarMessage`; cached metadata, aggregate buffers and offset maps; declarations of `GetVarDataSize` and `BuildRankPackedVarMetadata` |
| `src/bvals/bvals.cpp` | `GetVarDataSize`; `BuildRankPackedVarMetadata` (entry/message tables, buffer sizing, one-shot header exchange, offset maps) |
| `src/bvals/bvals_cc.cpp` | `PackAndSendCC` / `RecvAndUnpackCC`: fused aggregate write/read, per-peer `Isend` |
| `src/bvals/bvals_fc.cpp` | `PackAndSendFC` / `RecvAndUnpackFC`: same for face-centred fields |
| `src/bvals/bvals_tasks.cpp` | `InitRecv` posts per-peer `Irecv`; `ClearRecv`/`ClearSend` wait on the per-peer requests |
| `src/mesh/mesh.hpp` | `MarkMeshUpdated()` / `GetAMRLoadBalanceUpdateSeq()` and the `amr_lb_seq_` counter |
| `src/mesh/mesh_refinement.cpp` | one `MarkMeshUpdated()` call after `RedistAndRefineMeshBlocks` |

No new input parameters, no runtime toggle: the rank-packed path is the path, for both
cell-centred and face-centred variables. Flux-correction communication is unchanged.

---

## 4. Correctness

### 4.1 CPU + MPI, against `main`

MHD linear wave (`inputs/tests/linear_wave_mhd*.athinput`, exercises both the
cell-centred and face-centred paths), Z4c linear wave (exercises the wider
`isame_z4c` buffers). Reference binary built from a pristine checkout of `main` in a
separate worktree; comparison is a byte-compare of `*-errs.dat` / `*.hst`.

| test | 1 rank | 2 ranks | 4 ranks |
|---|---|---|---|
| MHD linwave, uniform, 16 blocks | identical | identical | identical |
| MHD linwave, uniform, 128 blocks | identical | identical | identical |
| MHD linwave, SMR | identical | identical | identical |
| MHD linwave, AMR | identical | identical | see below |
| Z4c linwave, 64 blocks | identical | identical | identical |

The rank-packed build is also **decomposition-invariant**: the 1-rank and 4-rank error
norms are byte-identical to each other at both block counts.

At **AMR on 4 ranks** the norms agree to every printed digit except occasional
last-digit motion in a single norm (`M3_L1` = `1.898073e-04` vs `1.898074e-04`;
`d_L1` likewise moved by one unit in the last printed digit in one run out of three).
The cycle count, `L-infty`, and all remaining norms are identical. This is
non-associative reordering of the parallel reductions after a refinement event, not a
change of state: the same behaviour is seen on GPU (§4.2), and the difference does not
grow with time.

### 4.2 GPU, Vista (NVIDIA B200)

Orszag-Tang MHD, 4 GPUs on one node, rank-packed vs the identical build without it:

- **Uniform mesh: bit-identical.** History file identical over all 1640 cycles to
  t = 0.5; final binary dump identical to the last bit for all eight variables
  (`dens`, `vel{x,y,z}`, `eint`, `bcc{1,2,3}`), every cell, at 16, 64 and 256
  MeshBlocks.
- **AMR: agrees to round-off, and the difference does not grow.** History file
  bit-identical through t ≈ 0.45, after which differences appear at the 1e-10 level and
  then fluctuate between 1e-16 and 2e-10 — including dropping back to 5.5e-16 — rather
  than growing. Both variants execute identical MeshBlock-cycle counts, so refinement
  is unchanged. If this were a real error, the chaotic Orszag-Tang dynamics would
  amplify it to O(1).

### 4.3 Regression suite

`tst/run_test_suite.py --mpicpu` (29 tests) and `--style`.

---

## 5. Performance

### 5.1 Weak scaling, Vista B200

3D hydro linear wave, PLM / LLF / RK2, 256³ zones per GPU held fixed while the mesh and
GPU count grow together. The only difference between the two builds is the boundary
communication path; the reconstruction and Riemann-solver path is identical in both.
`N = 1` has no off-rank neighbours and is therefore a null control.

**Speedup (with rank-packed ÷ without):**

| GPUs | 1 blk/GPU (256³) | 8 (128³) | 64 (64³) | 512 (32³) | 4096 (16³) |
|---:|---:|---:|---:|---:|---:|
| 1 | 1.01x | 1.00x | 1.01x | 1.00x | 1.06x |
| 2 | 1.04x | 1.05x | 1.37x | 1.97x | 3.13x |
| 4 | 1.06x | 1.11x | 1.66x | 3.10x | 6.37x |
| 8 | 0.99x | 1.08x | 1.45x | 3.45x | 6.76x |

The more informative view is what it does to weak-scaling efficiency. Per-GPU
throughput at 8 GPUs relative to 1 GPU:

| blocks/GPU | 1 | 8 | 64 | 512 | 4096 |
|---|---:|---:|---:|---:|---:|
| without rank-packed | 0.92 | 0.84 | 0.63 | 0.27 | **0.15** |
| with rank-packed | 0.90 | 0.91 | 0.90 | 0.93 | **0.95** |

Without rank-packing, weak scaling degrades sharply as blocks get smaller — at 4096
blocks per GPU only 15% of single-GPU throughput survives to 8 GPUs. With it,
efficiency is 0.90–0.95 essentially independently of block size. The change does not
just make the code faster; it removes block size as a scaling variable.

### 5.2 Orszag-Tang MHD, Vista B200, 512², 4 GPUs

Aggregate zone-cycles/s, uniform mesh (exercises both CC and FC paths):

| MeshBlocks (per GPU) | block size | with | without | speedup |
|---|---|---:|---:|---:|
| 16 (4/GPU) | 128² | 1.676e8 | 1.161e8 | 1.44x |
| 64 (16/GPU) | 64² | 1.566e8 | 1.065e8 | 1.47x |
| 256 (64/GPU) | 32² | 1.473e8 | 0.968e8 | 1.52x |

### 5.3 Weak scaling with AMR, Vista B200

3D hydro linear wave, 256³ zones/GPU at root, `num_levels = 2`,
`refinement_interval = 5`, `min_max` criterion on `hydro_w_d` tracking the wave crest.
Final MeshBlock counts are identical between the two builds (refinement is
deterministic). Speedup (with ÷ without):

| GPUs | 8 blk/GPU | 64 | 512 | 4096 |
|---:|---:|---:|---:|---:|
| 1 | 1.00 | 1.00 | 1.01 | 1.04 |
| 2 | 1.07 | 1.27 | 1.91 | 3.18 |
| 4 | 1.15 | 1.31 | 2.24 | 4.21 |
| 8 | 1.10 | 1.25 | 2.15 | 5.89 |
| 16 | 1.05 | 1.26 | 2.51 | — |

### 5.4 Known regime where this is not a win

With **refinement every cycle** (`refinement_interval = 1`) the cached metadata is
rebuilt every cycle, and the rebuild — including its one-shot header exchange —
is not amortised. Orszag-Tang AMR on 4 B200 GPUs:

| configuration | with | without | ratio |
|---|---:|---:|---:|
| uniform | 1.676e8 | 1.161e8 | 1.44x |
| AMR, `refinement_interval = 1` | 3.688e7 | 4.724e7 | 0.78x |
| AMR, `refinement_interval = 10` | 6.530e7 | 6.909e7 | 0.95x |

The deficit also narrows as the root block count grows (0.78x at 64 root blocks,
0.90x at 256), and is gone by `refinement_interval = 5` in the weak-scaling study
above, where the change is a 1.05–5.9x win.

`refinement_interval = 1` is not a common production setting, but the cost is real and
the fix is known: make the rebuild incremental, so that only blocks whose neighbour
set actually changed are re-derived, and skip the header re-exchange for peers whose
entry list is unchanged. That is left for a follow-up rather than folded into this
change.

---

## 6. Notes for reviewers

- **No new input parameters and no runtime toggle.** The rank-packed path replaces the
  per-pair path for both CC and FC variables rather than sitting behind a flag.
- **Serial builds are unaffected.** Every aggregate-buffer path is under
  `#if MPI_PARALLEL_ENABLED` with the original expression under `#else`.
- **Buffer sizing.** `rank_{send,recv}buf_vars_` are sized from the summed entry
  `data_size`, which comes from the same `isame/icoar/ifine` index bookkeeping the
  per-pair path uses, via `GetVarDataSize`. The `is_z4c_` case selects
  `isame_z4c_ndat` exactly as before.
- **Ordering agreement between peers** rests on both sides iterating the same
  `std::map` key order (destination rank) and on the one-shot header exchange
  communicating the sender's within-message entry order. Neither side infers the
  other's layout.
- **Flux correction is unchanged** — `flux_correct_cc.cpp` and `flux_correct_fc.cpp`
  still use the per-pair path. Those exchanges are far less frequent, so aggregating
  them is a separate question.

