### PR TITLE
Add RKL2 super-time-stepping for diffusion

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
         diffusion/ambipolar.cpp
         diffusion/conduction.cpp
         diffusion/resistivity.cpp
+        diffusion/sts_rkl2.cpp
         diffusion/viscosity.cpp
 
         driver/driver.cpp
@@ -68,6 +69,7 @@ add_executable(
         hydro/hydro_fluxes.cpp
         hydro/hydro_fofc.cpp
         hydro/hydro_newdt.cpp
+        hydro/hydro_sts.cpp
         hydro/hydro_tasks.cpp
         hydro/hydro_update.cpp
 
@@ -94,6 +96,7 @@ add_executable(
         mhd/mhd_fluxes.cpp
         mhd/mhd_fofc.cpp
         mhd/mhd_newdt.cpp
+        mhd/mhd_sts.cpp
         mhd/mhd_tasks.cpp
         mhd/mhd_update.cpp
 

--- a/src/diffusion/conduction.cpp
+++ b/src/diffusion/conduction.cpp
@@ -10,6 +10,8 @@
 
 #include <float.h>
 #include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <string>
 #include <iostream> // cout
@@ -23,6 +25,27 @@
 #include "eos/eos.hpp"
 #include "conduction.hpp"
 #include "units/units.hpp"
+
+namespace {
+
+parabolic::DiffusionSelection ParseConductivityIntegrator(const std::string &block,
+                                                           ParameterInput *pin) {
+  std::string integrator =
+      pin->GetOrAddString(block, "conductivity_integrator", "explicit");
+  if (integrator == "explicit") {
+    return parabolic::DiffusionSelection::explicit_only;
+  }
+  if (integrator == "sts") {
+    return parabolic::DiffusionSelection::sts_only;
+  }
+
+  std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+            << "<" << block << ">/conductivity_integrator = '" << integrator
+            << "' must be 'explicit' or 'sts'" << std::endl;
+  std::exit(EXIT_FAILURE);
+}
+
+} // namespace
 
 // VanLeer Limiter which takes 2 slopes
 KOKKOS_INLINE_FUNCTION
@@ -64,6 +87,7 @@ Real TempDepKappa(Real temp, Real limit) {
 
 Conduction::Conduction(std::string block, MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
+  dtnew = static_cast<Real>(std::numeric_limits<float>::max());
   // Read parameters for thermal diffusivity (if any)
   alpha_iso = pin->GetOrAddReal(block,"alpha_iso", 0.0);
   alpha_aniso = pin->GetOrAddReal(block,"alpha_aniso", 0.0);
@@ -71,6 +95,15 @@ Conduction::Conduction(std::string block, MeshBlockPack *pp, ParameterInput *pin
   // Limit on thermal heat flux (saturated conduction)
   q_limit = pin->GetOrAddReal(block,"q_limit",
                      static_cast<Real>(std::numeric_limits<float>::max()));
+  mode = ParseConductivityIntegrator(block, pin);
+  if (mode == parabolic::DiffusionSelection::sts_only &&
+      (!std::isfinite(alpha_iso) || !std::isfinite(alpha_aniso) || alpha_iso <= 0.0 ||
+       alpha_aniso != 0.0 || alpha_spitzer)) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+              << "STS requires positive constant isotropic thermal conduction"
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
 }
 
 //----------------------------------------------------------------------------------------
@@ -313,14 +346,6 @@ void Conduction::AddHeatFluxSpitzer(const DvceArray5D<Real> &w0, const EOS_Data 
 
 void Conduction::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_data) {
   dtnew = static_cast<Real>(std::numeric_limits<float>::max());
-  Real fac;
-  if (pmy_pack->pmesh->three_d) {
-    fac = 1.0/6.0;
-  } else if (pmy_pack->pmesh->two_d) {
-    fac = 0.25;
-  } else {
-    fac = 0.5;
-  }
 //  if (sat_hflux == true) {
 //    dtnew = static_cast<Real>(std::numeric_limits<float>::max());
 //    return;
@@ -359,21 +384,26 @@ void Conduction::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_da
     k += ks;
     j += js;
 
-    Real alpha_ = alpha0;
+    Real row_sum = 0.5*(w0_(m,IDN,k,j,i-1) + 2.0*w0_(m,IDN,k,j,i) +
+                        w0_(m,IDN,k,j,i+1))/SQR(size.d_view(m).dx1);
+    if (multi_d) {
+      row_sum += 0.5*(w0_(m,IDN,k,j-1,i) + 2.0*w0_(m,IDN,k,j,i) +
+                     w0_(m,IDN,k,j+1,i))/SQR(size.d_view(m).dx2);
+    }
+    if (three_d) {
+      row_sum += 0.5*(w0_(m,IDN,k-1,j,i) + 2.0*w0_(m,IDN,k,j,i) +
+                     w0_(m,IDN,k+1,j,i))/SQR(size.d_view(m).dx3);
+    }
 //    if (spitzer_) {
 //      Real temp = w0(m,IEN,k,j,i)/w0(m,IDN,k,j,i)*gm1;
 //      kappa_ = TempDepKappa(temp*temp_unit, limit_)/kappa_unit;
 //    }
 
-    min_dt = fmin(min_dt, SQR(size.d_view(m).dx1)/alpha_*w0_(m,IDN,k,j,i)/gm1);
-    if (multi_d) {
-      min_dt = fmin(min_dt, SQR(size.d_view(m).dx2)/alpha_*w0_(m,IDN,k,j,i)/gm1);
-    }
-    if (three_d) {
-      min_dt = fmin(min_dt, SQR(size.d_view(m).dx3)/alpha_*w0_(m,IDN,k,j,i)/gm1);
+    Real rate = alpha0*gm1*row_sum/w0_(m,IDN,k,j,i);
+    if (rate > 0.0) {
+      min_dt = fmin(min_dt, 1.0/rate);
     }
   }, Kokkos::Min<Real>(dtnew));
-  dtnew *= fac;
 
   return;
 }

--- a/src/diffusion/conduction.hpp
+++ b/src/diffusion/conduction.hpp
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "athena.hpp"
+#include "diffusion/sts_types.hpp"
 #include "parameter_input.hpp"
 
 //----------------------------------------------------------------------------------------
@@ -29,6 +30,7 @@ class Conduction {
   Real alpha_aniso;     // anisotropic thermal diffusivity
   bool alpha_spitzer;   // switch to turn on Spitzer conductivity
   Real q_limit;         // saturated heat flux limit
+  parabolic::DiffusionSelection mode = parabolic::DiffusionSelection::explicit_only;
 
   // functions
   void AddHeatFluxes(const DvceArray5D<Real> &w, const EOS_Data &eos,

--- a/src/diffusion/parabolic_process.hpp
+++ b/src/diffusion/parabolic_process.hpp
@@ -1,0 +1,37 @@
+#ifndef DIFFUSION_PARABOLIC_PROCESS_HPP_
+#define DIFFUSION_PARABOLIC_PROCESS_HPP_
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file parabolic_process.hpp
+//! \brief Metadata for diffusion processes that may use STS.
+
+#include <cassert>
+#include <string>
+
+#include "athena.hpp"
+#include "diffusion/sts_types.hpp"
+
+namespace parabolic {
+
+struct ParabolicProcessDescriptor {
+  std::string name;
+  ParabolicProcessOwner owner;
+  DiffusionSelection selection;
+  const Real *explicit_dt_ptr;
+
+  bool UsesSTS() const {
+    return selection == DiffusionSelection::sts_only;
+  }
+
+  Real ExplicitDt() const {
+    assert(explicit_dt_ptr != nullptr);
+    return *explicit_dt_ptr;
+  }
+};
+
+} // namespace parabolic
+
+#endif // DIFFUSION_PARABOLIC_PROCESS_HPP_

--- a/src/diffusion/resistivity.cpp
+++ b/src/diffusion/resistivity.cpp
@@ -8,6 +8,8 @@
 
 #include <float.h>
 #include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <string> // string
@@ -20,14 +22,49 @@
 #include "resistivity.hpp"
 #include "current_density.hpp"
 
+namespace {
+
+parabolic::DiffusionSelection ParseResistivityIntegrator(ParameterInput *pin) {
+  std::string integrator = pin->GetOrAddString("mhd", "resistivity_integrator",
+                                               "explicit");
+  if (integrator == "explicit") {
+    return parabolic::DiffusionSelection::explicit_only;
+  }
+  if (integrator == "sts") {
+    return parabolic::DiffusionSelection::sts_only;
+  }
+
+  std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+            << "<mhd>/resistivity_integrator = '" << integrator
+            << "' must be 'explicit' or 'sts'" << std::endl;
+  std::exit(EXIT_FAILURE);
+}
+
+} // namespace
+
 //----------------------------------------------------------------------------------------
 // ctor: also calls Resistivity base class constructor
 
 Resistivity::Resistivity(MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
+  dtnew = static_cast<Real>(std::numeric_limits<float>::max());
   // Read non-ideal MHD coefficients (if any). A non-zero value enables the term.
   eta_ohm = pin->GetOrAddReal("mhd","eta_ohm",0.0);
   eta_ad  = pin->GetOrAddReal("mhd","eta_ad",0.0);
+  mode = ParseResistivityIntegrator(pin);
+  if (mode == parabolic::DiffusionSelection::sts_only &&
+      (!std::isfinite(eta_ad) || eta_ad != 0.0)) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+              << "Ambipolar diffusion is not supported with STS; use explicit "
+              << "integration" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  if (mode == parabolic::DiffusionSelection::sts_only &&
+      (!std::isfinite(eta_ohm) || eta_ohm <= 0.0)) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+              << "STS requires positive constant Ohmic resistivity" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/diffusion/resistivity.hpp
+++ b/src/diffusion/resistivity.hpp
@@ -14,6 +14,7 @@
 //  either parameter triggers construction of this class in the MHD constructor.
 
 #include "athena.hpp"
+#include "diffusion/sts_types.hpp"
 #include "parameter_input.hpp"
 #include "mesh/meshblock.hpp"
 
@@ -31,6 +32,8 @@ class Resistivity {
   Real dtnew;
   Real eta_ohm;   // Ohmic resistivity coefficient (0 => Ohmic term off)
   Real eta_ad;    // ambipolar diffusion coefficient (0 => ambipolar term off)
+  parabolic::DiffusionSelection mode =
+      parabolic::DiffusionSelection::explicit_only;
 
   // wrapper functions: add non-ideal E-Field and energy (Poynting) flux. Each dispatches
   // to the Ohmic and/or ambipolar implementations depending on which coefficients are on.

--- a/src/diffusion/sts_rkl2.cpp
+++ b/src/diffusion/sts_rkl2.cpp
@@ -1,0 +1,123 @@
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file sts_rkl2.cpp
+//! \brief Host-side RKL2 stage-count and coefficient helpers.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "diffusion/sts_rkl2.hpp"
+
+namespace {
+
+[[noreturn]] void STSFatalError(const char *file, int line, const std::string &msg) {
+  std::cout << "### FATAL ERROR in " << file << " at line " << line << std::endl
+            << msg << std::endl;
+  std::exit(EXIT_FAILURE);
+}
+
+Real RawBj(int j) {
+  Real jr = static_cast<Real>(j);
+  return (jr*jr + jr - 2.0)/(2.0*jr*(jr + 1.0));
+}
+
+long double RKL2MaxRatio(int nstages) {
+  long double sr = static_cast<long double>(nstages);
+  return 0.25L*(sr*sr + sr - 2.0L);
+}
+
+} // namespace
+
+namespace parabolic {
+
+int ComputeRKL2StageCount(Real dt_sweep, Real dt_parabolic_min) {
+  if (dt_sweep < 0.0) {
+    STSFatalError(__FILE__, __LINE__,
+                  "dt_sweep must be non-negative in RKL2 stage-count calculation");
+  }
+  if (dt_parabolic_min <= 0.0) {
+    STSFatalError(__FILE__, __LINE__,
+                  "dt_parabolic_min must be positive in RKL2 stage-count calculation");
+  }
+
+  long double ratio = static_cast<long double>(dt_sweep)/
+                      static_cast<long double>(dt_parabolic_min);
+  constexpr int min_nstages = 3;
+  constexpr int max_nstages = std::numeric_limits<int>::max();
+  if (!std::isfinite(ratio) || ratio > RKL2MaxRatio(max_nstages)) {
+    STSFatalError(__FILE__, __LINE__,
+                  "required RKL2 stage count exceeds the supported integer range");
+  }
+
+  long double estimate = 0.5L*(-1.0L + std::sqrt(9.0L + 16.0L*ratio));
+  int nstages = static_cast<int>(std::ceil(estimate));
+  nstages = std::max(nstages, min_nstages);
+  if ((nstages % 2) == 0) {
+    ++nstages;
+  }
+
+  // Correct roundoff in the inverse estimate and return the smallest sufficient odd s.
+  while (RKL2MaxRatio(nstages) < ratio) {
+    if (nstages > max_nstages - 2) {
+      STSFatalError(__FILE__, __LINE__,
+                    "required RKL2 stage count exceeds the supported integer range");
+    }
+    nstages += 2;
+  }
+  while (nstages > min_nstages && RKL2MaxRatio(nstages - 2) >= ratio) {
+    nstages -= 2;
+  }
+  return nstages;
+}
+
+RKL2Coefficients ComputeRKL2Coefficients(int stage, int nstages) {
+  if (nstages < 2) {
+    STSFatalError(__FILE__, __LINE__,
+                  "nstages must be at least 2 in RKL2 coefficient calculation");
+  }
+  if (stage < 1 || stage > nstages) {
+    STSFatalError(__FILE__, __LINE__,
+                  "stage must satisfy 1 <= stage <= nstages in RKL2 coefficient "
+                  "calculation");
+  }
+
+  constexpr Real one_third = 1.0/3.0;
+  Real bj = 0.0;
+  Real bj_m1 = 0.0;
+  Real bj_m2 = 0.0;
+
+  if (stage == 1 || stage == 2) {
+    bj = bj_m1 = bj_m2 = one_third;
+  } else {
+    bj = RawBj(stage);
+    if (stage == 3) {
+      bj_m1 = bj_m2 = one_third;
+    } else {
+      bj_m1 = RawBj(stage - 1);
+      bj_m2 = (stage == 4) ? one_third : RawBj(stage - 2);
+    }
+  }
+
+  RKL2Coefficients coeffs;
+  coeffs.muj = ((2.0*stage - 1.0)/stage)*bj/bj_m1;
+  coeffs.nuj = -((stage - 1.0)/stage)*bj/bj_m2;
+
+  Real nstages_r = static_cast<Real>(nstages);
+  Real denom = nstages_r*nstages_r + nstages_r - 2.0;
+  if (stage == 1) {
+    coeffs.muj_tilde = bj*4.0/denom;
+  } else {
+    coeffs.muj_tilde = coeffs.muj*4.0/denom;
+    coeffs.gammaj_tilde = -(1.0 - bj_m1)*coeffs.muj_tilde;
+  }
+  return coeffs;
+}
+
+} // namespace parabolic

--- a/src/diffusion/sts_rkl2.hpp
+++ b/src/diffusion/sts_rkl2.hpp
@@ -1,0 +1,27 @@
+#ifndef DIFFUSION_STS_RKL2_HPP_
+#define DIFFUSION_STS_RKL2_HPP_
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file sts_rkl2.hpp
+//! \brief Host-side RKL2 stage-count and coefficient helpers.
+
+#include "athena.hpp"
+
+namespace parabolic {
+
+struct RKL2Coefficients {
+  Real muj = 0.0;
+  Real nuj = 0.0;
+  Real muj_tilde = 0.0;
+  Real gammaj_tilde = 0.0;
+};
+
+int ComputeRKL2StageCount(Real dt_sweep, Real dt_parabolic_min);
+RKL2Coefficients ComputeRKL2Coefficients(int stage, int nstages);
+
+} // namespace parabolic
+
+#endif // DIFFUSION_STS_RKL2_HPP_

--- a/src/diffusion/sts_types.hpp
+++ b/src/diffusion/sts_types.hpp
@@ -1,0 +1,19 @@
+#ifndef DIFFUSION_STS_TYPES_HPP_
+#define DIFFUSION_STS_TYPES_HPP_
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file sts_types.hpp
+//! \brief Shared types for selecting parabolic integration methods.
+
+namespace parabolic {
+
+enum class STSIntegrator {none, rkl2};
+enum class DiffusionSelection {explicit_only, sts_only};
+enum class ParabolicProcessOwner {hydro, mhd};
+
+} // namespace parabolic
+
+#endif // DIFFUSION_STS_TYPES_HPP_

--- a/src/diffusion/viscosity.cpp
+++ b/src/diffusion/viscosity.cpp
@@ -10,6 +10,8 @@
 
 #include <float.h>
 #include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <iostream>
 #include <string> // string
@@ -21,6 +23,27 @@
 #include "eos/eos.hpp"
 #include "viscosity.hpp"
 
+namespace {
+
+parabolic::DiffusionSelection ParseViscosityIntegrator(const std::string &block,
+                                                        ParameterInput *pin) {
+  std::string integrator =
+      pin->GetOrAddString(block, "viscosity_integrator", "explicit");
+  if (integrator == "explicit") {
+    return parabolic::DiffusionSelection::explicit_only;
+  }
+  if (integrator == "sts") {
+    return parabolic::DiffusionSelection::sts_only;
+  }
+
+  std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+            << "<" << block << ">/viscosity_integrator = '" << integrator
+            << "' must be 'explicit' or 'sts'" << std::endl;
+  std::exit(EXIT_FAILURE);
+}
+
+} // namespace
+
 //----------------------------------------------------------------------------------------
 // ctor:
 // Note first argument passes string ("hydro" or "mhd") denoting in which class this
@@ -29,9 +52,18 @@
 
 Viscosity::Viscosity(std::string block, MeshBlockPack *pp, ParameterInput *pin) :
     pmy_pack(pp) {
+  dtnew = static_cast<Real>(std::numeric_limits<float>::max());
   // Read parameters for viscosity (if any)
   nu_iso = pin->GetOrAddReal(block,"nu_iso",0.0);
   nu_aniso = pin->GetOrAddReal(block,"nu_aniso",0.0);
+  mode = ParseViscosityIntegrator(block, pin);
+  if (mode == parabolic::DiffusionSelection::sts_only &&
+      (!std::isfinite(nu_iso) || !std::isfinite(nu_aniso) || nu_iso <= 0.0 ||
+       nu_aniso != 0.0)) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__ << std::endl
+              << "STS requires positive constant isotropic viscosity" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
 }
 
 //----------------------------------------------------------------------------------------
@@ -229,23 +261,23 @@ void Viscosity::AddViscousFluxAniso(const DvceArray5D<Real> &w0, const EOS_Data 
 void Viscosity::NewTimeStep(const DvceArray5D<Real> &w0, const EOS_Data &eos_data) {
   // viscous timestep on MeshBlock(s) in this pack for constant isotropic viscosity
   dtnew = std::numeric_limits<float>::max();
+  if (nu_iso <= 0.0) return;
   auto size = pmy_pack->pmb->mb_size;
-  Real fac;
-  if (pmy_pack->pmesh->three_d) {
-    fac = 1.0/6.0;
-  } else if (pmy_pack->pmesh->two_d) {
-    fac = 0.25;
-  } else {
-    fac = 0.5;
-  }
   for (int m=0; m<(pmy_pack->nmb_thispack); ++m) {
-    dtnew = std::min(dtnew, fac*SQR(size.h_view(m).dx1)/nu_iso);
+    Real inv_dx2_sum = 1.0/SQR(size.h_view(m).dx1);
+    Real inv_dx2_max = inv_dx2_sum;
     if (pmy_pack->pmesh->multi_d) {
-      dtnew = std::min(dtnew, fac*SQR(size.h_view(m).dx2)/nu_iso);
+      Real inv_dx2 = 1.0/SQR(size.h_view(m).dx2);
+      inv_dx2_sum += inv_dx2;
+      inv_dx2_max = std::max(inv_dx2_max, inv_dx2);
     }
     if (pmy_pack->pmesh->three_d) {
-      dtnew = std::min(dtnew, fac*SQR(size.h_view(m).dx3)/nu_iso);
+      Real inv_dx2 = 1.0/SQR(size.h_view(m).dx3);
+      inv_dx2_sum += inv_dx2;
+      inv_dx2_max = std::max(inv_dx2_max, inv_dx2);
     }
+    Real rate = 2.0*nu_iso*(inv_dx2_sum + inv_dx2_max/3.0);
+    dtnew = std::min(dtnew, 1.0/rate);
   }
   return;
 }

--- a/src/diffusion/viscosity.hpp
+++ b/src/diffusion/viscosity.hpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "athena.hpp"
+#include "diffusion/sts_types.hpp"
 #include "parameter_input.hpp"
 #include "mesh/mesh.hpp"
 
@@ -29,6 +30,7 @@ class Viscosity {
   Real dtnew;
   Real nu_iso;      // coefficient of isotropic kinematic shear viscosity
   Real nu_aniso;    // coefficient of anisotropic kinematic shear viscosity
+  parabolic::DiffusionSelection mode = parabolic::DiffusionSelection::explicit_only;
 
   // function to add viscous fluxes to Hydro and/or MHD fluxes
   void AddViscousFluxes(const DvceArray5D<Real> &w, const EOS_Data &eos,

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -10,12 +10,14 @@
 #include <iomanip>    // std::setprecision()
 #include <limits>
 #include <algorithm>
+#include <cstdlib>
 #include <string> // string
 
 #include "athena.hpp"
 #include "globals.hpp"
 #include "parameter_input.hpp"
 #include "mesh/mesh.hpp"
+#include "coordinates/coordinates.hpp"
 #include "outputs/outputs.hpp"
 #include "hydro/hydro.hpp"
 #include "mhd/mhd.hpp"
@@ -30,6 +32,16 @@
 #if MPI_PARALLEL_ENABLED
 #include <mpi.h>
 #endif
+
+namespace {
+
+[[noreturn]] void DriverFatalError(const char *file, int line, const std::string &msg) {
+  std::cout << "### FATAL ERROR in " << file << " at line " << line << std::endl
+            << msg << std::endl;
+  std::exit(EXIT_FAILURE);
+}
+
+} // namespace
 
 //----------------------------------------------------------------------------------------
 // constructor, initializes data structures and parameters
@@ -278,7 +290,143 @@ Driver::Driver(ParameterInput *pin, Mesh *pmesh, Real wtlim, Kokkos::Timer* ptim
          << "Valid choices are [rk1,rk2,rk3,rk4,imex2,imex3]." << std::endl;
       exit(EXIT_FAILURE);
     }
+
+    ValidateSTSConfiguration(pmesh);
   }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn Driver::ResetSTSController()
+//! \brief Clear cycle-local STS controller state.
+
+void Driver::ResetSTSController() {
+  sts.enabled = false;
+  sts.integrator = parabolic::STSIntegrator::none;
+  sts.sweep = STSSweep::none;
+  sts.dt_cycle = 0.0;
+  sts.dt_sweep = 0.0;
+  sts.dt_parabolic_min = std::numeric_limits<float>::max();
+  sts.nstages = 0;
+  sts.current_stage = 0;
+  sts.coeffs = parabolic::RKL2Coefficients{};
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn Driver::ValidateSTSConfiguration()
+//! \brief Validate global STS settings against registered diffusion processes.
+
+void Driver::ValidateSTSConfiguration(Mesh *pm) {
+  int nsts_processes = 0;
+  const parabolic::ParabolicProcessDescriptor *first_sts_process = nullptr;
+  bool has_hydro_sts = false;
+  bool has_mhd_sts = false;
+
+  for (const auto &process : pm->pmb_pack->parabolic_processes) {
+    if (!process.UsesSTS()) {
+      continue;
+    }
+    ++nsts_processes;
+    if (first_sts_process == nullptr) {
+      first_sts_process = &process;
+    }
+    has_hydro_sts |= process.owner == parabolic::ParabolicProcessOwner::hydro;
+    has_mhd_sts |= process.owner == parabolic::ParabolicProcessOwner::mhd;
+  }
+
+  if (pm->sts_integrator == parabolic::STSIntegrator::none) {
+    if (first_sts_process != nullptr) {
+      DriverFatalError(__FILE__, __LINE__,
+                       "Parabolic process '" + first_sts_process->name +
+                       "' selects STS, but <time>/sts_integrator = none");
+    }
+    return;
+  }
+
+  if (nsts_processes == 0) {
+    DriverFatalError(__FILE__, __LINE__,
+                     "<time>/sts_integrator = rkl2 requires at least one active "
+                     "diffusion process with *_integrator = sts");
+  }
+  if (pm->pmb_pack->pionn != nullptr) {
+    DriverFatalError(__FILE__, __LINE__,
+                     "STS is not supported with <ion-neutral> physics");
+  }
+  if (pm->pmb_pack->prad != nullptr) {
+    DriverFatalError(__FILE__, __LINE__,
+                     "Hydro/MHD STS diffusion is not supported with <radiation> physics");
+  }
+  if (pm->pmb_pack->pcoord->is_special_relativistic ||
+      pm->pmb_pack->pcoord->is_general_relativistic ||
+      pm->pmb_pack->pcoord->is_dynamical_relativistic) {
+    DriverFatalError(__FILE__, __LINE__,
+                     "STS diffusion currently supports only Newtonian Hydro and MHD");
+  }
+
+  hydro::Hydro *phydro = pm->pmb_pack->phydro;
+  if (has_hydro_sts && phydro != nullptr &&
+      (phydro->porb_u != nullptr || phydro->psbox_u != nullptr)) {
+    DriverFatalError(__FILE__, __LINE__,
+                     "Hydro STS is not supported with shearing-box or orbital advection");
+  }
+
+  mhd::MHD *pmhd = pm->pmb_pack->pmhd;
+  if (has_mhd_sts && pmhd != nullptr &&
+      (pmhd->porb_u != nullptr || pmhd->porb_b != nullptr ||
+       pmhd->psbox_u != nullptr || pmhd->psbox_b != nullptr)) {
+    DriverFatalError(__FILE__, __LINE__,
+                     "MHD STS is not supported with shearing-box or orbital advection");
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn Driver::RefreshSTSCycleState()
+//! \brief Refresh cycle-local STS controller data from the Mesh timestep budget.
+
+void Driver::RefreshSTSCycleState(Mesh *pm) {
+  ResetSTSController();
+  sts.integrator = pm->sts_integrator;
+  sts.dt_cycle = pm->dt;
+  sts.dt_parabolic_min = pm->dt_parabolic_sts;
+
+  if (sts.integrator == parabolic::STSIntegrator::none || sts.dt_cycle <= 0.0 ||
+      sts.dt_parabolic_min >= std::numeric_limits<float>::max()) {
+    return;
+  }
+
+  sts.dt_sweep = 0.5*sts.dt_cycle;
+  sts.nstages = parabolic::ComputeRKL2StageCount(sts.dt_sweep,
+                                                 sts.dt_parabolic_min);
+  sts.enabled = sts.nstages > 0;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn Driver::BeginSTSSweep()
+//! \brief Initialize the controller for one pre- or post-RK parabolic sweep.
+
+void Driver::BeginSTSSweep(Mesh *pm, STSSweep sweep) {
+  RefreshSTSCycleState(pm);
+  if (sts.enabled) {
+    sts.sweep = sweep;
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn Driver::SetSTSStage()
+//! \brief Set the coefficients for one RKL2 stage.
+
+void Driver::SetSTSStage(int stage) {
+  sts.current_stage = stage;
+  sts.coeffs = parabolic::ComputeRKL2Coefficients(stage, sts.nstages);
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn Driver::EndSTSSweep()
+//! \brief Clear sweep-local state.
+
+void Driver::EndSTSSweep() {
+  sts.sweep = STSSweep::none;
+  sts.current_stage = 0;
+  sts.coeffs = parabolic::RKL2Coefficients{};
 }
 
 //----------------------------------------------------------------------------------------
@@ -335,6 +483,7 @@ void Driver::Initialize(Mesh *pmesh, ParameterInput *pin, Outputs *pout, bool re
     }
 
     pmesh->NewTimeStep(tlim);
+    RefreshSTSCycleState(pmesh);
   }
 
   //---- Step 3.  Cycle through output Types and load data / write files.
@@ -396,6 +545,17 @@ void Driver::Execute(Mesh *pmesh, ParameterInput *pin, Outputs *pout, bool wdfla
       if (global_variable::my_rank == 0) {OutputCycleDiagnostics(pmesh);}
       if (wdflag) {WatchDog(0);}
 
+      if (sts.enabled) {
+        BeginSTSSweep(pmesh, STSSweep::pre);
+        for (int sts_stage=1; sts_stage<=sts.nstages; ++sts_stage) {
+          SetSTSStage(sts_stage);
+          ExecuteTaskList(pmesh, "before_parabolic_stagen", sts_stage);
+          ExecuteTaskList(pmesh, "parabolic_stagen", sts_stage);
+          ExecuteTaskList(pmesh, "after_parabolic_stagen", sts_stage);
+        }
+        EndSTSSweep();
+      }
+
       // Execute TaskLists
       // Work before time integrator indicated by "0" in stage
       ExecuteTaskList(pmesh, "before_timeintegrator", 0);
@@ -412,6 +572,23 @@ void Driver::Execute(Mesh *pmesh, ParameterInput *pin, Outputs *pout, bool wdfla
 
       // Work after time integrator indicated by "1" in stage
       ExecuteTaskList(pmesh, "after_timeintegrator", 1);
+
+      // Diffusion coefficients may depend on the post-RK state. Refresh the global
+      // stability bound before choosing the second Strang-split half-sweep.
+      if (pmesh->sts_integrator != parabolic::STSIntegrator::none) {
+        pmesh->RefreshSTSParabolicTimeStep();
+        BeginSTSSweep(pmesh, STSSweep::post);
+        if (sts.enabled) {
+          for (int sts_stage=1; sts_stage<=sts.nstages; ++sts_stage) {
+            SetSTSStage(sts_stage);
+            ExecuteTaskList(pmesh, "before_parabolic_stagen", sts_stage);
+            ExecuteTaskList(pmesh, "parabolic_stagen", sts_stage);
+            ExecuteTaskList(pmesh, "after_parabolic_stagen", sts_stage);
+          }
+          EndSTSSweep();
+        }
+      }
+
       // Work outside of TaskLists:
       // increment time, ncycle, etc.
       pmesh->time = pmesh->time + pmesh->dt;
@@ -448,6 +625,7 @@ void Driver::Execute(Mesh *pmesh, ParameterInput *pin, Outputs *pout, bool wdfla
       if (pmesh->adaptive) {pmesh->pmr->AdaptiveMeshRefinement(this, pin);}
       // compute new timestep AFTER all Meshblocks refined/derefined
       pmesh->NewTimeStep(tlim);
+      RefreshSTSCycleState(pmesh);
 
       // Update wall clock time if needed.
       if (wall_time > 0.) {

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -13,9 +13,12 @@
 // called in Finalize().
 
 #include <ctime>
+#include <limits>
 #include <memory>
 #include <string>
 
+#include "diffusion/sts_rkl2.hpp"
+#include "diffusion/sts_types.hpp"
 #include "parameter_input.hpp"
 #include "outputs/outputs.hpp"
 #include "pgen/pgen.hpp"
@@ -25,12 +28,27 @@
 
 class Driver {
  public:
+  enum class STSSweep {none, pre, post};
+
+  struct STSController {
+    bool enabled = false;
+    parabolic::STSIntegrator integrator = parabolic::STSIntegrator::none;
+    STSSweep sweep = STSSweep::none;
+    Real dt_cycle = 0.0;
+    Real dt_sweep = 0.0;
+    Real dt_parabolic_min = std::numeric_limits<float>::max();
+    int nstages = 0;
+    int current_stage = 0;
+    parabolic::RKL2Coefficients coeffs;
+  };
+
   Driver(ParameterInput *pin, Mesh *pmesh, Real wtlim, Kokkos::Timer* ptimer);
   ~Driver() = default;
 
   // data
   TimeEvolution time_evolution;
   DvceArray6D<Real> impl_src;  // stiff source terms used in ImEx integrators
+  STSController sts;
 
   // folowing data only relevant for runs involving time evolution
   Real tlim;      // stopping time
@@ -60,6 +78,12 @@ class Driver {
   std::uint64_t nmb_updated_;   // running total of MB updated during run
   std::uint64_t npart_updated_; // running total of particles updated during run
   float lb_efficiency_;         // measure of how efficient was load balancing
+  void ResetSTSController();
+  void ValidateSTSConfiguration(Mesh *pm);
+  void RefreshSTSCycleState(Mesh *pm);
+  void BeginSTSSweep(Mesh *pm, STSSweep sweep);
+  void SetSTSStage(int stage);
+  void EndSTSSweep();
   void OutputCycleDiagnostics(Mesh *pm);
   Real UpdateWallClock();
 };

--- a/src/hydro/hydro.cpp
+++ b/src/hydro/hydro.cpp
@@ -32,6 +32,10 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
     coarse_u0("ccons",1,1,1,1,1),
     coarse_w0("cprim",1,1,1,1,1),
     u1("cons1",1,1,1,1,1),
+    u_sts0("u_sts0",1,1,1,1,1),
+    u_sts1("u_sts1",1,1,1,1,1),
+    u_sts2("u_sts2",1,1,1,1,1),
+    u_sts_rhs("u_sts_rhs",1,1,1,1,1),
     uflx("uflx",1,1,1,1,1),
     wl3d("wl3d",1,1,1,1,1),
     wr3d("wr3d",1,1,1,1,1),
@@ -78,6 +82,16 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   if (pin->DoesParameterExist("hydro","nu_iso") ||
       pin->DoesParameterExist("hydro","nu_aniso")) {
     pvisc = new Viscosity("hydro", ppack, pin);
+    const bool active = (pvisc->nu_iso != 0.0 || pvisc->nu_aniso != 0.0);
+    has_explicit_viscosity =
+        active && pvisc->mode == parabolic::DiffusionSelection::explicit_only;
+    has_sts_viscosity =
+        active && pvisc->mode == parabolic::DiffusionSelection::sts_only;
+    if (active) {
+      ppack->RegisterParabolicProcess(
+          {"hydro/viscosity", parabolic::ParabolicProcessOwner::hydro,
+           pvisc->mode, &(pvisc->dtnew)});
+    }
   } else {
     pvisc = nullptr;
   }
@@ -88,6 +102,17 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
       pin->DoesParameterExist("hydro","alpha_spitzer")) {
     if (peos->eos_data.is_ideal) {
       pcond = new Conduction("hydro", ppack, pin);
+      const bool active =
+          (pcond->alpha_iso != 0.0 || pcond->alpha_aniso != 0.0 || pcond->alpha_spitzer);
+      has_explicit_conduction =
+          active && pcond->mode == parabolic::DiffusionSelection::explicit_only;
+      has_sts_conduction =
+          active && pcond->mode == parabolic::DiffusionSelection::sts_only;
+      if (active) {
+        ppack->RegisterParabolicProcess(
+            {"hydro/conductivity", parabolic::ParabolicProcessOwner::hydro,
+             pcond->mode, &(pcond->dtnew)});
+      }
     } else {
       std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
                 << "Thermal conduction in hydro requires ideal gas EOS" << std::endl;
@@ -101,6 +126,8 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
   if (pin->DoesBlockExist("hydro_srcterms")) {
     psrc = new SourceTerms("hydro_srcterms", ppack, pin);
   }
+
+  has_any_sts_diffusion = has_sts_viscosity || has_sts_conduction;
 
   // (3) read time-evolution option [already error checked in driver constructor]
   // Then initialize memory and algorithms for reconstruction and Riemann solvers
@@ -287,6 +314,12 @@ Hydro::Hydro(MeshBlockPack *ppack, ParameterInput *pin) :
       int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
       int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
       Kokkos::realloc(u1,       nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+      if (has_any_sts_diffusion) {
+        Kokkos::realloc(u_sts0,    nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+        Kokkos::realloc(u_sts1,    nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+        Kokkos::realloc(u_sts2,    nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+        Kokkos::realloc(u_sts_rhs, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
+      }
       Kokkos::realloc(uflx.x1f, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
       Kokkos::realloc(uflx.x2f, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);
       Kokkos::realloc(uflx.x3f, nmb, (nhydro+nscalars), ncells3, ncells2, ncells1);

--- a/src/hydro/hydro.hpp
+++ b/src/hydro/hydro.hpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "athena.hpp"
+#include "diffusion/sts_types.hpp"
 #include "parameter_input.hpp"
 #include "tasklist/task_list.hpp"
 #include "bvals/bvals.hpp"
@@ -96,8 +97,18 @@ class Hydro {
 
   // following only used for time-evolving flow
   DvceArray5D<Real> u1;       // conserved variables at intermediate step
+  DvceArray5D<Real> u_sts0;   // conserved variables at start of STS sweep
+  DvceArray5D<Real> u_sts1;   // previous STS stage state
+  DvceArray5D<Real> u_sts2;   // second previous STS stage state
+  DvceArray5D<Real> u_sts_rhs;  // cached first-stage RKL2 operator contribution
   DvceFaceFld5D<Real> uflx;   // fluxes of conserved quantities on cell faces
   Real dtnew;
+
+  bool has_explicit_viscosity = false;
+  bool has_explicit_conduction = false;
+  bool has_sts_viscosity = false;
+  bool has_sts_conduction = false;
+  bool has_any_sts_diffusion = false;
 
   // Global per-face L/R primitive buffers used by the split-kernel flux path
   // (PLM + LLF|HLLC). Shaped (nmb, nvars, nf3, nf2, nf1) where
@@ -124,6 +135,7 @@ class Hydro {
   void AssembleHydroTasks(std::map<std::string, std::shared_ptr<TaskList>> tl);
   // ...in "before_stagen_tl" list
   TaskStatus InitRecv(Driver *d, int stage);
+  TaskStatus InitRecvParabolic(Driver *d, int stage);
   // ...in "stagen_tl" list
   TaskStatus CopyCons(Driver *d, int stage);
   TaskStatus Fluxes(Driver *d, int stage);
@@ -142,6 +154,10 @@ class Hydro {
   TaskStatus Prolongate(Driver* pdrive, int stage);
   TaskStatus ConToPrim(Driver *d, int stage);
   TaskStatus NewTimeStep(Driver *d, int stage);
+  TaskStatus ClearSTSFlux(Driver *d, int stage);
+  TaskStatus STSFluxes(Driver *d, int stage);
+  TaskStatus STSUpdate(Driver *d, int stage);
+  TaskStatus STSRefreshTimeStep(Driver *d, int stage);
   // ...in "after_stagen_tl" list
   TaskStatus ClearSend(Driver *d, int stage);
   TaskStatus ClearRecv(Driver *d, int stage);  // also in Driver::Initialize
@@ -154,6 +170,7 @@ class Hydro {
   void FOFC(Driver *d, int stage);
 
  private:
+  void AddSelectedDiffusionFluxes(parabolic::DiffusionSelection selection);
   MeshBlockPack* pmy_pack;  // ptr to MeshBlockPack containing this Hydro
 };
 

--- a/src/hydro/hydro_sts.cpp
+++ b/src/hydro/hydro_sts.cpp
@@ -1,0 +1,175 @@
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file hydro_sts.cpp
+//! \brief Hydro-owned helpers and task wrappers for super time stepping.
+
+#include "athena.hpp"
+#include "mesh/mesh.hpp"
+#include "driver/driver.hpp"
+#include "eos/eos.hpp"
+#include "diffusion/conduction.hpp"
+#include "diffusion/viscosity.hpp"
+#include "hydro.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+bool UpdateSTSHydroVariable(const int n, const bool update_momentum,
+                            const bool update_energy) {
+  return (update_momentum && (n == IVX || n == IVY || n == IVZ)) ||
+         (update_energy && n == IEN);
+}
+
+} // namespace
+
+namespace hydro {
+
+//----------------------------------------------------------------------------------------
+//! \fn void Hydro::AddSelectedDiffusionFluxes()
+//! \brief Add only the requested subset of Hydro diffusion operators.
+
+void Hydro::AddSelectedDiffusionFluxes(parabolic::DiffusionSelection selection) {
+  const bool add_viscosity =
+      selection == parabolic::DiffusionSelection::explicit_only
+          ? has_explicit_viscosity : has_sts_viscosity;
+  const bool add_conduction =
+      selection == parabolic::DiffusionSelection::explicit_only
+          ? has_explicit_conduction : has_sts_conduction;
+
+  if (add_conduction) {
+    pcond->AddHeatFluxes(w0, peos->eos_data, uflx);
+  }
+  if (add_viscosity) {
+    pvisc->AddViscousFluxes(w0, peos->eos_data, uflx);
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn TaskStatus Hydro::ClearSTSFlux()
+//! \brief Zero the Hydro flux scratch before one STS stage.
+
+TaskStatus Hydro::ClearSTSFlux(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  Kokkos::deep_copy(DevExeSpace(), uflx.x1f, 0.0);
+  Kokkos::deep_copy(DevExeSpace(), uflx.x2f, 0.0);
+  Kokkos::deep_copy(DevExeSpace(), uflx.x3f, 0.0);
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn TaskStatus Hydro::STSFluxes()
+//! \brief Accumulate only the STS-managed Hydro diffusion operators.
+
+TaskStatus Hydro::STSFluxes(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  AddSelectedDiffusionFluxes(parabolic::DiffusionSelection::sts_only);
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn TaskStatus Hydro::STSUpdate()
+//! \brief Apply one Hydro-owned RKL2 STS stage.
+
+TaskStatus Hydro::STSUpdate(Driver *pdrive, int stage) {
+  if (!pdrive->sts.enabled) {
+    return TaskStatus::complete;
+  }
+
+  if (stage == 1) {
+    Kokkos::deep_copy(DevExeSpace(), u_sts0, u0);
+    Kokkos::deep_copy(DevExeSpace(), u_sts1, u0);
+    Kokkos::deep_copy(DevExeSpace(), u_sts2, u0);
+  } else {
+    Kokkos::deep_copy(DevExeSpace(), u_sts2, u_sts1);
+    Kokkos::deep_copy(DevExeSpace(), u_sts1, u0);
+  }
+
+  const bool update_momentum = has_sts_viscosity;
+  const bool update_energy =
+      has_sts_conduction || (has_sts_viscosity && peos->eos_data.is_ideal);
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  int is = indcs.is, ie = indcs.ie;
+  int js = indcs.js, je = indcs.je;
+  int ks = indcs.ks, ke = indcs.ke;
+  int ncells1 = indcs.nx1 + 2*(indcs.ng);
+  bool &multi_d = pmy_pack->pmesh->multi_d;
+  bool &three_d = pmy_pack->pmesh->three_d;
+
+  int nmb1 = pmy_pack->nmb_thispack - 1;
+  Real dt_sweep = pdrive->sts.dt_sweep;
+  auto coeffs = pdrive->sts.coeffs;
+  auto u0_ = u0;
+  auto u_sts0_ = u_sts0;
+  auto u_sts1_ = u_sts1;
+  auto u_sts2_ = u_sts2;
+  auto u_sts_rhs_ = u_sts_rhs;
+  auto flx1 = uflx.x1f;
+  auto flx2 = uflx.x2f;
+  auto flx3 = uflx.x3f;
+  auto &mbsize = pmy_pack->pmb->mb_size;
+
+  int scr_level = 0;
+  size_t scr_size = ScrArray1D<Real>::shmem_size(ncells1);
+
+  par_for_outer("hydro_sts_update", DevExeSpace(), scr_size, scr_level, 0, nmb1,
+                0, nhydro - 1, ks, ke, js, je,
+  KOKKOS_LAMBDA(TeamMember_t member, const int m, const int n, const int k, const int j) {
+    if (!UpdateSTSHydroVariable(n, update_momentum, update_energy)) {
+      return;
+    }
+
+    ScrArray1D<Real> divf(member.team_scratch(scr_level), ncells1);
+
+    par_for_inner(member, is, ie, [&](const int i) {
+      divf(i) = (flx1(m,n,k,j,i+1) - flx1(m,n,k,j,i))/mbsize.d_view(m).dx1;
+    });
+    member.team_barrier();
+
+    if (multi_d) {
+      par_for_inner(member, is, ie, [&](const int i) {
+        divf(i) += (flx2(m,n,k,j+1,i) - flx2(m,n,k,j,i))/mbsize.d_view(m).dx2;
+      });
+      member.team_barrier();
+    }
+
+    if (three_d) {
+      par_for_inner(member, is, ie, [&](const int i) {
+        divf(i) += (flx3(m,n,k+1,j,i) - flx3(m,n,k,j,i))/mbsize.d_view(m).dx3;
+      });
+      member.team_barrier();
+    }
+
+    par_for_inner(member, is, ie, [&](const int i) {
+      const Real delta_u = -dt_sweep*divf(i);
+      u0_(m,n,k,j,i) = coeffs.muj*u_sts1_(m,n,k,j,i)
+                     + coeffs.nuj*u_sts2_(m,n,k,j,i)
+                     + (1.0 - coeffs.muj - coeffs.nuj)*u_sts0_(m,n,k,j,i)
+                     + coeffs.gammaj_tilde*u_sts_rhs_(m,n,k,j,i)
+                     + coeffs.muj_tilde*delta_u;
+      if (stage == 1) {
+        u_sts_rhs_(m,n,k,j,i) = delta_u;
+      }
+    });
+  });
+
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn TaskStatus Hydro::STSRefreshTimeStep()
+//! \brief Refresh Hydro-local timestep estimates after the post-sweep.
+
+TaskStatus Hydro::STSRefreshTimeStep(Driver *pdrive, int stage) {
+  if (pdrive->sts.sweep == Driver::STSSweep::post && stage == pdrive->sts.nstages) {
+    return NewTimeStep(pdrive, pdrive->nexp_stages);
+  }
+  return TaskStatus::complete;
+}
+
+} // namespace hydro

--- a/src/hydro/hydro_tasks.cpp
+++ b/src/hydro/hydro_tasks.cpp
@@ -76,6 +76,27 @@ void Hydro::AssembleHydroTasks(std::map<std::string, std::shared_ptr<TaskList>> 
   // task list anyways to catch potential bugs in MPI communication logic
   id.crecv = tl["after_stagen"]->AddTask(&Hydro::ClearRecv, this, id.csend);
 
+  if (has_any_sts_diffusion) {
+    tl["before_parabolic_stagen"]->AddTask(&Hydro::InitRecvParabolic, this, none);
+
+    TaskID pclearf = tl["parabolic_stagen"]->AddTask(&Hydro::ClearSTSFlux, this, none);
+    TaskID pflux = tl["parabolic_stagen"]->AddTask(&Hydro::STSFluxes, this, pclearf);
+    TaskID psendf = tl["parabolic_stagen"]->AddTask(&Hydro::SendFlux, this, pflux);
+    TaskID precvf = tl["parabolic_stagen"]->AddTask(&Hydro::RecvFlux, this, psendf);
+    TaskID pupdt = tl["parabolic_stagen"]->AddTask(&Hydro::STSUpdate, this, precvf);
+    TaskID prestu = tl["parabolic_stagen"]->AddTask(&Hydro::RestrictU, this, pupdt);
+    TaskID psendu = tl["parabolic_stagen"]->AddTask(&Hydro::SendU, this, prestu);
+    TaskID precvu = tl["parabolic_stagen"]->AddTask(&Hydro::RecvU, this, psendu);
+    TaskID pprol = tl["parabolic_stagen"]->AddTask(&Hydro::Prolongate, this, precvu);
+    TaskID pbcs =
+        tl["parabolic_stagen"]->AddTask(&Hydro::ApplyPhysicalBCs, this, pprol);
+    TaskID pc2p = tl["parabolic_stagen"]->AddTask(&Hydro::ConToPrim, this, pbcs);
+    (void) tl["parabolic_stagen"]->AddTask(&Hydro::STSRefreshTimeStep, this, pc2p);
+
+    TaskID pcsend = tl["after_parabolic_stagen"]->AddTask(&Hydro::ClearSend, this, none);
+    (void) tl["after_parabolic_stagen"]->AddTask(&Hydro::ClearRecv, this, pcsend);
+  }
+
   return;
 }
 
@@ -119,6 +140,21 @@ TaskStatus Hydro::InitRecv(Driver *pdrive, int stage) {
     }
   }
 
+  return tstat;
+}
+
+//----------------------------------------------------------------------------------------
+//! \fn TaskStatus Hydro::InitRecvParabolic
+//! \brief Post receive operations required for one STS parabolic stage.
+
+TaskStatus Hydro::InitRecvParabolic(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  TaskStatus tstat = pbval_u->InitRecv(nhydro+nscalars);
+  if (tstat != TaskStatus::complete) return tstat;
+  if (pmy_pack->pmesh->multilevel) {
+    tstat = pbval_u->InitFluxRecv(nhydro+nscalars);
+  }
   return tstat;
 }
 
@@ -180,13 +216,8 @@ TaskStatus Hydro::Fluxes(Driver *pdrive, int stage) {
     CalculateFluxes<Hydro_RSolver::hlle_gr>(pdrive, stage);
   }
 
-  // Add diffusion fluxes
-  if (pcond != nullptr) {
-    pcond->AddHeatFluxes(w0, peos->eos_data, uflx);
-  }
-  if (pvisc != nullptr) {
-    pvisc->AddViscousFluxes(w0, peos->eos_data, uflx);
-  }
+  // Terms selected for STS are advanced only in the parabolic half-sweeps.
+  AddSelectedDiffusionFluxes(parabolic::DiffusionSelection::explicit_only);
 
   // call FOFC if necessary
   if (use_fofc) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <cstdio> // fclose
@@ -53,7 +54,28 @@ Mesh::Mesh(ParameterInput *pin) :
   nprtcl_total(0),
   dtold(0.),
   dt_last_completed(0.),
+  dt_parabolic_sts(std::numeric_limits<float>::max()),
+  sts_max_dt_ratio(-1.0),
+  sts_integrator(parabolic::STSIntegrator::none),
   nmb_packs_thisrank(1) {
+  std::string sts_method = pin->GetOrAddString("time", "sts_integrator", "none");
+  if (sts_method == "rkl2") {
+    sts_integrator = parabolic::STSIntegrator::rkl2;
+  } else if (sts_method != "none") {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "<time>/sts_integrator = '" << sts_method
+              << "' must be 'none' or 'rkl2'" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  sts_max_dt_ratio = pin->GetOrAddReal("time", "sts_max_dt_ratio", -1.0);
+  if (!std::isfinite(sts_max_dt_ratio) ||
+      (sts_max_dt_ratio != -1.0 && sts_max_dt_ratio <= 0.0)) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl
+              << "<time>/sts_max_dt_ratio must be -1.0 or a positive real" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
   // Set physical size and number of cells in mesh (root level)
   mesh_size.x1min = pin->GetReal("mesh", "x1min");
   mesh_size.x1max = pin->GetReal("mesh", "x1max");
@@ -577,69 +599,98 @@ void Mesh::NewTimeStep(const Real tlim) {
     dtold = 0.;
   }
 
-  // cycle over all MeshBlocks on this rank and find minimum dt
-  // Requires at least ONE of the physics modules to be defined.
-  // limit increase in timestep to 2x old value
-  dt = 2.0*dt;
+  // Cycle over all MeshBlocks on this rank and find the minimum cycle timestep,
+  // excluding diffusion processes selected for STS. Limit its increase to 2x.
+  Real dt_cycle = 2.0*dt;
+  dt_parabolic_sts = std::numeric_limits<float>::max();
+  Real sts_inverse_dt = 0.0;
 
   // Hydro timestep
   if (pmb_pack->phydro != nullptr) {
-    dt = std::min(dt, (cfl_no)*(pmb_pack->phydro->dtnew) );
-    // viscosity timestep
-    if (pmb_pack->phydro->pvisc != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->phydro->pvisc->dtnew) );
-    }
-    // thermal conduction timestep
-    if (pmb_pack->phydro->pcond != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->phydro->pcond->dtnew) );
-    }
+    dt_cycle = std::min(dt_cycle, (cfl_no)*(pmb_pack->phydro->dtnew) );
     // source terms timestep
     if (pmb_pack->phydro->psrc != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->phydro->psrc->dtnew) );
+      dt_cycle = std::min(dt_cycle, (cfl_no)*(pmb_pack->phydro->psrc->dtnew) );
     }
   }
   // MHD timestep
   if (pmb_pack->pmhd != nullptr) {
-    dt = std::min(dt, (cfl_no)*(pmb_pack->pmhd->dtnew) );
-    // viscosity timestep
-    if (pmb_pack->pmhd->pvisc != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->pmhd->pvisc->dtnew) );
-    }
-    // resistivity timestep (includes ambipolar diffusion, handled within Resistivity)
-    if (pmb_pack->pmhd->presist != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->pmhd->presist->dtnew) );
-    }
-    // thermal conduction timestep
-    if (pmb_pack->pmhd->pcond != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->pmhd->pcond->dtnew) );
-    }
+    dt_cycle = std::min(dt_cycle, (cfl_no)*(pmb_pack->pmhd->dtnew) );
     // source terms timestep
     if (pmb_pack->pmhd->psrc != nullptr) {
-      dt = std::min(dt, (cfl_no)*(pmb_pack->pmhd->psrc->dtnew) );
+      dt_cycle = std::min(dt_cycle, (cfl_no)*(pmb_pack->pmhd->psrc->dtnew) );
     }
+  }
+  // Diffusion-process timestep budgets
+  for (const auto &process : pmb_pack->parabolic_processes) {
+    Real process_dt = (cfl_no)*(process.ExplicitDt());
+    if (process.UsesSTS()) {
+      if (process_dt < std::numeric_limits<float>::max()) {
+        sts_inverse_dt += 1.0/process_dt;
+      }
+    } else {
+      dt_cycle = std::min(dt_cycle, process_dt);
+    }
+  }
+  if (sts_inverse_dt > 0.0) {
+    dt_parabolic_sts = 1.0/sts_inverse_dt;
   }
   // z4c timestep
   if (pmb_pack->pz4c != nullptr) {
-    dt = std::min(dt, (cfl_no)*(pmb_pack->pz4c->dtnew) );
+    dt_cycle = std::min(dt_cycle, (cfl_no)*(pmb_pack->pz4c->dtnew) );
   }
   // Radiation timestep
   if (pmb_pack->prad != nullptr) {
-    dt = std::min(dt, (cfl_no)*(pmb_pack->prad->dtnew) );
+    dt_cycle = std::min(dt_cycle, (cfl_no)*(pmb_pack->prad->dtnew) );
   }
   // Particles timestep
   if (pmb_pack->ppart != nullptr) {
-    dt = std::min(dt, (pmb_pack->ppart->dtnew) );
+    dt_cycle = std::min(dt_cycle, (pmb_pack->ppart->dtnew) );
   }
 
 #if MPI_PARALLEL_ENABLED
-  // get minimum dt over all MPI ranks
-  MPI_Allreduce(MPI_IN_PLACE, &dt, 1, MPI_ATHENA_REAL, MPI_MIN, MPI_COMM_WORLD);
+  // get minimum cycle and parabolic timesteps over all MPI ranks
+  Real dt_reduction[2] = {dt_cycle, dt_parabolic_sts};
+  MPI_Allreduce(MPI_IN_PLACE, dt_reduction, 2, MPI_ATHENA_REAL, MPI_MIN, MPI_COMM_WORLD);
+  dt_cycle = dt_reduction[0];
+  dt_parabolic_sts = dt_reduction[1];
 #endif
+
+  if (sts_integrator != parabolic::STSIntegrator::none && sts_max_dt_ratio > 0.0 &&
+      dt_parabolic_sts < std::numeric_limits<float>::max()) {
+    dt_cycle = std::min(dt_cycle, sts_max_dt_ratio*dt_parabolic_sts);
+  }
+  dt = dt_cycle;
 
   // limit last time step to stop at tlim *exactly*
   if ( (time < tlim) && ((time + dt) > tlim) ) {dt = tlim - time;}
 
   return;
+}
+
+//----------------------------------------------------------------------------------------
+// \fn Mesh::RefreshSTSParabolicTimeStep()
+// \brief Refresh the globally minimum explicit timestep for STS processes.
+
+void Mesh::RefreshSTSParabolicTimeStep() {
+  dt_parabolic_sts = std::numeric_limits<float>::max();
+  Real sts_inverse_dt = 0.0;
+  for (const auto &process : pmb_pack->parabolic_processes) {
+    if (process.UsesSTS()) {
+      Real process_dt = (cfl_no)*(process.ExplicitDt());
+      if (process_dt < std::numeric_limits<float>::max()) {
+        sts_inverse_dt += 1.0/process_dt;
+      }
+    }
+  }
+  if (sts_inverse_dt > 0.0) {
+    dt_parabolic_sts = 1.0/sts_inverse_dt;
+  }
+
+#if MPI_PARALLEL_ENABLED
+  MPI_Allreduce(MPI_IN_PLACE, &dt_parabolic_sts, 1, MPI_ATHENA_REAL, MPI_MIN,
+                MPI_COMM_WORLD);
+#endif
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "athena.hpp"
+#include "diffusion/sts_types.hpp"
 
 // Define following structure before other "include" files to resolve declarations
 //----------------------------------------------------------------------------------------
@@ -137,7 +138,8 @@ class Mesh {
   // following 1x arrays allocated with length [nranks] in AddCoordinatesAndPhysics()
   int *nprtcl_eachrank;    // number of particles on each rank
 
-  Real time, dt, dtold, dt_last_completed, cfl_no;
+  Real time, dt, dtold, dt_last_completed, dt_parabolic_sts, sts_max_dt_ratio, cfl_no;
+  parabolic::STSIntegrator sts_integrator;
   int ncycle;
   EventCounters ecounter;
 
@@ -153,6 +155,7 @@ class Mesh {
   void PrintMeshDiagnostics();
   void WriteMeshStructure();
   void NewTimeStep(const Real tlim);
+  void RefreshSTSParabolicTimeStep();
   void AddCoordinatesAndPhysics(ParameterInput *pinput);
   BoundaryFlag GetBoundaryFlag(const std::string& input_string);
   std::string GetBoundaryString(BoundaryFlag input_flag);

--- a/src/mesh/meshblock_pack.cpp
+++ b/src/mesh/meshblock_pack.cpp
@@ -47,6 +47,9 @@ MeshBlockPack::MeshBlockPack(Mesh *pm, int igids, int igide) :
   tl_map.insert(std::make_pair("before_stagen",std::make_shared<TaskList>()));
   tl_map.insert(std::make_pair("stagen",std::make_shared<TaskList>()));
   tl_map.insert(std::make_pair("after_stagen",std::make_shared<TaskList>()));
+  tl_map.insert(std::make_pair("before_parabolic_stagen",std::make_shared<TaskList>()));
+  tl_map.insert(std::make_pair("parabolic_stagen",std::make_shared<TaskList>()));
+  tl_map.insert(std::make_pair("after_parabolic_stagen",std::make_shared<TaskList>()));
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -15,6 +15,7 @@
 
 #include "parameter_input.hpp"
 #include "coordinates/coordinates.hpp"
+#include "diffusion/parabolic_process.hpp"
 #include "driver/driver.hpp"
 #include "tasklist/task_list.hpp"
 
@@ -83,11 +84,15 @@ class MeshBlockPack {
 
   // map for task lists which operate over all MeshBlocks in this MeshBlockPack
   std::map<std::string, std::shared_ptr<TaskList>> tl_map;
+  std::vector<parabolic::ParabolicProcessDescriptor> parabolic_processes;
 
   // functions
   void AddPhysics(ParameterInput *pin);
   void AddMeshBlocks(ParameterInput *pin);
   void AddCoordinates(ParameterInput *pin);
+  void RegisterParabolicProcess(parabolic::ParabolicProcessDescriptor process) {
+    parabolic_processes.push_back(process);
+  }
 
  private:
   // data

--- a/src/mhd/mhd.cpp
+++ b/src/mhd/mhd.cpp
@@ -36,7 +36,15 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
     coarse_w0("cprim",1,1,1,1,1),
     coarse_b0("cB_fc",1,1,1,1),
     u1("cons1",1,1,1,1,1),
+    u_sts0("u_sts0",1,1,1,1,1),
+    u_sts1("u_sts1",1,1,1,1,1),
+    u_sts2("u_sts2",1,1,1,1,1),
+    u_sts_rhs("u_sts_rhs",1,1,1,1,1),
     b1("B_fc1",1,1,1,1),
+    b_sts0("b_sts0",1,1,1,1),
+    b_sts1("b_sts1",1,1,1,1),
+    b_sts2("b_sts2",1,1,1,1),
+    b_sts_rhs("b_sts_rhs",1,1,1,1),
     uflx("uflx",1,1,1,1,1),
     efld("efld",1,1,1,1),
     e3x1("e3x1",1,1,1,1),
@@ -104,6 +112,16 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   if (pin->DoesParameterExist("mhd","nu_iso") ||
       pin->DoesParameterExist("mhd","nu_aniso")) {
     pvisc = new Viscosity("mhd", ppack, pin);
+    const bool active = (pvisc->nu_iso != 0.0 || pvisc->nu_aniso != 0.0);
+    has_sts_viscosity = active &&
+        (pvisc->mode == parabolic::DiffusionSelection::sts_only);
+    has_explicit_viscosity = active &&
+        (pvisc->mode == parabolic::DiffusionSelection::explicit_only);
+    if (active) {
+      ppack->RegisterParabolicProcess({"mhd/viscosity",
+                                       parabolic::ParabolicProcessOwner::mhd,
+                                       pvisc->mode, &(pvisc->dtnew)});
+    }
   } else {
     pvisc = nullptr;
   }
@@ -114,6 +132,16 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   if (pin->DoesParameterExist("mhd","eta_ohm") ||
       pin->DoesParameterExist("mhd","eta_ad")) {
     presist = new Resistivity(ppack, pin);
+    const bool active = (presist->eta_ohm != 0.0 || presist->eta_ad != 0.0);
+    has_sts_resistivity = active &&
+        (presist->mode == parabolic::DiffusionSelection::sts_only);
+    has_explicit_resistivity = active &&
+        (presist->mode == parabolic::DiffusionSelection::explicit_only);
+    if (active) {
+      ppack->RegisterParabolicProcess({"mhd/resistivity",
+                                       parabolic::ParabolicProcessOwner::mhd,
+                                       presist->mode, &(presist->dtnew)});
+    }
   } else {
     presist = nullptr;
   }
@@ -124,6 +152,17 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
       pin->DoesParameterExist("mhd","alpha_spitzer")) {
     if (peos->eos_data.is_ideal) {
       pcond = new Conduction("mhd", ppack, pin);
+      const bool active = (pcond->alpha_iso != 0.0 || pcond->alpha_aniso != 0.0 ||
+                           pcond->alpha_spitzer);
+      has_sts_conduction = active &&
+          (pcond->mode == parabolic::DiffusionSelection::sts_only);
+      has_explicit_conduction = active &&
+          (pcond->mode == parabolic::DiffusionSelection::explicit_only);
+      if (active) {
+        ppack->RegisterParabolicProcess({"mhd/conduction",
+                                         parabolic::ParabolicProcessOwner::mhd,
+                                         pcond->mode, &(pcond->dtnew)});
+      }
     } else {
       std::cout << "### FATAL ERROR in "<< __FILE__ <<" at line " << __LINE__ << std::endl
                 << "Thermal conduction in MHD requires ideal gas EOS" << std::endl;
@@ -132,6 +171,11 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
   } else {
     pcond = nullptr;
   }
+
+  has_any_sts_cell_update = (has_sts_viscosity || has_sts_conduction ||
+                             (has_sts_resistivity && peos->eos_data.is_ideal));
+  has_any_sts_field_update = has_sts_resistivity;
+  has_any_sts_diffusion = (has_any_sts_cell_update || has_any_sts_field_update);
 
   // Source terms (if needed)
   if (pin->DoesBlockExist("mhd_srcterms")) {
@@ -333,9 +377,29 @@ MHD::MHD(MeshBlockPack *ppack, ParameterInput *pin) :
       int ncells2 = (indcs.nx2 > 1)? (indcs.nx2 + 2*(indcs.ng)) : 1;
       int ncells3 = (indcs.nx3 > 1)? (indcs.nx3 + 2*(indcs.ng)) : 1;
       Kokkos::realloc(u1,     nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+      if (has_any_sts_cell_update) {
+        Kokkos::realloc(u_sts0,    nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+        Kokkos::realloc(u_sts1,    nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+        Kokkos::realloc(u_sts2,    nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+        Kokkos::realloc(u_sts_rhs, nmb, (nmhd+nscalars), ncells3, ncells2, ncells1);
+      }
       Kokkos::realloc(b1.x1f, nmb, ncells3, ncells2, ncells1+1);
       Kokkos::realloc(b1.x2f, nmb, ncells3, ncells2+1, ncells1);
       Kokkos::realloc(b1.x3f, nmb, ncells3+1, ncells2, ncells1);
+      if (has_any_sts_field_update) {
+        Kokkos::realloc(b_sts0.x1f,    nmb, ncells3, ncells2, ncells1+1);
+        Kokkos::realloc(b_sts0.x2f,    nmb, ncells3, ncells2+1, ncells1);
+        Kokkos::realloc(b_sts0.x3f,    nmb, ncells3+1, ncells2, ncells1);
+        Kokkos::realloc(b_sts1.x1f,    nmb, ncells3, ncells2, ncells1+1);
+        Kokkos::realloc(b_sts1.x2f,    nmb, ncells3, ncells2+1, ncells1);
+        Kokkos::realloc(b_sts1.x3f,    nmb, ncells3+1, ncells2, ncells1);
+        Kokkos::realloc(b_sts2.x1f,    nmb, ncells3, ncells2, ncells1+1);
+        Kokkos::realloc(b_sts2.x2f,    nmb, ncells3, ncells2+1, ncells1);
+        Kokkos::realloc(b_sts2.x3f,    nmb, ncells3+1, ncells2, ncells1);
+        Kokkos::realloc(b_sts_rhs.x1f, nmb, ncells3, ncells2, ncells1+1);
+        Kokkos::realloc(b_sts_rhs.x2f, nmb, ncells3, ncells2+1, ncells1);
+        Kokkos::realloc(b_sts_rhs.x3f, nmb, ncells3+1, ncells2, ncells1);
+      }
 
       // allocate fluxes, electric fields
       Kokkos::realloc(uflx.x1f, nmb, (nmhd+nscalars), ncells3, ncells2, ncells1+1);

--- a/src/mhd/mhd.hpp
+++ b/src/mhd/mhd.hpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "athena.hpp"
+#include "diffusion/sts_types.hpp"
 #include "parameter_input.hpp"
 #include "tasklist/task_list.hpp"
 #include "bvals/bvals.hpp"
@@ -124,7 +125,15 @@ class MHD {
 
   // following only used for time-evolving flow
   DvceArray5D<Real> u1;       // conserved variables, second register
+  DvceArray5D<Real> u_sts0;   // conserved variables at start of STS sweep
+  DvceArray5D<Real> u_sts1;   // previous STS stage state
+  DvceArray5D<Real> u_sts2;   // second previous STS stage state
+  DvceArray5D<Real> u_sts_rhs;  // cached first-stage RKL2 operator contribution
   DvceFaceFld4D<Real> b1;     // face-centered magnetic fields, second register
+  DvceFaceFld4D<Real> b_sts0;  // face-centered fields at start of STS sweep
+  DvceFaceFld4D<Real> b_sts1;  // previous STS stage fields
+  DvceFaceFld4D<Real> b_sts2;  // second previous STS stage fields
+  DvceFaceFld4D<Real> b_sts_rhs;  // cached first-stage RKL2 operator contribution
   DvceFaceFld5D<Real> uflx;   // fluxes of conserved quantities on cell faces
   DvceEdgeFld4D<Real> efld;   // edge-centered electric fields (fluxes of B)
   // temporary variables used to store face-centered electric fields returned by RS
@@ -147,6 +156,16 @@ class MHD {
   DvceArray5D<bool> fofc_scal;  // flag to indicate if FOFC for scalar is needed
   bool use_fofc = false;   // flag to enable FOFC
 
+  bool has_explicit_viscosity = false;
+  bool has_explicit_conduction = false;
+  bool has_explicit_resistivity = false;
+  bool has_sts_viscosity = false;
+  bool has_sts_conduction = false;
+  bool has_sts_resistivity = false;
+  bool has_any_sts_diffusion = false;
+  bool has_any_sts_cell_update = false;
+  bool has_any_sts_field_update = false;
+
   // container to hold names of TaskIDs
   MHDTaskIDs id;
 
@@ -157,6 +176,7 @@ class MHD {
   TaskStatus SaveMHDState(Driver *d, int stage);
   // ...in "before_stagen_tl" task list
   TaskStatus InitRecv(Driver *d, int stage);
+  TaskStatus InitRecvParabolic(Driver *d, int stage);
   // ...in "stagen_tl" task list
   TaskStatus CopyCons(Driver *d, int stage);
   TaskStatus Fluxes(Driver *d, int stage);
@@ -187,6 +207,13 @@ class MHD {
   TaskStatus Prolongate(Driver* pdrive, int stage);
   TaskStatus ConToPrim(Driver *d, int stage);
   TaskStatus NewTimeStep(Driver *d, int stage);
+  TaskStatus ClearSTSFlux(Driver *d, int stage);
+  TaskStatus ClearSTSEField(Driver *d, int stage);
+  TaskStatus STSFluxes(Driver *d, int stage);
+  TaskStatus STSEField(Driver *d, int stage);
+  TaskStatus STSUpdateU(Driver *d, int stage);
+  TaskStatus STSUpdateB(Driver *d, int stage);
+  TaskStatus STSRefreshTimeStep(Driver *d, int stage);
   // ...in "after_stagen_tl" task list
   TaskStatus ClearSend(Driver *d, int stage);
   TaskStatus ClearRecv(Driver *d, int stage);  // also in Driver::Initialize
@@ -201,6 +228,9 @@ class MHD {
   DvceArray5D<Real> utest, bcctest;  // scratch arrays for FOFC
 
  private:
+  void AddSelectedDiffusionFluxes(parabolic::DiffusionSelection selection);
+  void AddSelectedDiffusionEMF(parabolic::DiffusionSelection selection);
+  void RecomputeTimeStepFromCurrentState(Driver *pdrive);
   MeshBlockPack* pmy_pack;   // ptr to MeshBlockPack containing this MHD
   // temporary variables used to store face-centered electric fields returned by RS
   DvceArray4D<Real> e1_cc, e2_cc, e3_cc;

--- a/src/mhd/mhd.hpp
+++ b/src/mhd/mhd.hpp
@@ -207,6 +207,7 @@ class MHD {
   TaskStatus Prolongate(Driver* pdrive, int stage);
   TaskStatus ConToPrim(Driver *d, int stage);
   TaskStatus NewTimeStep(Driver *d, int stage);
+  void RecomputeTimeStepFromCurrentState(Driver *pdrive);
   TaskStatus ClearSTSFlux(Driver *d, int stage);
   TaskStatus ClearSTSEField(Driver *d, int stage);
   TaskStatus STSFluxes(Driver *d, int stage);
@@ -230,7 +231,6 @@ class MHD {
  private:
   void AddSelectedDiffusionFluxes(parabolic::DiffusionSelection selection);
   void AddSelectedDiffusionEMF(parabolic::DiffusionSelection selection);
-  void RecomputeTimeStepFromCurrentState(Driver *pdrive);
   MeshBlockPack* pmy_pack;   // ptr to MeshBlockPack containing this MHD
   // temporary variables used to store face-centered electric fields returned by RS
   DvceArray4D<Real> e1_cc, e2_cc, e3_cc;

--- a/src/mhd/mhd_newdt.cpp
+++ b/src/mhd/mhd_newdt.cpp
@@ -33,6 +33,14 @@ TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
     return TaskStatus::complete; // only execute last stage
   }
 
+  RecomputeTimeStepFromCurrentState(pdriver);
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \brief Recompute hyperbolic and parabolic timestep limits from the current state.
+
+void MHD::RecomputeTimeStepFromCurrentState(Driver *pdriver) {
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int is = indcs.is, nx1 = indcs.nx1;
   int js = indcs.js, nx2 = indcs.nx2;
@@ -170,6 +178,6 @@ TaskStatus MHD::NewTimeStep(Driver *pdriver, int stage) {
     psrc->NewTimeStep(w0, peos->eos_data);
   }
 
-  return TaskStatus::complete;
+  return;
 }
 } // namespace mhd

--- a/src/mhd/mhd_sts.cpp
+++ b/src/mhd/mhd_sts.cpp
@@ -1,0 +1,316 @@
+//========================================================================================
+// AthenaXXX astrophysical plasma code
+// Copyright(C) 2020 James M. Stone <jmstone@ias.edu> and the Athena code team
+// Licensed under the 3-clause BSD License (the "LICENSE")
+//========================================================================================
+//! \file mhd_sts.cpp
+//! \brief MHD-owned helpers and task wrappers for RKL2 super time stepping.
+
+#include "athena.hpp"
+#include "mesh/mesh.hpp"
+#include "driver/driver.hpp"
+#include "eos/eos.hpp"
+#include "diffusion/conduction.hpp"
+#include "diffusion/resistivity.hpp"
+#include "diffusion/viscosity.hpp"
+#include "mhd.hpp"
+
+namespace {
+
+KOKKOS_INLINE_FUNCTION
+bool UpdateSTSMHDVariable(const int n, const bool update_momentum,
+                          const bool update_energy) {
+  if (update_momentum && (n == IVX || n == IVY || n == IVZ)) {
+    return true;
+  }
+  return update_energy && n == IEN;
+}
+
+} // namespace
+
+namespace mhd {
+
+//----------------------------------------------------------------------------------------
+//! \brief Add only the requested subset of MHD diffusion operators to the live fluxes.
+
+void MHD::AddSelectedDiffusionFluxes(parabolic::DiffusionSelection selection) {
+  const bool add_viscosity =
+      (selection == parabolic::DiffusionSelection::explicit_only) ?
+      has_explicit_viscosity : has_sts_viscosity;
+  const bool add_conduction =
+      (selection == parabolic::DiffusionSelection::explicit_only) ?
+      has_explicit_conduction : has_sts_conduction;
+  const bool add_resistivity =
+      (selection == parabolic::DiffusionSelection::explicit_only) ?
+      has_explicit_resistivity : has_sts_resistivity;
+
+  if (add_conduction && pcond != nullptr) {
+    pcond->AddHeatFluxes(w0, peos->eos_data, uflx);
+  }
+  if (add_viscosity && pvisc != nullptr) {
+    pvisc->AddViscousFluxes(w0, peos->eos_data, uflx);
+  }
+  if (add_resistivity && presist != nullptr && peos->eos_data.is_ideal) {
+    presist->AddResistiveFluxes(b0, uflx);
+  }
+}
+
+//----------------------------------------------------------------------------------------
+//! \brief Add only the requested subset of resistive EMFs.
+
+void MHD::AddSelectedDiffusionEMF(parabolic::DiffusionSelection selection) {
+  const bool add_resistivity =
+      (selection == parabolic::DiffusionSelection::explicit_only) ?
+      has_explicit_resistivity : has_sts_resistivity;
+  if (add_resistivity && presist != nullptr) {
+    presist->AddResistiveEMFs(b0, efld);
+  }
+}
+
+//----------------------------------------------------------------------------------------
+
+TaskStatus MHD::ClearSTSFlux(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  Kokkos::deep_copy(DevExeSpace(), uflx.x1f, 0.0);
+  Kokkos::deep_copy(DevExeSpace(), uflx.x2f, 0.0);
+  Kokkos::deep_copy(DevExeSpace(), uflx.x3f, 0.0);
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+
+TaskStatus MHD::ClearSTSEField(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  Kokkos::deep_copy(DevExeSpace(), efld.x1e, 0.0);
+  Kokkos::deep_copy(DevExeSpace(), efld.x2e, 0.0);
+  Kokkos::deep_copy(DevExeSpace(), efld.x3e, 0.0);
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+
+TaskStatus MHD::STSFluxes(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  if (has_any_sts_cell_update) {
+    AddSelectedDiffusionFluxes(parabolic::DiffusionSelection::sts_only);
+  }
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+
+TaskStatus MHD::STSEField(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  if (has_any_sts_field_update) {
+    AddSelectedDiffusionEMF(parabolic::DiffusionSelection::sts_only);
+  }
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \brief Apply one RKL2 stage to the STS-managed cell-centered MHD variables.
+
+TaskStatus MHD::STSUpdateU(Driver *pdrive, int stage) {
+  if (!has_any_sts_cell_update || !(pdrive->sts.enabled)) {
+    return TaskStatus::complete;
+  }
+
+  if (stage == 1) {
+    Kokkos::deep_copy(DevExeSpace(), u_sts0, u0);
+    Kokkos::deep_copy(DevExeSpace(), u_sts1, u0);
+    Kokkos::deep_copy(DevExeSpace(), u_sts2, u0);
+  } else {
+    Kokkos::deep_copy(DevExeSpace(), u_sts2, u_sts1);
+    Kokkos::deep_copy(DevExeSpace(), u_sts1, u0);
+  }
+
+  const bool update_momentum = has_sts_viscosity;
+  const bool update_energy = has_sts_conduction ||
+      ((has_sts_viscosity || has_sts_resistivity) && peos->eos_data.is_ideal);
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  int is = indcs.is, ie = indcs.ie;
+  int js = indcs.js, je = indcs.je;
+  int ks = indcs.ks, ke = indcs.ke;
+  int ncells1 = indcs.nx1 + 2*(indcs.ng);
+  bool &multi_d = pmy_pack->pmesh->multi_d;
+  bool &three_d = pmy_pack->pmesh->three_d;
+
+  int nmb1 = pmy_pack->nmb_thispack - 1;
+  int nvars = nmhd + nscalars;
+  Real dt_sweep = pdrive->sts.dt_sweep;
+  auto coeffs = pdrive->sts.coeffs;
+  auto u0_ = u0;
+  auto u_sts0_ = u_sts0;
+  auto u_sts1_ = u_sts1;
+  auto u_sts2_ = u_sts2;
+  auto u_sts_rhs_ = u_sts_rhs;
+  auto flx1 = uflx.x1f;
+  auto flx2 = uflx.x2f;
+  auto flx3 = uflx.x3f;
+  auto &mbsize = pmy_pack->pmb->mb_size;
+
+  int scr_level = 0;
+  size_t scr_size = ScrArray1D<Real>::shmem_size(ncells1);
+
+  par_for_outer("mhd_sts_update_u", DevExeSpace(), scr_size, scr_level, 0, nmb1,
+                0, nvars - 1, ks, ke, js, je,
+  KOKKOS_LAMBDA(TeamMember_t member, const int m, const int n, const int k, const int j) {
+    if (!UpdateSTSMHDVariable(n, update_momentum, update_energy)) {
+      return;
+    }
+
+    ScrArray1D<Real> divf(member.team_scratch(scr_level), ncells1);
+    par_for_inner(member, is, ie, [&](const int i) {
+      divf(i) = (flx1(m,n,k,j,i+1) - flx1(m,n,k,j,i))/mbsize.d_view(m).dx1;
+    });
+    member.team_barrier();
+
+    if (multi_d) {
+      par_for_inner(member, is, ie, [&](const int i) {
+        divf(i) += (flx2(m,n,k,j+1,i) - flx2(m,n,k,j,i))/mbsize.d_view(m).dx2;
+      });
+      member.team_barrier();
+    }
+    if (three_d) {
+      par_for_inner(member, is, ie, [&](const int i) {
+        divf(i) += (flx3(m,n,k+1,j,i) - flx3(m,n,k,j,i))/mbsize.d_view(m).dx3;
+      });
+      member.team_barrier();
+    }
+
+    par_for_inner(member, is, ie, [&](const int i) {
+      const Real delta_u = -dt_sweep*divf(i);
+      u0_(m,n,k,j,i) = coeffs.muj*u_sts1_(m,n,k,j,i)
+                     + coeffs.nuj*u_sts2_(m,n,k,j,i)
+                     + (1.0 - coeffs.muj - coeffs.nuj)*u_sts0_(m,n,k,j,i)
+                     + coeffs.gammaj_tilde*u_sts_rhs_(m,n,k,j,i)
+                     + coeffs.muj_tilde*delta_u;
+      if (stage == 1) {
+        u_sts_rhs_(m,n,k,j,i) = delta_u;
+      }
+    });
+  });
+
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+//! \brief Apply one constrained-transport RKL2 stage to the magnetic field.
+
+TaskStatus MHD::STSUpdateB(Driver *pdrive, int stage) {
+  if (!has_any_sts_field_update || !(pdrive->sts.enabled)) {
+    return TaskStatus::complete;
+  }
+
+  if (stage == 1) {
+    Kokkos::deep_copy(DevExeSpace(), b_sts0.x1f, b0.x1f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts0.x2f, b0.x2f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts0.x3f, b0.x3f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts1.x1f, b0.x1f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts1.x2f, b0.x2f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts1.x3f, b0.x3f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts2.x1f, b0.x1f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts2.x2f, b0.x2f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts2.x3f, b0.x3f);
+  } else {
+    Kokkos::deep_copy(DevExeSpace(), b_sts2.x1f, b_sts1.x1f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts2.x2f, b_sts1.x2f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts2.x3f, b_sts1.x3f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts1.x1f, b0.x1f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts1.x2f, b0.x2f);
+    Kokkos::deep_copy(DevExeSpace(), b_sts1.x3f, b0.x3f);
+  }
+
+  auto &indcs = pmy_pack->pmesh->mb_indcs;
+  int is = indcs.is, ie = indcs.ie;
+  int js = indcs.js, je = indcs.je;
+  int ks = indcs.ks, ke = indcs.ke;
+  int nmb1 = pmy_pack->nmb_thispack - 1;
+  const bool &multi_d = pmy_pack->pmesh->multi_d;
+  const bool &three_d = pmy_pack->pmesh->three_d;
+  Real dt_sweep = pdrive->sts.dt_sweep;
+  auto coeffs = pdrive->sts.coeffs;
+  auto e1 = efld.x1e;
+  auto e2 = efld.x2e;
+  auto e3 = efld.x3e;
+  auto bx1f = b0.x1f;
+  auto bx2f = b0.x2f;
+  auto bx3f = b0.x3f;
+  auto bx1f_sts0 = b_sts0.x1f;
+  auto bx2f_sts0 = b_sts0.x2f;
+  auto bx3f_sts0 = b_sts0.x3f;
+  auto bx1f_sts1 = b_sts1.x1f;
+  auto bx2f_sts1 = b_sts1.x2f;
+  auto bx3f_sts1 = b_sts1.x3f;
+  auto bx1f_sts2 = b_sts2.x1f;
+  auto bx2f_sts2 = b_sts2.x2f;
+  auto bx3f_sts2 = b_sts2.x3f;
+  auto bx1f_rhs = b_sts_rhs.x1f;
+  auto bx2f_rhs = b_sts_rhs.x2f;
+  auto bx3f_rhs = b_sts_rhs.x3f;
+  auto &mbsize = pmy_pack->pmb->mb_size;
+
+  par_for("mhd_sts_update_b1", DevExeSpace(), 0, nmb1, ks, ke, js, je, is, ie+1,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real delta_b = 0.0;
+    if (multi_d) {
+      delta_b -= dt_sweep*(e3(m,k,j+1,i) - e3(m,k,j,i))/mbsize.d_view(m).dx2;
+      if (three_d) {
+        delta_b += dt_sweep*(e2(m,k+1,j,i) - e2(m,k,j,i))/mbsize.d_view(m).dx3;
+      }
+    }
+    bx1f(m,k,j,i) = coeffs.muj*bx1f_sts1(m,k,j,i)
+                  + coeffs.nuj*bx1f_sts2(m,k,j,i)
+                  + (1.0 - coeffs.muj - coeffs.nuj)*bx1f_sts0(m,k,j,i)
+                  + coeffs.gammaj_tilde*bx1f_rhs(m,k,j,i)
+                  + coeffs.muj_tilde*delta_b;
+    if (stage == 1) bx1f_rhs(m,k,j,i) = delta_b;
+  });
+
+  par_for("mhd_sts_update_b2", DevExeSpace(), 0, nmb1, ks, ke, js, je+1, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real delta_b = dt_sweep*(e3(m,k,j,i+1) - e3(m,k,j,i))/mbsize.d_view(m).dx1;
+    if (three_d) {
+      delta_b -= dt_sweep*(e1(m,k+1,j,i) - e1(m,k,j,i))/mbsize.d_view(m).dx3;
+    }
+    bx2f(m,k,j,i) = coeffs.muj*bx2f_sts1(m,k,j,i)
+                  + coeffs.nuj*bx2f_sts2(m,k,j,i)
+                  + (1.0 - coeffs.muj - coeffs.nuj)*bx2f_sts0(m,k,j,i)
+                  + coeffs.gammaj_tilde*bx2f_rhs(m,k,j,i)
+                  + coeffs.muj_tilde*delta_b;
+    if (stage == 1) bx2f_rhs(m,k,j,i) = delta_b;
+  });
+
+  par_for("mhd_sts_update_b3", DevExeSpace(), 0, nmb1, ks, ke+1, js, je, is, ie,
+  KOKKOS_LAMBDA(int m, int k, int j, int i) {
+    Real delta_b = -dt_sweep*(e2(m,k,j,i+1) - e2(m,k,j,i))/mbsize.d_view(m).dx1;
+    if (multi_d) {
+      delta_b += dt_sweep*(e1(m,k,j+1,i) - e1(m,k,j,i))/mbsize.d_view(m).dx2;
+    }
+    bx3f(m,k,j,i) = coeffs.muj*bx3f_sts1(m,k,j,i)
+                  + coeffs.nuj*bx3f_sts2(m,k,j,i)
+                  + (1.0 - coeffs.muj - coeffs.nuj)*bx3f_sts0(m,k,j,i)
+                  + coeffs.gammaj_tilde*bx3f_rhs(m,k,j,i)
+                  + coeffs.muj_tilde*delta_b;
+    if (stage == 1) bx3f_rhs(m,k,j,i) = delta_b;
+  });
+
+  return TaskStatus::complete;
+}
+
+//----------------------------------------------------------------------------------------
+
+TaskStatus MHD::STSRefreshTimeStep(Driver *pdrive, int stage) {
+  if (has_any_sts_diffusion && pdrive->sts.enabled &&
+      pdrive->sts.sweep == Driver::STSSweep::post && stage == pdrive->sts.nstages) {
+    RecomputeTimeStepFromCurrentState(pdrive);
+  }
+  return TaskStatus::complete;
+}
+
+} // namespace mhd

--- a/src/mhd/mhd_tasks.cpp
+++ b/src/mhd/mhd_tasks.cpp
@@ -80,6 +80,47 @@ void MHD::AssembleMHDTasks(std::map<std::string, std::shared_ptr<TaskList>> tl) 
   // task list anyways to catch potential bugs in MPI communication logic
   id.crecv = tl["after_stagen"]->AddTask(&MHD::ClearRecv, this, id.csend);
 
+  if (has_any_sts_diffusion) {
+    tl["before_parabolic_stagen"]->AddTask(&MHD::InitRecvParabolic, this, none);
+
+    TaskID pclearf = tl["parabolic_stagen"]->AddTask(&MHD::ClearSTSFlux, this, none);
+    TaskID pflux = tl["parabolic_stagen"]->AddTask(&MHD::STSFluxes, this, pclearf);
+    TaskID psendf = tl["parabolic_stagen"]->AddTask(&MHD::SendFlux, this, pflux);
+    TaskID precvf = tl["parabolic_stagen"]->AddTask(&MHD::RecvFlux, this, psendf);
+    TaskID update_dependency = precvf;
+    if (has_any_sts_field_update) {
+      TaskID pcleare = tl["parabolic_stagen"]->AddTask(&MHD::ClearSTSEField,
+                                                       this, precvf);
+      TaskID pefld = tl["parabolic_stagen"]->AddTask(&MHD::STSEField, this, pcleare);
+      TaskID psende = tl["parabolic_stagen"]->AddTask(&MHD::SendE, this, pefld);
+      update_dependency = tl["parabolic_stagen"]->AddTask(&MHD::RecvE, this, psende);
+    }
+    TaskID pupdt = tl["parabolic_stagen"]->AddTask(&MHD::STSUpdateU, this,
+                                                   update_dependency);
+    TaskID state_dependency = pupdt;
+    if (has_any_sts_field_update) {
+      state_dependency = tl["parabolic_stagen"]->AddTask(&MHD::STSUpdateB, this, pupdt);
+    }
+    TaskID prestu = tl["parabolic_stagen"]->AddTask(&MHD::RestrictU, this,
+                                                    state_dependency);
+    TaskID psendu = tl["parabolic_stagen"]->AddTask(&MHD::SendU, this, prestu);
+    TaskID precvu = tl["parabolic_stagen"]->AddTask(&MHD::RecvU, this, psendu);
+    TaskID boundary_dependency = precvu;
+    if (has_any_sts_field_update) {
+      TaskID prestb = tl["parabolic_stagen"]->AddTask(&MHD::RestrictB, this, precvu);
+      TaskID psendb = tl["parabolic_stagen"]->AddTask(&MHD::SendB, this, prestb);
+      boundary_dependency = tl["parabolic_stagen"]->AddTask(&MHD::RecvB, this, psendb);
+    }
+    TaskID pprol = tl["parabolic_stagen"]->AddTask(&MHD::Prolongate, this,
+                                                   boundary_dependency);
+    TaskID pbcs = tl["parabolic_stagen"]->AddTask(&MHD::ApplyPhysicalBCs, this, pprol);
+    TaskID pc2p = tl["parabolic_stagen"]->AddTask(&MHD::ConToPrim, this, pbcs);
+    (void) tl["parabolic_stagen"]->AddTask(&MHD::STSRefreshTimeStep, this, pc2p);
+
+    TaskID pcsend = tl["after_parabolic_stagen"]->AddTask(&MHD::ClearSend, this, none);
+    (void) tl["after_parabolic_stagen"]->AddTask(&MHD::ClearRecv, this, pcsend);
+  }
+
   return;
 }
 
@@ -156,6 +197,26 @@ TaskStatus MHD::InitRecv(Driver *pdrive, int stage) {
 }
 
 //----------------------------------------------------------------------------------------
+//! \brief Post receives required for one STS parabolic stage.
+
+TaskStatus MHD::InitRecvParabolic(Driver *pdrive, int stage) {
+  (void) pdrive;
+  (void) stage;
+  TaskStatus tstat = pbval_u->InitRecv(nmhd+nscalars);
+  if (tstat != TaskStatus::complete) return tstat;
+  if (pmy_pack->pmesh->multilevel) {
+    tstat = pbval_u->InitFluxRecv(nmhd+nscalars);
+    if (tstat != TaskStatus::complete) return tstat;
+  }
+  if (has_any_sts_field_update) {
+    tstat = pbval_b->InitRecv(3);
+    if (tstat != TaskStatus::complete) return tstat;
+    tstat = pbval_b->InitFluxRecv(3);
+  }
+  return tstat;
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn TaskStatus MHD::CopyCons
 //! \brief Simple task list function that copies u0 --> u1, and b0 --> b1 in first stage
 
@@ -194,16 +255,8 @@ TaskStatus MHD::Fluxes(Driver *pdrive, int stage) {
     CalculateFluxes<MHD_RSolver::hlle_gr>(pdrive, stage);
   }
 
-  // Add diffusive fluxes
-  if (pcond != nullptr) {
-    pcond->AddHeatFluxes(w0, peos->eos_data, uflx);
-  }
-  if (pvisc != nullptr) {
-    pvisc->AddViscousFluxes(w0, peos->eos_data, uflx);
-  }
-  if ((presist != nullptr) && (peos->eos_data.is_ideal)) {
-    presist->AddResistiveFluxes(b0, uflx);
-  }
+  // STS-selected diffusion is advanced only in the parabolic half-sweeps.
+  AddSelectedDiffusionFluxes(parabolic::DiffusionSelection::explicit_only);
 
   // call FOFC if necessary
   if (use_fofc) {
@@ -377,11 +430,7 @@ TaskStatus MHD::EField(Driver *pdrive, int stage) {
   // Use CT to compute corner E
   CornerE(pdrive, stage);
 
-  // Add resistive electric field (if needed)
-  if (presist != nullptr) {
-    presist->AddResistiveEMFs(b0, efld);
-  }
-  // TODO(@user): Add more resistive effects here
+  AddSelectedDiffusionEMF(parabolic::DiffusionSelection::explicit_only);
 
   if (psbox_b != nullptr) {
     // only execute when (2D)

--- a/tst/inputs/diffusion.athinput
+++ b/tst/inputs/diffusion.athinput
@@ -37,6 +37,8 @@ nx3       = 1          # Number of cells in each MeshBlock, X3-dir
 <time>
 evolution  = kinematic # dynamic/kinematic/static (diffusion tests require kinematic)
 integrator = rk2       # time integration algorithm
+sts_integrator = none  # parabolic super-time-step integrator (none/rkl2)
+sts_max_dt_ratio = -1.0 # optional cap on cycle/parabolic timestep ratio
 cfl_number = 0.4       # The Courant, Friedrichs, & Lewy (CFL) Number
 nlim       = -1        # cycle limit (no limit if <0)
 tlim       = 1.0       # time limit
@@ -49,6 +51,8 @@ rsolver     = advect   # Riemann-solver to be used
 gamma       = 1.66666666667   # gamma = C_p/C_v
 nu_iso      = 0.0      # isotropic kinematic viscosity (set by viscosity tests)
 alpha_iso   = 0.0      # isotropic thermal diffusivity (set by conduction tests)
+viscosity_integrator = explicit    # explicit/sts
+conductivity_integrator = explicit # explicit/sts
 
 <units>
 # Default (length=mass=time=mu=1) code units. Present so the thermal-conduction module

--- a/tst/inputs/diffusion_mhd.athinput
+++ b/tst/inputs/diffusion_mhd.athinput
@@ -38,6 +38,8 @@ nx3       = 1          # Number of cells in each MeshBlock, X3-dir
 <time>
 evolution  = kinematic # dynamic/kinematic/static (diffusion tests require kinematic)
 integrator = rk2       # time integration algorithm
+sts_integrator = none  # parabolic super-time-step integrator (none/rkl2)
+sts_max_dt_ratio = -1.0 # optional cap on cycle/parabolic timestep ratio
 cfl_number = 0.4       # The Courant, Friedrichs, & Lewy (CFL) Number
 nlim       = -1        # cycle limit (no limit if <0)
 tlim       = 1.0       # time limit
@@ -49,6 +51,7 @@ reconstruct       = wenoz    # spatial reconstruction method
 rsolver           = advect   # Riemann-solver (kinematic MHD uses advect)
 gamma             = 1.66666666667   # gamma = C_p/C_v
 eta_ohm           = 0.25     # Ohmic resistivity (set by resistivity tests)
+resistivity_integrator = explicit # explicit/sts
 
 <units>
 # Default (length=mass=time=mu=1) code units.

--- a/tst/inputs/lwave_ambipolar.athinput
+++ b/tst/inputs/lwave_ambipolar.athinput
@@ -39,6 +39,8 @@ refinement       = none
 <time>
 evolution  = dynamic
 integrator = rk2
+sts_integrator = none
+sts_max_dt_ratio = -1.0
 cfl_number = 0.3
 nlim       = -1
 tlim       = 5.0
@@ -50,6 +52,7 @@ reconstruct = plm
 rsolver     = hlld
 iso_sound_speed = 1.0
 eta_ad      = 0.01
+resistivity_integrator = explicit
 
 <output1>
 file_type  = hst

--- a/tst/test_suite/diffusion/test_diffusion_ambipolar_linwave_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_ambipolar_linwave_cpu.py
@@ -10,6 +10,7 @@ import pytest
 import numpy as np
 from numpy.polynomial import Polynomial
 import os
+import subprocess
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -157,3 +158,22 @@ def test_ambipolar_linwave(wave_flag, dim):
             )
     finally:
         testutils.cleanup()
+
+
+def test_ambipolar_rejects_sts():
+    """STS rejects ambipolar diffusion until its state-dependent bound is stage-safe."""
+    result = subprocess.run(
+        [
+            "./athena",
+            "-i",
+            "inputs/lwave_ambipolar.athinput",
+            "time/sts_integrator=rkl2",
+            "mhd/resistivity_integrator=sts",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = (result.stdout + result.stderr).lower()
+    assert result.returncode != 0
+    assert "ambipolar diffusion is not supported with sts" in output

--- a/tst/test_suite/diffusion/test_diffusion_conduct_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_conduct_cpu.py
@@ -28,7 +28,7 @@ def arguments(iv, rv, fv, wv, res, soe, name):
     ndim = _ndim[wv]
     nx2 = res if ndim >= 2 else 1
     mbx2 = res // 2 if ndim >= 2 else 1
-    return [
+    args = [
         f"job/basename={name}",
         "time/tlim=1.0",
         "time/integrator=" + iv,
@@ -46,6 +46,16 @@ def arguments(iv, rv, fv, wv, res, soe, name):
         "hydro/alpha_iso=0.5",
         "problem/amp=1.0e-6",
     ]
+    if fv == "sts":
+        args += [
+            "time/sts_integrator=rkl2",
+            "time/sts_max_dt_ratio=16.0",
+            "hydro/conductivity_integrator=sts",
+            # Keep a harmless explicit process active to cover mixed scheduling.
+            "hydro/nu_iso=1.0e-6",
+            "hydro/viscosity_integrator=explicit",
+        ]
+    return args
 
 
 """
@@ -66,5 +76,21 @@ def test_run():
         "rk2",
         "diff",
         "none",
+        "hydro",
+    )
+
+
+def test_sts_run():
+    """Check RKL2 conduction convergence with an explicit viscosity process present."""
+    testutils.test_error_convergence(
+        "inputs/diffusion.athinput",
+        "diffusion_heat_sts",
+        arguments,
+        errors,
+        ["1d"],
+        _res,
+        "rk2",
+        "diff",
+        "sts",
         "hydro",
     )

--- a/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_cpu.py
@@ -24,7 +24,7 @@ _b_comp = {"By": 2, "Bz": 3}
 
 def arguments(iv, rv, fv, wv, res, soe, name):
     """Assemble arguments for run command"""
-    return [
+    args = [
         f"job/basename={name}",
         "time/tlim=1.0",
         "time/integrator=" + iv,
@@ -42,6 +42,13 @@ def arguments(iv, rv, fv, wv, res, soe, name):
         "mhd/eta_ohm=0.25",
         "problem/amp=1.0e-6",
     ]
+    if fv == "sts":
+        args += [
+            "time/sts_integrator=rkl2",
+            "time/sts_max_dt_ratio=16.0",
+            "mhd/resistivity_integrator=sts",
+        ]
+    return args
 
 
 """
@@ -62,5 +69,21 @@ def test_run():
         "rk2",
         "diff",
         "none",
+        "mhd",
+    )
+
+
+def test_sts_run():
+    """Check RKL2 Ohmic constrained-transport convergence for one field component."""
+    testutils.test_error_convergence(
+        "inputs/diffusion_mhd.athinput",
+        "diffusion_resist1d_sts",
+        arguments,
+        errors,
+        ["By"],
+        _res,
+        "rk2",
+        "diff",
+        "sts",
         "mhd",
     )

--- a/tst/test_suite/diffusion/test_diffusion_resist_gpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_resist_gpu.py
@@ -41,9 +41,9 @@ def arguments(iv, rv, fv, wv, res, soe, name):
     mbx = {1: res // 2, 2: res // 2, 3: res // 2}
     nx[p["thin"]] = _NTHIN
     mbx[p["thin"]] = _NTHIN
-    return [
+    args = [
         f"job/basename={name}",
-        "time/tlim=1.0",
+        "time/tlim=" + ("0.05" if fv == "sts" else "1.0"),
         "time/integrator=" + iv,
         "mesh/nx1=" + repr(nx[1]),
         "mesh/nx2=" + repr(nx[2]),
@@ -59,6 +59,13 @@ def arguments(iv, rv, fv, wv, res, soe, name):
         "mhd/eta_ohm=0.25",
         "problem/amp=1.0e-6",
     ]
+    if fv == "sts":
+        args += [
+            "time/sts_integrator=rkl2",
+            "time/sts_max_dt_ratio=16.0",
+            "mhd/resistivity_integrator=sts",
+        ]
+    return args
 
 
 def test_run():
@@ -75,3 +82,14 @@ def test_run():
         "none",
         "mhd",
     )
+
+
+def test_sts_smoke():
+    """Exercise the RKL2 cell/CT update kernels in a small GPU run."""
+    try:
+        testutils.run(
+            "inputs/diffusion_mhd.athinput",
+            arguments("rk2", "diff", "sts", "xy", 32, "mhd", "diffusion_sts_gpu"),
+        )
+    finally:
+        testutils.cleanup()

--- a/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
+++ b/tst/test_suite/diffusion/test_diffusion_visc_cpu.py
@@ -23,7 +23,7 @@ _vel_comp = {"vy": 2, "vz": 3}
 
 def arguments(iv, rv, fv, wv, res, soe, name):
     """Assemble arguments for run command"""
-    return [
+    args = [
         f"job/basename={name}",
         "time/tlim=1.0",
         "time/integrator=" + iv,
@@ -42,6 +42,16 @@ def arguments(iv, rv, fv, wv, res, soe, name):
         "hydro/nu_iso=0.25",
         "problem/amp=1.0e-6",
     ]
+    if fv == "sts":
+        args += [
+            "time/sts_integrator=rkl2",
+            "time/sts_max_dt_ratio=16.0",
+            "hydro/viscosity_integrator=sts",
+            # Exercise the combined STS stability bound with a second active process.
+            "hydro/alpha_iso=0.25",
+            "hydro/conductivity_integrator=sts",
+        ]
+    return args
 
 
 """
@@ -62,5 +72,21 @@ def test_run():
         "rk2",
         "diff",
         "none",
+        "hydro",
+    )
+
+
+def test_sts_run():
+    """Check combined RKL2 viscosity/conduction with a transverse velocity pulse."""
+    testutils.test_error_convergence(
+        "inputs/diffusion.athinput",
+        "diffusion_visc1d_sts",
+        arguments,
+        errors,
+        ["vy"],
+        _res,
+        "rk2",
+        "diff",
+        "sts",
         "hydro",
     )

--- a/tst/test_suite/diffusion/test_sts_rkl2_controller_cpu.py
+++ b/tst/test_suite/diffusion/test_sts_rkl2_controller_cpu.py
@@ -1,0 +1,114 @@
+"""Focused unit tests for the host-side RKL2 controller."""
+
+import math
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def controller(tmp_path_factory):
+    """Build the controller with a minimal athena.hpp type stub."""
+    build_dir = tmp_path_factory.mktemp("sts_rkl2_controller")
+    (build_dir / "athena.hpp").write_text("using Real = double;\n", encoding="ascii")
+    source = build_dir / "controller.cpp"
+    source.write_text(
+        r"""
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "diffusion/sts_rkl2.hpp"
+
+int main(int argc, char **argv) {
+  std::string operation(argv[1]);
+  std::cout << std::setprecision(17);
+  if (operation == "stages") {
+    std::cout << parabolic::ComputeRKL2StageCount(std::stod(argv[2]),
+                                                  std::stod(argv[3]));
+    return 0;
+  }
+  auto coeffs = parabolic::ComputeRKL2Coefficients(std::stoi(argv[2]),
+                                                   std::stoi(argv[3]));
+  std::cout << coeffs.muj << " " << coeffs.nuj << " "
+            << coeffs.muj_tilde << " " << coeffs.gammaj_tilde;
+  return 0;
+}
+""",
+        encoding="ascii",
+    )
+    executable = build_dir / "controller"
+    subprocess.run(
+        [
+            "c++",
+            "-std=c++17",
+            "-O2",
+            f"-I{build_dir}",
+            f"-I{REPO_ROOT / 'src'}",
+            str(source),
+            str(REPO_ROOT / "src/diffusion/sts_rkl2.cpp"),
+            "-o",
+            str(executable),
+        ],
+        check=True,
+    )
+    return executable
+
+
+def _run(controller, *args):
+    result = subprocess.run(
+        [str(controller), *map(str, args)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+@pytest.mark.parametrize("nstages", [3, 5, 7, 101, 46341])
+def test_exact_odd_threshold_selects_smallest_stage_count(controller, nstages):
+    ratio = (nstages*nstages + nstages - 2)/4
+    assert int(_run(controller, "stages", ratio, 1.0)) == nstages
+    assert int(_run(controller, "stages", math.nextafter(ratio, math.inf), 1.0)) == (
+        nstages + 2
+    )
+
+
+def test_zero_ratio_retains_three_stage_minimum(controller):
+    assert int(_run(controller, "stages", 0.0, 1.0)) == 3
+
+
+def test_large_stage_coefficients_do_not_overflow_integer_products(controller):
+    stage = 1_000_000_001
+    values = [float(value) for value in _run(controller, "coeff", stage, stage).split()]
+    jr = float(stage)
+    bj = (jr*jr + jr - 2.0)/(2.0*jr*(jr + 1.0))
+    jm1 = jr - 1.0
+    bj_m1 = (jm1*jm1 + jm1 - 2.0)/(2.0*jm1*(jm1 + 1.0))
+    jm2 = jr - 2.0
+    bj_m2 = (jm2*jm2 + jm2 - 2.0)/(2.0*jm2*(jm2 + 1.0))
+    muj = ((2.0*jr - 1.0)/jr)*bj/bj_m1
+    nuj = -((jr - 1.0)/jr)*bj/bj_m2
+    denom = jr*jr + jr - 2.0
+    muj_tilde = muj*4.0/denom
+    gammaj_tilde = -(1.0 - bj_m1)*muj_tilde
+
+    assert all(math.isfinite(value) for value in values)
+    assert values == pytest.approx(
+        [muj, nuj, muj_tilde, gammaj_tilde], rel=1.0e-14
+    )
+
+
+def test_unrepresentable_stage_count_fails_cleanly(controller):
+    result = subprocess.run(
+        [str(controller), "stages", "1e300", "1.0"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "stage count exceeds the supported integer range" in result.stdout

--- a/tst/test_suite/diffusion/test_sts_rkl2_mpicpu.py
+++ b/tst/test_suite/diffusion/test_sts_rkl2_mpicpu.py
@@ -1,0 +1,172 @@
+"""Focused MPI, mesh-refinement, and restart checks for RKL2 diffusion."""
+
+import math
+from pathlib import Path
+import shutil
+
+import numpy as np
+
+import athena_read
+import test_suite.testutils as testutils
+
+
+def _mhd_input(tmp_path):
+    """Add test-only static-refinement and restart blocks to the shared MHD input."""
+    path = tmp_path / "sts_diffusion_mhd.athinput"
+    path.write_text(
+        Path("inputs/diffusion_mhd.athinput").read_text()
+        + """
+
+<mesh_refinement>
+refinement = none
+
+<refined_region1>
+level = 1
+x1min = -1.0
+x1max = 1.0
+x2min = -1.0
+x2max = 1.0
+
+<output1>
+file_type = rst
+dcycle = 0
+"""
+    )
+    return str(path)
+
+
+def test_sts_conduction_2d_mpi():
+    """Exercise a nonzero cell-centered STS flux across MPI MeshBlocks."""
+    basename = "sts_conduction_2d_mpi"
+    try:
+        results = testutils.mpi_run(
+            "inputs/diffusion.athinput",
+            [
+                f"job/basename={basename}",
+                "time/tlim=100.0",
+                "time/nlim=2",
+                "time/sts_integrator=rkl2",
+                "time/sts_max_dt_ratio=8.0",
+                "mesh/nx1=32",
+                "mesh/nx2=32",
+                "mesh/nx3=1",
+                "meshblock/nx1=8",
+                "meshblock/nx2=8",
+                "meshblock/nx3=1",
+                "problem/conduction_test=true",
+                "problem/viscosity_test=false",
+                "problem/spread_x1=true",
+                "problem/spread_x2=true",
+                "problem/spread_x3=false",
+                "hydro/alpha_iso=2.0",
+                "hydro/conductivity_integrator=sts",
+            ],
+            threads=4,
+        )
+        assert results, "2D MPI RKL2 conduction run failed"
+        rms_l1 = athena_read.error_dat(f"{basename}-errs.dat")[0][4]
+        assert math.isfinite(rms_l1) and rms_l1 < 1.0e-7
+    finally:
+        testutils.cleanup()
+
+
+def test_sts_ohmic_2d_static_amr_mpi(tmp_path):
+    """Exercise RKL2 Ohmic CT, MPI boundaries, and static refinement together."""
+    basename = "sts_ohmic_2d_smr_mpi"
+    try:
+        results = testutils.mpi_run(
+            _mhd_input(tmp_path),
+            [
+                f"job/basename={basename}",
+                "time/tlim=100.0",
+                "time/nlim=2",
+                "time/sts_integrator=rkl2",
+                "time/sts_max_dt_ratio=8.0",
+                "mesh/nghost=2",
+                "mesh/nx1=32",
+                "mesh/nx2=32",
+                "mesh/nx3=1",
+                "meshblock/nx1=8",
+                "meshblock/nx2=8",
+                "meshblock/nx3=1",
+                "mesh_refinement/refinement=static",
+                "mhd/reconstruct=plm",
+                "mhd/eta_ohm=2.0",
+                "mhd/resistivity_integrator=sts",
+                "problem/spread_x1=true",
+                "problem/spread_x2=true",
+                "problem/spread_x3=false",
+                "problem/vel_comp=3",
+            ],
+            threads=4,
+        )
+        assert results, "2D static-AMR MPI RKL2 Ohmic run failed"
+        row = athena_read.error_dat(f"{basename}-errs.dat")[0]
+        assert row[3] == 2
+        assert math.isfinite(row[4]) and row[4] < 1.0e-7
+    finally:
+        testutils.cleanup()
+
+
+def test_sts_cycle_boundary_restart(tmp_path):
+    """A restart between complete RKL2 sweeps must reproduce an uninterrupted run."""
+    common = [
+        "time/tlim=100.0",
+        "time/sts_integrator=rkl2",
+        "time/sts_max_dt_ratio=8.0",
+        "mesh/nx1=32",
+        "mesh/nx2=1",
+        "mesh/nx3=1",
+        "meshblock/nx1=16",
+        "meshblock/nx2=1",
+        "meshblock/nx3=1",
+        "mhd/eta_ohm=2.0",
+        "mhd/resistivity_integrator=sts",
+        "problem/spread_x1=true",
+        "problem/spread_x2=false",
+        "problem/spread_x3=false",
+        "problem/vel_comp=2",
+    ]
+    shutil.rmtree("rst", ignore_errors=True)
+    try:
+        direct = "sts_restart_direct"
+        assert testutils.run(
+            _mhd_input(tmp_path),
+            [f"job/basename={direct}", "time/nlim=4"] + common,
+        )
+        direct_error = np.array(
+            athena_read.error_dat(f"{direct}-errs.dat")[0], copy=True
+        )
+        testutils.cleanup()
+
+        split = "sts_restart_split"
+        assert testutils.run(
+            _mhd_input(tmp_path),
+            [
+                f"job/basename={split}",
+                "time/nlim=2",
+                "output1/dcycle=2",
+            ]
+            + common,
+        )
+        restart_file = Path("rst") / f"{split}.00001.rst"
+        assert restart_file.exists()
+        testutils.cleanup()
+
+        resumed = "sts_restart_resumed"
+        results = testutils.run_command(
+            [
+                "./athena",
+                "-r",
+                str(restart_file),
+                f"job/basename={resumed}",
+                "time/nlim=4",
+                "output1/dcycle=0",
+            ]
+        )
+        assert results, "RKL2 restart run failed"
+        resumed_error = athena_read.error_dat(f"{resumed}-errs.dat")[0]
+        np.testing.assert_allclose(resumed_error, direct_error, rtol=0.0, atol=0.0)
+    finally:
+        shutil.rmtree("rst", ignore_errors=True)
+        testutils.cleanup()


### PR DESCRIPTION
## Summary

This PR adds optional second-order Runge-Kutta-Legendre super-time-stepping (RKL2 STS) for the existing constant-coefficient diffusion operators:

- isotropic thermal conduction in Newtonian Hydro and MHD
- isotropic viscosity in Newtonian Hydro and MHD
- Ohmic resistivity in Newtonian MHD, using constrained transport

Explicit integration remains the default, and each diffusion process independently selects explicit or STS integration.

When enabled, the STS update is applied as symmetric half-sweeps before and after the ordinary Runge-Kutta update. The implementation reuses AthenaK's existing task lists, boundary communication, flux correction, AMR, MPI, and constrained-transport machinery.

## Configuration

STS uses two levels of configuration.

First, the `<time>` block selects the STS algorithm available to the run:

```text
<time>
sts_integrator = rkl2
```

Second, each active diffusion process chooses whether it is advanced explicitly or with STS:

```text
conductivity_integrator = explicit  # or sts
viscosity_integrator = explicit     # or sts
resistivity_integrator = explicit   # or sts
```

Thus, setting `sts_integrator = rkl2` does not automatically move every diffusion process into the STS sweeps. It enables the RKL2 controller; the individual process settings determine which diffusion operators use it.

For example, this configuration advances thermal conduction with STS while leaving viscosity in the ordinary explicit update:

```text
<time>
sts_integrator = rkl2
sts_max_dt_ratio = 16.0

<hydro>
alpha_iso = 0.5
conductivity_integrator = sts

nu_iso = 0.25
viscosity_integrator = explicit
```

The explicit viscosity limit continues to constrain the ordinary timestep, while conduction is advanced in the two RKL2 half-sweeps.

Multiple processes can use STS simultaneously:

```text
<time>
sts_integrator = rkl2
sts_max_dt_ratio = 16.0

<hydro>
alpha_iso = 0.5
conductivity_integrator = sts

nu_iso = 0.25
viscosity_integrator = sts
```

In this case, the conduction and viscosity stability rates are combined when selecting the number of RKL2 stages, and both operators are advanced during the same STS sweeps.

For Ohmic diffusion in MHD, a minimal configuration is:

```text
<time>
sts_integrator = rkl2
sts_max_dt_ratio = 16.0

<mhd>
eta_ohm = 0.25
resistivity_integrator = sts
```

Conduction and viscosity use the same keywords in the `<mhd>` block when running MHD.

The optional `sts_max_dt_ratio` limits the ordinary cycle timestep relative to the combined explicit stability limit of the STS-managed processes. It provides a user-controlled upper bound on the amount of STS acceleration.

The defaults remain:

```text
<time>
sts_integrator = none
```

and `explicit` for each individual diffusion process, so existing input files retain their previous integration mode.

## Implementation

The PR adds:

- a shared RKL2 stage-count and coefficient controller
- registration of explicit and STS diffusion timestep limits
- combination of the stability limits when multiple STS processes are active
- globally synchronized stage counts across MPI ranks
- refreshed stability estimates before the post-RK half-sweep
- optional `sts_max_dt_ratio` control over the maximum acceleration relative to the explicit diffusion timestep
- cycle-boundary restart compatibility

## Explicit timestep estimates

This work also corrects the existing conduction and viscosity stability estimates. These corrections apply in explicit mode as well as STS mode.

For conduction, the new estimate sums the diffusion rates in all active directions and includes the neighboring densities appearing in the discrete operator. For uniform density on an equal-spacing grid, this reproduces the previous timestep.

For viscosity, the new estimate includes the longitudinal `4/3` normal-stress contribution. On an equal-spacing grid, this reduces the diffusion-limited explicit timestep by approximately 25% in 1D, 14% in 2D, and 10% in 3D.

The diffusion fluxes and physical operators are unchanged. However, diffusion-limited explicit calculations may now take a different timestep sequence and should not be expected to remain bit-for-bit identical.

## Validation

The focused local validation passes:

- bounds-checked Debug/Serial build and representative RKL2 conduction run
- style tests: 2/2
- CPU diffusion regressions: 14/14
- MPI CPU regressions: 3/3

The regression coverage includes:

- RKL2 controller thresholds, coefficients, and large-stage arithmetic
- conduction and viscosity convergence
- Ohmic constrained-transport convergence
- simultaneous STS diffusion processes
- mixed explicit and STS process scheduling
- 2D MPI conduction
- 2D MPI Ohmic diffusion with static refinement
- bitwise-identical cycle-boundary restart
- a GPU Ohmic STS smoke test for CI
