### PR TITLE
Guard lower-dimensional pgen neighbor reads

### DIFF
--- a/src/pgen/dyn_grmhd/dyngr_tov.cpp
+++ b/src/pgen/dyn_grmhd/dyngr_tov.cpp
@@ -240,8 +240,8 @@ void SetupTOV(ParameterInput *pin, Mesh* pmy_mesh_) {
 
   // compute vector potential over all faces
   int ncells1 = indcs.nx1 + 2*(indcs.ng);
-  int ncells2 = (indcs.nx2 > 1) ? (indcs.nx2 + 2*(indcs.ng)) : 1;
-  int ncells3 = (indcs.nx3 > 1) ? (indcs.nx3 + 2*(indcs.ng)) : 1;
+  int ncells2 = (indcs.nx2 > 1) ? (indcs.nx2 + 2*(indcs.ng)) : 2;
+  int ncells3 = (indcs.nx3 > 1) ? (indcs.nx3 + 2*(indcs.ng)) : 2;
   int nmb = pmbp->nmb_thispack;
   DvceArray4D<Real> a1, a2, a3;
   Kokkos::realloc(a1, nmb, ncells3, ncells2, ncells1);
@@ -287,15 +287,17 @@ void SetupTOV(ParameterInput *pin, Mesh* pmy_mesh_) {
     // faces is identical.
 
     // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-    if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+    if ((indcs.nx2 > 1 &&
+        ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -310,7 +312,7 @@ void SetupTOV(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
       Real xl = x1v + 0.25*dx1;
       Real xr = x1v - 0.25*dx1;
       a1(m,k,j,i) = 0.5*(A1(tov_, eos_, isotropic, pcut, magindex, xl,x2f,x3f) +
@@ -326,7 +328,8 @@ void SetupTOV(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -341,7 +344,7 @@ void SetupTOV(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
       Real xl = x2v + 0.25*dx2;
       Real xr = x2v - 0.25*dx2;
       a2(m,k,j,i) = 0.5*(A2(tov_, eos_, isotropic, pcut, magindex, x1f,xl,x3f) +

--- a/src/pgen/dyn_grmhd/elliptica/elliptica.cpp
+++ b/src/pgen/dyn_grmhd/elliptica/elliptica.cpp
@@ -642,15 +642,17 @@ void SetupSystem(ParameterInput *pin, Mesh* pmy_mesh_) {
     // faces is identical.
 
     // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-    if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+    if ((indcs.nx2 > 1 &&
+        ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -665,7 +667,7 @@ void SetupSystem(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
       Real xl = x1v + 0.25 * dx1;
       Real xr = x1v - 0.25 * dx1;
 
@@ -701,7 +703,8 @@ void SetupSystem(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -716,7 +719,7 @@ void SetupSystem(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
       Real xl = x2v + 0.25 * dx2;
       Real xr = x2v - 0.25 * dx2;
 

--- a/src/pgen/dyn_grmhd/lorene/lorene_bns.cpp
+++ b/src/pgen/dyn_grmhd/lorene/lorene_bns.cpp
@@ -374,15 +374,17 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
     // faces is identical.
 
     // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-    if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+    if ((indcs.nx2 > 1 &&
+        ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -397,7 +399,7 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
       Real xl = x1v + 0.25*dx1;
       Real xr = x1v - 0.25*dx1;
       a1(m,k,j,i) = 0.5*((A1(xl - center_m, x2f, x3f, I_0, r_0) +
@@ -415,7 +417,8 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -430,7 +433,7 @@ void SetupBNS(ParameterInput *pin, Mesh* pmy_mesh_) {
         (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
       Real xl = x2v + 0.25*dx2;
       Real xr = x2v - 0.25*dx2;
       a2(m,k,j,i) = 0.5*((A2(x1f - center_m, xl, x3f, I_0, r_0) +

--- a/src/pgen/fluids/gr_torus.cpp
+++ b/src/pgen/fluids/gr_torus.cpp
@@ -497,8 +497,8 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
 
     // compute vector potential over all faces
     int ncells1 = indcs.nx1 + 2*(indcs.ng);
-    int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
-    int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
+    int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 2;
+    int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 2;
     DvceArray4D<Real> a1, a2, a3;
     Kokkos::realloc(a1, nmb,ncells3,ncells2,ncells1);
     Kokkos::realloc(a2, nmb,ncells3,ncells2,ncells1);
@@ -541,15 +541,17 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
       // faces is identical.
 
       // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-      if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+      if ((indcs.nx2 > 1 &&
+          ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
           (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
           (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-          (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-          (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+          (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+          (indcs.nx3 > 1 &&
+          ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -564,7 +566,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
           (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
           (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-          (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+          (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
         Real xl = x1v + 0.25*dx1;
         Real xr = x1v - 0.25*dx1;
         a1(m,k,j,i) = 0.5*(A1(trs, xl,x2f,x3f) + A1(trs, xr,x2f,x3f));
@@ -579,7 +581,8 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-          (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+          (indcs.nx3 > 1 &&
+          ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -594,7 +597,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
           (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
           (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-          (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+          (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
         Real xl = x2v + 0.25*dx2;
         Real xr = x2v - 0.25*dx2;
         a2(m,k,j,i) = 0.5*(A2(trs, x1f,xl,x3f) + A2(trs, x1f,xr,x3f));
@@ -609,7 +612,8 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-          (nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+          (indcs.nx2 > 1 &&
+          ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
@@ -624,7 +628,7 @@ void ProblemGenerator::UserProblem(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,20).lev > mblev.d_view(m) && i==is && j==je+1) ||
           (nghbr.d_view(m,21).lev > mblev.d_view(m) && i==is && j==je+1) ||
           (nghbr.d_view(m,22).lev > mblev.d_view(m) && i==ie+1 && j==je+1) ||
-          (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)) {
+          (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)))) {
         Real xl = x3v + 0.25*dx3;
         Real xr = x3v - 0.25*dx3;
         a3(m,k,j,i) = 0.5*(A3(trs, x1f,x2f,xl) + A3(trs, x1f,x2f,xr));

--- a/src/pgen/tests/cpaw.cpp
+++ b/src/pgen/tests/cpaw.cpp
@@ -218,8 +218,8 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
 
     // compute vector potential over all faces
     int ncells1 = indcs.nx1 + 2*(indcs.ng);
-    int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
-    int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
+    int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 2;
+    int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 2;
     DvceArray4D<Real> a1, a2, a3;
     Kokkos::realloc(a1, nmb,ncells3,ncells2,ncells1);
     Kokkos::realloc(a2, nmb,ncells3,ncells2,ncells1);
@@ -261,15 +261,17 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
       // faces is identical.
 
       // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-      if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+      if ((indcs.nx2 > 1 &&
+          ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
           (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
           (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-          (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-          (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+          (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+          (indcs.nx3 > 1 &&
+          ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -284,7 +286,7 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
           (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
           (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-          (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+          (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
         Real xl = x1v + 0.25*dx1;
         Real xr = x1v - 0.25*dx1;
         a1(m,k,j,i) = 0.5*(A1(xl,x2f,x3f,awv) + A1(xr,x2f,x3f,awv));
@@ -299,7 +301,8 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-          (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+          (indcs.nx3 > 1 &&
+          ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
           (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -314,7 +317,7 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
           (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
           (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-          (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+          (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
         Real xl = x2v + 0.25*dx2;
         Real xr = x2v - 0.25*dx2;
         a2(m,k,j,i) = 0.5*(A2(x1f,xl,x3f,awv) + A2(x1f,xr,x3f,awv));
@@ -329,7 +332,8 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
           (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-          (nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+          (indcs.nx2 > 1 &&
+          ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
           (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
@@ -344,7 +348,7 @@ void ProblemGenerator::AlfvenWave(ParameterInput *pin, const bool restart) {
           (nghbr.d_view(m,20).lev > mblev.d_view(m) && i==is && j==je+1) ||
           (nghbr.d_view(m,21).lev > mblev.d_view(m) && i==is && j==je+1) ||
           (nghbr.d_view(m,22).lev > mblev.d_view(m) && i==ie+1 && j==je+1) ||
-          (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)) {
+          (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)))) {
         Real xl = x3v + 0.25*dx3;
         Real xr = x3v - 0.25*dx3;
         a3(m,k,j,i) = 0.5*(A3(x1f,x2f,xl,awv) + A3(x1f,x2f,xr,awv));

--- a/src/pgen/tests/gr_monopole.cpp
+++ b/src/pgen/tests/gr_monopole.cpp
@@ -156,8 +156,8 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
 
   // compute vector potential over all faces
   int ncells1 = indcs.nx1 + 2*(indcs.ng);
-  int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
-  int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
+  int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 2;
+  int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 2;
   DvceArray4D<Real> a1, a2, a3;
   Kokkos::realloc(a1, nmb,ncells3,ncells2,ncells1);
   Kokkos::realloc(a2, nmb,ncells3,ncells2,ncells1);
@@ -199,15 +199,17 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
     // faces is identical.
 
     // Correct A1 at x2-faces, x3-faces, and x2x3-edges
-    if ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+    if ((indcs.nx2 > 1 &&
+        ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,12).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,13).lev > mblev.d_view(m) && j==je+1) ||
         (nghbr.d_view(m,14).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (nghbr.d_view(m,15).lev > mblev.d_view(m) && j==je+1))) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -222,7 +224,7 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
         (nghbr.d_view(m,44).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,45).lev > mblev.d_view(m) && j==js && k==ke+1) ||
         (nghbr.d_view(m,46).lev > mblev.d_view(m) && j==je+1 && k==ke+1) ||
-        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)) {
+        (nghbr.d_view(m,47).lev > mblev.d_view(m) && j==je+1 && k==ke+1)))) {
       Real xl = x1v + 0.25*dx1;
       Real xr = x1v - 0.25*dx1;
       a1(m,k,j,i) = 0.5*(A1(a_norm,spin,xl,x2f,x3f) + A1(a_norm,spin,xr,x2f,x3f));
@@ -237,7 +239,8 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
         (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-        (nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
+        (indcs.nx3 > 1 &&
+        ((nghbr.d_view(m,24).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,25).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,26).lev > mblev.d_view(m) && k==ks) ||
         (nghbr.d_view(m,27).lev > mblev.d_view(m) && k==ks) ||
@@ -252,7 +255,7 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
         (nghbr.d_view(m,36).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,37).lev > mblev.d_view(m) && i==is && k==ke+1) ||
         (nghbr.d_view(m,38).lev > mblev.d_view(m) && i==ie+1 && k==ke+1) ||
-        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)) {
+        (nghbr.d_view(m,39).lev > mblev.d_view(m) && i==ie+1 && k==ke+1)))) {
       Real xl = x2v + 0.25*dx2;
       Real xr = x2v - 0.25*dx2;
       a2(m,k,j,i) = 0.5*(A2(a_norm,spin,x1f,xl,x3f) + A2(a_norm,spin,x1f,xr,x3f));
@@ -267,7 +270,8 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
         (nghbr.d_view(m,5 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,6 ).lev > mblev.d_view(m) && i==ie+1) ||
         (nghbr.d_view(m,7 ).lev > mblev.d_view(m) && i==ie+1) ||
-        (nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
+        (indcs.nx2 > 1 &&
+        ((nghbr.d_view(m,8 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,9 ).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,10).lev > mblev.d_view(m) && j==js) ||
         (nghbr.d_view(m,11).lev > mblev.d_view(m) && j==js) ||
@@ -282,7 +286,7 @@ void ProblemGenerator::Monopole(ParameterInput *pin, const bool restart) {
         (nghbr.d_view(m,20).lev > mblev.d_view(m) && i==is && j==je+1) ||
         (nghbr.d_view(m,21).lev > mblev.d_view(m) && i==is && j==je+1) ||
         (nghbr.d_view(m,22).lev > mblev.d_view(m) && i==ie+1 && j==je+1) ||
-        (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)) {
+        (nghbr.d_view(m,23).lev > mblev.d_view(m) && i==ie+1 && j==je+1)))) {
       Real xl = x3v + 0.25*dx3;
       Real xr = x3v - 0.25*dx3;
       a3(m,k,j,i) = 0.5*(A3(a_norm,spin,x1f,x2f,xl) + A3(a_norm,spin,x1f,x2f,xr));

--- a/tst/inputs/cpaw.athinput
+++ b/tst/inputs/cpaw.athinput
@@ -1,0 +1,60 @@
+# Circularly polarized Alfven wave with static mesh refinement
+
+<job>
+basename = cpaw
+
+<mesh>
+nghost = 2
+nx1 = 32
+x1min = 0.0
+x1max = 2.0
+ix1_bc = periodic
+ox1_bc = periodic
+nx2 = 1
+x2min = 0.0
+x2max = 1.0
+ix2_bc = periodic
+ox2_bc = periodic
+nx3 = 1
+x3min = 0.0
+x3max = 1.0
+
+<meshblock>
+nx1 = 8
+nx2 = 1
+nx3 = 1
+
+<mesh_refinement>
+refinement = static
+
+<refined_region1>
+level = 1
+x1min = 0.8
+x1max = 1.2
+x2min = 0.4
+x2max = 0.6
+
+<time>
+evolution = dynamic
+integrator = rk2
+cfl_number = 0.3
+nlim = -1
+tlim = 1.0
+ndiag = 100000
+
+<mhd>
+eos = ideal
+reconstruct = plm
+rsolver = llf
+gamma = 1.66666666667
+
+<problem>
+pgen_name = cpaw
+b_par = 1.0
+b_perp = 0.1
+pres = 0.1
+v_par = 0.0
+right_polar = true
+along_x1 = false
+along_x2 = false
+along_x3 = false

--- a/tst/test_suite/nr/test_nr_cpaw_amr_cpu.py
+++ b/tst/test_suite/nr/test_nr_cpaw_amr_cpu.py
@@ -1,0 +1,59 @@
+"""Circularly polarized Alfven wave convergence in 1D/2D with static AMR."""
+
+import pytest
+
+import athena_read
+import test_suite.testutils as testutils
+
+
+_CASES = [
+    pytest.param("1D", "cpaw1d", 2.0e-3, 0.35, id="1d"),
+    pytest.param("2D", "cpaw2d", 7.0e-3, 0.45, id="2d"),
+]
+_RESOLUTIONS = [32, 64]
+_RMS_L1_INDEX = 4
+
+
+def arguments(label, basename, resolution):
+    """Return a four-block-per-active-direction CPAW mesh."""
+    one_d = label == "1D"
+    return [
+        f"job/basename={basename}",
+        f"mesh/nx1={resolution}",
+        f"mesh/nx2={1 if one_d else resolution // 2}",
+        "mesh/nx3=1",
+        f"meshblock/nx1={resolution // 4}",
+        f"meshblock/nx2={1 if one_d else resolution // 8}",
+        "meshblock/nx3=1",
+        f"problem/along_x1={'true' if one_d else 'false'}",
+    ]
+
+
+@pytest.mark.parametrize("label,basename,max_error,max_ratio", _CASES)
+def test_run(label, basename, max_error, max_ratio):
+    """Check lower-dimensional CPAW accuracy and convergence across static AMR."""
+    try:
+        for resolution in _RESOLUTIONS:
+            results = testutils.run(
+                "inputs/cpaw.athinput",
+                arguments(label, basename, resolution),
+            )
+            assert results, f"{label} CPAW run failed at resolution {resolution}."
+
+        data = athena_read.error_dat(f"{basename}-errs.dat")
+        low_error = data[0][_RMS_L1_INDEX]
+        high_error = data[1][_RMS_L1_INDEX]
+        ratio = high_error / low_error
+
+        if high_error > max_error:
+            pytest.fail(
+                f"{label} CPAW error too large: {high_error:g}, "
+                f"threshold {max_error:g}"
+            )
+        if ratio > max_ratio:
+            pytest.fail(
+                f"{label} CPAW convergence too slow: {ratio:g}, "
+                f"threshold {max_ratio:g}"
+            )
+    finally:
+        testutils.cleanup()


### PR DESCRIPTION
## Summary

- apply the lower-dimensional neighbor guards from #777 to the six remaining problem generators that use the same fine-neighbor vector-potential correction
- allocate the two face planes evaluated in collapsed directions where needed
- add a 1D/2D static-AMR CPAW convergence regression

This does not make the intrinsically 3D problem generators support lower-dimensional runs; it makes their shared initialization logic dimensionally correct and leaves the 3D path unchanged.

## Validation

- CPU regression entry point: `2 passed`
- style suite: `2 passed`
- bounds-checked Debug CPAW runs: 1D and 2D complete cleanly
- CPAW RMS-L1 error from 32 to 64 cells: 1D `4.314182e-3 -> 1.182409e-3`; 2D `1.376344e-2 -> 4.963514e-3`

`linear_wave.cpp` remains in #777, so the two PRs do not overlap.
