### PR TITLE
Fix primitive-solver MagnetizationResponse

### DIFF
--- a/src/eos/primitive-solver/primitive_solver.hpp
+++ b/src/eos/primitive-solver/primitive_solver.hpp
@@ -352,9 +352,11 @@ SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim[NPRIM]
   // Apply limits to Y to ensure a physical state
   bool Y_adjusted = eos.ApplySpeciesLimits(Y);
 
+  const Real Bsq = SquareVector(B_u, g3d);
+
   // Check the conserved variables for consistency and do whatever
   // the EOSPolicy wants us to.
-  bool floored = eos.ApplyConservedFloor(D, S_d, tau, Y, SquareVector(B_u, g3d));
+  bool floored = eos.ApplyConservedFloor(D, S_d, tau, Y, Bsq);
   solver_result.cons_floor = floored;
   if (floored && eos.IsConservedFlooringFailure()) {
     HandleFailure(prim, cons, b, g3d);
@@ -406,10 +408,9 @@ SolverResult PrimitiveSolver<EOSPolicy, ErrorPolicy>::ConToPrim(Real prim[NPRIM]
     solver_result.cons_adjusted = true;
     // If b_u is rescaled, we also need to adjust D, which means we'll
     // have to adjust all our other rescalings, too.
-    Real Bsq = SquareVector(B_u, g3d);
     D = Bsq/bsqr;
     r_d[0] = S_d[0]/D; r_d[1] = S_d[1]/D; r_d[2] = S_d[2]/D;
-    RaiseForm(r_u, r_d, g3d);
+    RaiseForm(r_u, r_d, g3u);
     rb = Contract(b_u, r_d);
     rbsqr = rb*rb;
     q = tau/D;

--- a/src/eos/primitive-solver/reset_floor.hpp
+++ b/src/eos/primitive-solver/reset_floor.hpp
@@ -78,9 +78,9 @@ class ResetFloor : public ErrorPolicyInterface {
       Real factor = sqrt(max_bsq/bsq);
       bsq = max_bsq;
 
-      b_u[0] /= factor;
-      b_u[1] /= factor;
-      b_u[2] /= factor;
+      b_u[0] *= factor;
+      b_u[1] *= factor;
+      b_u[2] *= factor;
 
       return Error::CONS_ADJUSTED;
     }


### PR DESCRIPTION
There are two inconsistencies in how the magnetization is capped against it's maximum value:

1. There is a bug in `primitive_solver.hpp` that when checking the physicality of the magnetic field we raise a vector $r_i$ with the lower-case metric $\gamma_{ij}$ to get $r^i$ which is obviously not correct. It is however correctly done in the GR-Athena++ implementation of primitive-solver (see https://github.com/computationalrelativity/gr-athena/blob/8583eb9b13639ef7cef65b93f12e9858884527a9/src/z4c/primitive/primitive_solver.hpp#L550).
2. This is something I noticed when looking at GR-Athena++ in the `MagnetizationResponse` function to cap the magnetization. There in `reset_floor.hpp` they multiply by some factor that is the ratio of maximum magnetization and the current magnetization of the cell, i.e. something less than 1 if it is violated (https://github.com/computationalrelativity/gr-athena/blob/8583eb9b13639ef7cef65b93f12e9858884527a9/src/z4c/primitive/reset_floor.cpp#L87-L101). In AthenaK, we divide by that factor. If we follow the logic, then I believe GR-Athena++ does the correct thing.

Reasoning: Primitive-solver if it flags one cell as exceeding the maximum magnetization rescales that feed, which raises the density and keeps $B^i$ fixed according to $b^i=B^i/\sqrt{D}$. So essentially the "new" density becomes 
```math
D_{\mathrm{new}}=\frac{B^2}{\mathbf{bsq}}=\frac{B^2}{\mathbf{max\_bsq}}=D_{\mathrm{old}}\frac{\sigma_{\mathrm{old}}}{\mathbf{max\_bsq}},
```
With that new density the comoving magnetic field components have to be rescaled if $B^i$ is fixed:
```math
b^i_{\mathrm{new}}=\frac{B^i}{\sqrt{D_{\mathrm{new}}}}=b^i_{\mathrm{old}}\sqrt{\frac{D_{\mathrm{old}}}{D_{\mathrm{new}}}}=b^i_{\mathrm{old}}\sqrt{\frac{\mathbf{max\_bsq}}{\sigma_{\mathrm{old}}}}=b^i_{\mathrm{old}}\cdot\mathbf{factor}
```
So in the end, we get:
```math
\gamma_{ij}b^i_{\mathrm{new}}b^j_{\mathrm{new}}=\sigma_{\mathrm{old}}\cdot \mathbf{factor}^2=\mathbf{max\_bsq}
```
By dividing the magnetization on the new state with the rescaling factor we would not be at the ceiling, i.e. $\sigma_{\mathrm{max}}$, but
```math
\sigma_{\mathrm{old}}/\mathbf{factor}^2=\sigma_{\mathrm{old}}^2/\mathbf{max\_bsq}
```

