### PR TITLE
Add angle grid options to SphericalSurface output class

### DIFF
--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -433,6 +433,7 @@ class SphericalSurfaceOutput : public BaseTypeOutput {
   void WriteOutputFile(Mesh *pm, ParameterInput *pin) override;
  private:
   SphericalSurface *psurf;
+  bool dump_weights;  // write the quadrature weight of each point to file
 };
 //----------------------------------------------------------------------------------------
 //! \class EventLogOutput

--- a/src/outputs/spherical_surface.cpp
+++ b/src/outputs/spherical_surface.cpp
@@ -5,6 +5,17 @@
 //========================================================================================
 //! \file spherical_surface.cpp
 //! \brief writes data on a SphericalSurface sub-grid in binary VTK format
+//!
+//! Parameters of an <output> block with file_type = sph:
+//!   radius | radii | (nradii, r_min, r_max, r_spacing)  surface radii, see ParseRadii
+//!   ntheta, nphi, theta_spacing, theta_centering        angular grid, see
+//!                                                       ParseAngleOptions
+//!   xc, yc, zc                                          center of the surfaces
+//!   weights                                             write the surface element of
+//!                                                       each point (default true)
+//!
+//! Points are written with the radius varying fastest, then theta, then phi. theta
+//! increases with its index, phi starts at 0.
 
 #include "utils/spherical_surface.hpp"
 
@@ -116,6 +127,58 @@ std::vector<Real> ParseRadii(ParameterInput *pin, const OutputParameters &op) {
   }
   return rad;
 }
+
+//! \fn SphericalSurface::AngleOptions ParseAngleOptions(...)
+//! \brief Build the angular grid description requested by an <output> block.
+//! Accepted parameters:
+//!   ntheta           number of points along theta (default 32)
+//!   nphi             number of points along phi (default 2*ntheta)
+//!   theta_spacing    'uniform_costheta' (default) or 'uniform_theta'
+//!   theta_centering  'node' (default) or 'cell'
+SphericalSurface::AngleOptions ParseAngleOptions(ParameterInput *pin,
+                                                 const OutputParameters &op,
+                                                 int ntheta) {
+  SphericalSurface::AngleOptions aopt;
+  aopt.nphi = pin->GetOrAddInteger(op.block_name, "nphi", 2*ntheta);
+
+  std::string spacing = pin->GetOrAddString(op.block_name, "theta_spacing",
+                                            "uniform_costheta");
+  if (spacing.compare("uniform_theta") == 0) {
+    aopt.theta_spacing = SphThetaSpacing::uniform_theta;
+  } else if (spacing.compare("uniform_costheta") == 0) {
+    aopt.theta_spacing = SphThetaSpacing::uniform_costheta;
+  } else {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "Unrecognized theta_spacing = '" << spacing
+              << "' in output block '" << op.block_name
+              << "' (must be 'uniform_theta' or 'uniform_costheta')" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  std::string centering = pin->GetOrAddString(op.block_name, "theta_centering", "node");
+  if (centering.compare("cell") == 0) {
+    aopt.theta_centering = SphThetaCentering::cell;
+  } else if (centering.compare("node") == 0) {
+    aopt.theta_centering = SphThetaCentering::node;
+  } else {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "Unrecognized theta_centering = '" << centering
+              << "' in output block '" << op.block_name
+              << "' (must be 'cell' or 'node')" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  return aopt;
+}
+
+//! \brief names of the angular grid layout, written to the file header so that the grid
+//! a file was dumped on can be identified without the input file
+const char *SpacingName(SphThetaSpacing spacing) {
+  return (spacing == SphThetaSpacing::uniform_theta) ? "uniform_theta"
+                                                     : "uniform_costheta";
+}
+const char *CenteringName(SphThetaCentering centering) {
+  return (centering == SphThetaCentering::cell) ? "cell" : "node";
+}
 } // namespace
 
 SphericalSurfaceOutput::SphericalSurfaceOutput(ParameterInput *pin, Mesh *pm,
@@ -125,10 +188,14 @@ SphericalSurfaceOutput::SphericalSurfaceOutput(ParameterInput *pin, Mesh *pm,
 
   std::vector<Real> rad = ParseRadii(pin, op);
   int ntheta = pin->GetOrAddInteger(op.block_name, "ntheta", 32);
+  SphericalSurface::AngleOptions aopt = ParseAngleOptions(pin, op, ntheta);
   Real xc = pin->GetOrAddReal(op.block_name, "xc", 0.0);
   Real yc = pin->GetOrAddReal(op.block_name, "yc", 0.0);
   Real zc = pin->GetOrAddReal(op.block_name, "zc", 0.0);
-  psurf = new SphericalSurface(pm->pmb_pack, ntheta, rad, xc, yc, zc);
+  // the quadrature weights are only useful when integrating over the surface, so they
+  // can be switched off if not needed
+  dump_weights = pin->GetOrAddBoolean(op.block_name, "weights", true);
+  psurf = new SphericalSurface(pm->pmb_pack, ntheta, rad, xc, yc, zc, aopt);
 }
 
 SphericalSurfaceOutput::~SphericalSurfaceOutput() { delete psurf; }
@@ -198,12 +265,14 @@ void SphericalSurfaceOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
           << " rmin=" << psurf->radii.h_view(0)
           << " rmax=" << psurf->radii.h_view(nradii-1)
           << " xc=" << psurf->xc << " yc=" << psurf->yc << " zc=" << psurf->zc
+          << " theta_spacing=" << SpacingName(psurf->theta_spacing)
+          << " theta_centering=" << CenteringName(psurf->theta_centering)
           << std::endl;
     ofile << "BINARY" << std::endl;
     ofile << "DATASET STRUCTURED_GRID" << std::endl;
     // radius varies fastest, then theta, then phi
     ofile << "DIMENSIONS " << nradii << " " << psurf->ntheta
-          << " " << 2 * psurf->ntheta << std::endl;
+          << " " << psurf->nphi << std::endl;
     ofile << "POINTS " << psurf->npoints << " float\n";
 
     for (int i = 0; i < psurf->nangles; ++i) {
@@ -246,17 +315,21 @@ void SphericalSurfaceOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin) {
       ofile.write(reinterpret_cast<char *>(&rr), sizeof(float));
     }
 
-    ofile << "\nPOINT_DATA " << psurf->npoints << std::endl;
-    ofile << "SCALARS weights float 1" << std::endl;
-    ofile << "LOOKUP_TABLE default" << std::endl;
-    for (int i = 0; i < psurf->nangles; ++i) {
-      for (int r = 0; r < nradii; ++r) {
-        Real rad = psurf->radii.h_view(r);
-        float d = rad * rad * psurf->int_weights.h_view(i);
-        if (!big_end) {
-          Swap4Bytes(&d);
+    // every block below starts on a new line, since the preceding one ends in binary data
+    ofile << "\nPOINT_DATA " << psurf->npoints;
+    if (dump_weights) {
+      ofile << "\nSCALARS weights float 1" << std::endl;
+      ofile << "LOOKUP_TABLE default" << std::endl;
+      for (int i = 0; i < psurf->nangles; ++i) {
+        for (int r = 0; r < nradii; ++r) {
+          Real rad = psurf->radii.h_view(r);
+          // int_weights is the solid angle of the point, r^2*dOmega its surface element
+          float d = rad * rad * psurf->int_weights.h_view(i);
+          if (!big_end) {
+            Swap4Bytes(&d);
+          }
+          ofile.write(reinterpret_cast<char *>(&d), sizeof(float));
         }
-        ofile.write(reinterpret_cast<char *>(&d), sizeof(float));
       }
     }
 

--- a/src/utils/spherical_surface.cpp
+++ b/src/utils/spherical_surface.cpp
@@ -384,3 +384,4 @@ void SphericalSurface::InterpolateToSphere(int var_ind,
 
   return;
 }
+

--- a/src/utils/spherical_surface.cpp
+++ b/src/utils/spherical_surface.cpp
@@ -9,6 +9,7 @@
 #include "spherical_surface.hpp"
 
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <list>
 #include <vector>
@@ -24,14 +25,18 @@
 // constructor, initializes data structures and parameters
 
 SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
-                                   Real rad, Real xc, Real yc, Real zc)
-    : SphericalSurface(pmy_pack, ntheta, std::vector<Real>{rad}, xc, yc, zc) {}
+                                   Real rad, Real xc, Real yc, Real zc,
+                                   const AngleOptions &aopt)
+    : SphericalSurface(pmy_pack, ntheta, std::vector<Real>{rad}, xc, yc, zc, aopt) {}
 
 SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
                                    const std::vector<Real> &rad, Real xc, Real yc,
-                                   Real zc)
+                                   Real zc, const AngleOptions &aopt)
     : ntheta(ntheta),
+      nphi((aopt.nphi < 0) ? 2 * ntheta : aopt.nphi),
       nradii(static_cast<int>(rad.size())),
+      theta_spacing(aopt.theta_spacing),
+      theta_centering(aopt.theta_centering),
       radii("radii", 1),
       xc(xc),
       yc(yc),
@@ -45,7 +50,23 @@ SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
       pmy_pack(pmy_pack) {
   // reallocate and set interpolation coordinates, indices, and weights
   int &ng = pmy_pack->pmesh->mb_indcs.ng;
-  nangles = 2 * ntheta * ntheta;
+
+  if (ntheta < 1 || nphi < 1) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "SphericalSurface requires ntheta >= 1 and nphi >= 1, got "
+              << "ntheta = " << ntheta << ", nphi = " << nphi << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  // node centering places points on both poles, so the ntheta points span ntheta-1
+  // intervals and at least two of them are needed
+  if (theta_centering == SphThetaCentering::node && ntheta < 2) {
+    std::cout << "### FATAL ERROR in " << __FILE__ << " at line " << __LINE__
+              << std::endl << "SphericalSurface requires ntheta >= 2 for node centering"
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  nangles = ntheta * nphi;
   npoints = nradii * nangles;
 
   // Allocate memory for the radii DualArray1D<Real>
@@ -67,6 +88,11 @@ SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
   Kokkos::realloc(interp_indcs, npoints, 4);
   Kokkos::realloc(interp_wghts, npoints, 2 * ng, 3);
 
+  // stamp of the mesh the indices below are computed against
+  MeshRefinement *pmr = pmy_pack->pmesh->pmr;
+  amr_nmb_created = (pmr == nullptr) ? 0 : pmr->nmb_created;
+  amr_nmb_deleted = (pmr == nullptr) ? 0 : pmr->nmb_deleted;
+
   InitializeAngleAndWeights();
   InitializeRadius();
   SetInterpolationIndices();
@@ -79,14 +105,47 @@ SphericalSurface::SphericalSurface(MeshBlockPack *pmy_pack, int ntheta,
 
 SphericalSurface::~SphericalSurface() {}
 
+//----------------------------------------------------------------------------------------
+//! \fn void SphericalSurface::InitializeAngleAndWeights
+//! \brief set the (theta,phi) of every angle and the solid angle it represents
+//
+// theta increases with the angle index for both spacings, so index 0 is the point
+// closest to (cell centering) or on (node centering) the north pole. phi is periodic and
+// always starts at phi=0 with spacing 2*pi/nphi.
+//
+// The weight of an angle is the solid angle of the cell it owns,
+//   w = dphi * [cos(theta_minus) - cos(theta_plus)],
+// with the cell edges theta_minus/theta_plus clipped to [0,pi]. Node centered grids
+// therefore automatically get half weights on the poles, and the weights sum to 4*pi
+// exactly for every combination of spacing and centering.
+
 void SphericalSurface::InitializeAngleAndWeights() {
+  const Real dphi = 2.0 * M_PI / nphi;
+  const bool node = (theta_centering == SphThetaCentering::node);
+  // points on both poles span one interval less than there are points
+  const Real nspan = static_cast<Real>(node ? ntheta - 1 : ntheta);
+
   int n = 0;
-  for (int i = 0; i < 2 * ntheta; ++i) {
-    Real phi = M_PI / ntheta * i;
+  for (int i = 0; i < nphi; ++i) {
+    Real phi = dphi * i;
     for (int j = 0; j < ntheta; ++j) {
-      Real mu = -1.0 + 2.0 / (ntheta - 1) * j;
-      int_weights.h_view(n) = (M_PI / ntheta) * (2.0 / ntheta);
-      polar_pos.h_view(n, 0) = acos(mu);
+      Real theta, dcos;
+      if (theta_spacing == SphThetaSpacing::uniform_theta) {
+        Real dth = M_PI / nspan;
+        theta = node ? j * dth : (j + 0.5) * dth;
+        Real thm = fmax(theta - 0.5 * dth, 0.0);
+        Real thp = fmin(theta + 0.5 * dth, M_PI);
+        dcos = cos(thm) - cos(thp);
+      } else {
+        // mu = cos(theta) decreases with j so that theta still increases with j
+        Real dmu = 2.0 / nspan;
+        Real mu = node ? 1.0 - j * dmu : 1.0 - (j + 0.5) * dmu;
+        // roundoff can push mu on the poles just outside of [-1,1]
+        theta = acos(fmin(fmax(mu, -1.0), 1.0));
+        dcos = fmin(mu + 0.5 * dmu, 1.0) - fmax(mu - 0.5 * dmu, -1.0);
+      }
+      int_weights.h_view(n) = dphi * dcos;
+      polar_pos.h_view(n, 0) = theta;
       polar_pos.h_view(n, 1) = phi;
       n++;
     }
@@ -175,6 +234,32 @@ void SphericalSurface::SetInterpolationIndices() {
 }
 
 //----------------------------------------------------------------------------------------
+//! \fn void SphericalSurface::UpdateInterpolationOnMeshChange
+//! \brief recompute interpolation indices and weights after the mesh has changed
+//
+// interp_indcs stores the *local* MeshBlock index of the owner of each point, so any
+// refinement, derefinement or load balance invalidates it: an index can point at a
+// MeshBlock that now covers a different region, or past the end of a shrunken pack.
+// nmb_created/nmb_deleted are cumulative counters that MeshRefinement only advances when
+// blocks were actually redistributed, so comparing against them makes this a no-op on
+// the (many) outputs where the mesh did not move.
+
+void SphericalSurface::UpdateInterpolationOnMeshChange() {
+  if (!pmy_pack->pmesh->adaptive) return;
+
+  MeshRefinement *pmr = pmy_pack->pmesh->pmr;
+  if (pmr == nullptr) return;
+  if (pmr->nmb_created == amr_nmb_created && pmr->nmb_deleted == amr_nmb_deleted) return;
+
+  amr_nmb_created = pmr->nmb_created;
+  amr_nmb_deleted = pmr->nmb_deleted;
+  SetInterpolationIndices();
+  SetInterpolationWeights();
+
+  return;
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn void SphericalSurface::SetInterpolationWeights
 //! \brief set weights used by Lagrangian interpolation
 
@@ -252,11 +337,9 @@ void SphericalSurface::SetInterpolationWeights() {
 
 void SphericalSurface::InterpolateToSphere(int var_ind,
                                            DvceArray5D<Real> &val) {
-  // reinitialize interpolation indices and weights if AMR
-  // if (pmy_pack->pmesh->adaptive) {
-  //  SetInterpolationIndices();
-  //  SetInterpolationWeights();
-  //}
+  // reinitialize interpolation indices and weights if the mesh has changed
+  UpdateInterpolationOnMeshChange();
+
   auto &indcs = pmy_pack->pmesh->mb_indcs;
   int &is = indcs.is;
   int &js = indcs.js;

--- a/src/utils/spherical_surface.hpp
+++ b/src/utils/spherical_surface.hpp
@@ -17,25 +17,56 @@
 class MeshBlockPack;
 
 //----------------------------------------------------------------------------------------
+//! \brief layout of the polar angle grid of a SphericalSurface
+//! uniform_theta:    points equally spaced in theta, i.e. uniform angular resolution
+//! uniform_costheta: points equally spaced in cos(theta), i.e. uniform in solid angle
+//!                   but with poor angular resolution near the poles
+enum class SphThetaSpacing {uniform_theta, uniform_costheta};
+
+//----------------------------------------------------------------------------------------
+//! \brief placement of the polar angle grid points relative to their cells
+//! cell: points sit at cell centers, the first one half a cell away from the pole, so
+//!       that no point lies on the z-axis (and the grid can be mirrored across it)
+//! node: points sit at cell edges, so the first and last point lie on the z-axis
+enum class SphThetaCentering {cell, node};
+
+//----------------------------------------------------------------------------------------
+//! \brief layout of the angular grid of a SphericalSurface. Defaults to the node centered
+//! grid uniform in cos(theta) with nphi = 2*ntheta that the class has always used; the
+//! cell centered grid uniform in theta is opt-in.
+struct SphericalSurfaceAngles {
+  SphThetaSpacing theta_spacing = SphThetaSpacing::uniform_costheta;
+  SphThetaCentering theta_centering = SphThetaCentering::node;
+  int nphi = -1;  // number of gridpoints along phi, any value < 0 selects 2*ntheta
+};
+
+//----------------------------------------------------------------------------------------
 //! \class SphericalSurface
 //! \brief One or more spherical surfaces sharing a common grid. The surface
 //! contains npoints = nradii*nangles. Point ir*nangles+n is angle n on shell ir.
 class SphericalSurface {
  public:
+  using AngleOptions = SphericalSurfaceAngles;
+
   // Single-radius surface
   SphericalSurface(MeshBlockPack *pmy_pack, int ntheta, Real rad, Real xc = 0.0,
-                   Real yc = 0.0, Real zc = 0.0);
+                   Real yc = 0.0, Real zc = 0.0,
+                   const AngleOptions &aopt = AngleOptions());
   // Multi-radii surface
   SphericalSurface(MeshBlockPack *pmy_pack, int ntheta, const std::vector<Real> &rad,
-                   Real xc = 0.0, Real yc = 0.0, Real zc = 0.0);
+                   Real xc = 0.0, Real yc = 0.0, Real zc = 0.0,
+                   const AngleOptions &aopt = AngleOptions());
   ~SphericalSurface();
-  int nangles;  // total number of gridpoints per surface
-  int ntheta;   // number of gridpoints along theta direction, nphi = 2ntheta
+  int nangles;  // total number of gridpoints per surface, ntheta*nphi
+  int ntheta;   // number of gridpoints along theta direction
+  int nphi;     // number of gridpoints along phi direction
   int nradii;   // number of surfaces
   int npoints;  // total number of grid points, nradii*nangles
+  SphThetaSpacing theta_spacing;      // layout of the theta grid
+  SphThetaCentering theta_centering;  // placement of the theta gridpoints
   DualArray1D<Real> radii;        // radii of the surfaces
   Real xc, yc, zc;                // sphere center
-  DualArray1D<Real> int_weights;  // weights for quadrature integration (per angle)
+  DualArray1D<Real> int_weights;  // solid angle element dOmega (per angle), sums to 4pi
   DualArray2D<Real> cart_pos;     // coord position (cartesian) at gridpoints
   DualArray2D<Real> polar_pos;    // (theta,phi) at gridpoints (per angle)
   DualArray1D<Real> interp_vals;  // container for data interpolated to sphere
@@ -53,8 +84,11 @@ class SphericalSurface {
   void SetInterpolationCoordinates();  // set indexing for interpolation
   void SetInterpolationIndices();      // set indexing for interpolation
   void SetInterpolationWeights();      // set weights for interpolation
+  void UpdateInterpolationOnMeshChange();  // redo both if AMR moved the mesh
 
  private:
+  int amr_nmb_created;      // mesh stamp the interpolation indices were built against
+  int amr_nmb_deleted;
   MeshBlockPack *pmy_pack;  // ptr to MeshBlockPack containing this Hydro
 };
 #endif  // UTILS_SPHERICAL_SURFACE_HPP_


### PR DESCRIPTION
This PR extends the `SphericalSurface` output class with a set of grid options for the angles. So far, the grid in $\theta$ has used a grid uniform in $\cos{\theta}$ which has the downside, that the angular resolution degrades as we move to the poles. In some applications that might want to resolve polar outflows or else this might not be desirable. Also, with the old grid the node-centered points at the poles own half a cell but got a full weight which for surface integration can lead to significant errors. This is amplified by the fact that the points were spaced as $2/(n_{\theta}-1)$, while the weights assumed $2/n_{\theta}$. Here, we fix these problems and extend the class with some angular grid options:
1. In the old class we always set `ntheta` and `nphi` is then computed as `2*ntheta`. Per default this is also kept here, but if desired the user can now also independently choose `nphi`.
2. The parameter `theta_spacing` can be set to `uniform_costheta` (default; corresponds to the "old" grid; uniform in $\cos{\theta}$) and `uniform_theta` (the "new" grid; `dtheta=pi/ntheta` for cell or `pi/(ntheta-1)` for node).
3. The parameter `theta_centering` can be set to `node` (default; "old" option; first point on the z-axis) and `cell` ("new" option; first point is at `dtheta/2`).
4. `weights` is by default set to true (as in the old path) and will dump the weights to the corresponding .vtk files, but setting it to false would not write to file.

A PR has been opened for the updated documentation under https://github.com/IAS-Astrophysics/athenak-docs/pull/11.