### PR TITLE
Refresh MHD ghosts and guard linear-wave neighbor reads

### DIFF
--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -163,14 +163,10 @@ void MeshRefinement::AdaptiveMeshRefinement(Driver *pdriver, ParameterInput *pin
     MeshBlockPack* pmbp = pmy_mesh->pmb_pack;
     if (pmbp->pmhd != nullptr) {
       RepairAMRFC(pmbp->pmhd->b0);
-      if (pmbp->pdyngr == nullptr) {
-        (void) pmbp->pmhd->ConToPrim(pdriver, 0);
-      } else {
-        if (pmbp->pz4c != nullptr) {
-          (void) pmbp->pz4c->ConvertZ4cToADM(pdriver, 0);
-        }
-        (void) pmbp->pdyngr->ConToPrim(pdriver, 0);
-      }
+      // Repair changes internal faces after the first exchange finalized exterior
+      // faces. Refresh neighboring ghost fields and their primitives before the next
+      // reconstruction consumes them.
+      pdriver->InitBoundaryValuesAndPrimitives(pmy_mesh);
     }
     if (pmbp->phydro != nullptr) {
       (void) pmbp->phydro->NewTimeStep(pdriver, pdriver->nexp_stages);

--- a/src/pgen/tests/linear_wave.cpp
+++ b/src/pgen/tests/linear_wave.cpp
@@ -575,15 +575,17 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
       // faces is identical.
 
       // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-      if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+      if ((indcs.nx2 > 1 &&
+          ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
           (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
           (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-          (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-          (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+          (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+          (indcs.nx3 > 1 &&
+          ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -598,7 +600,7 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
           (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
           (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-          (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+          (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
         Real xl = x1v + 0.25*dx1;
         Real xr = x1v - 0.25*dx1;
         a1(m,k,j,i) = 0.5*(A1(xl,x2f,x3f,lwv) + A1(xr,x2f,x3f,lwv));
@@ -613,7 +615,8 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-          (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+          (indcs.nx3 > 1 &&
+          ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -628,7 +631,7 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
           (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
           (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-          (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+          (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
         Real xl = x2v + 0.25*dx2;
         Real xr = x2v - 0.25*dx2;
         a2(m,k,j,i) = 0.5*(A2(x1f,xl,x3f,lwv) + A2(x1f,xr,x3f,lwv));
@@ -643,7 +646,8 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-          (nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+          (indcs.nx2 > 1 &&
+          ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
@@ -658,7 +662,7 @@ void ProblemGenerator::LinearWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,20).lev > mblev.d_view(m) && i==is && j==je+1) ||
           (nghbr.d_view(m,21).lev > mblev.d_view(m) && i==is && j==je+1) ||
           (nghbr.d_view(m,22).lev > mblev.d_view(m) && i==ie+1 && j==je+1) ||
-          (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)) {
+          (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)))) {
         Real xl = x3v + 0.25*dx3;
         Real xr = x3v - 0.25*dx3;
         a3(m,k,j,i) = 0.5*(A3(x1f,x2f,xl,lwv) + A3(x1f,x2f,xr,lwv));


### PR DESCRIPTION
## Summary

Follow up on #739 with two focused fixes:

- Rerun the standard boundary-value and primitive initialization after `RepairAMRFC()` so repaired face-centered magnetic fields are propagated to neighboring ghosts before reconstruction.
- Guard the linear-wave AMR vector-potential neighbor checks by dimensionality. 1D and 2D MeshBlocks allocate 8 and 24 neighbor entries, respectively, but the problem generator could read 2D/3D-only entries. Those out-of-bounds reads made the regenerated MHD reference state rank-layout dependent, first appearing in `B3`.

Both fixes use the existing communication and initialization paths; no new flags or boundary messages are needed. The existing GR linear-wave error bounds are unchanged.

## Why this surfaced after #739

This was a pre-existing problem-generator bug, not a GR/WENOZ solver regression. The invalid accesses date to 2022, and #739 did not modify `linear_wave.cpp`.

In 2D, each MeshBlock has 24 neighbor entries (indices 0–23), but the linear-wave AMR vector-potential correction also inspected 3D-only entries 24–47. With the array’s `LayoutRight` storage, these accesses can alias the next local MeshBlock’s neighbor row, while the final local block reads beyond the allocation. `LinearWaveErrors()` reruns the problem generator on the final AMR topology to construct the reference solution, so the measured error could depend on MeshBlock packing and memory state.

Consistent with this, the exact same #739 commit and source tree passed one 16-rank MPI CI run and failed another; the failure exceeded the bound by only 0.0145%. The AMR changes exposed this latent undefined behavior but did not introduce it. The dimensional guards remove the invalid reads, and the original regression bounds are unchanged.

## Validation

- MPI 2D and deep-3D-L2 div(B) AMR regressions
- Bit-for-bit identical 4-rank and 16-rank 2D GRMHD states through the first AMR regrid
- Full MPI 2D GR linear-wave suite: 4 passed
- MHD/RK3/WENOZ high-resolution RMS-L1 `1.994064e-06` (limit `2.0e-06`), convergence ratio `0.214408` (limit `0.22`)
- Python and C++ style checks: 2 passed